### PR TITLE
fix(ai-sidecar): pin Jackson 2.21.2 on runtime classpath for record DTOs (#1734)

### DIFF
--- a/game-app/ai-sidecar/build.gradle
+++ b/game-app/ai-sidecar/build.gradle
@@ -14,6 +14,12 @@ dependencies {
     implementation project(":lib:java-extras")
     implementation project(":lib:xml-reader")
 
+    // dropwizard-jackson 1.3.14 (transitive via game-core) pulls Jackson 2.9.9,
+    // which predates Java record support. Pin Jackson to the catalog version
+    // so JsonBodies can (de)serialize our record DTOs at runtime.
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.21.2"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.21.2"
+
     testImplementation project(":lib:test-common")
     testImplementation testFixtures(project(":game-app:game-core"))
 }


### PR DESCRIPTION
Phase 1 follow-up. The Jackson pin was made on the feat branch after PR #4 was opened but before merge, and didn't make it into the squashed commit. Map Room PR #1738 CI needs this on main to build a working sidecar image. Cherry-pick of 6871ec572.