### PR TITLE
perf(ai-sidecar): speed up Docker build (BuildKit cache mounts + configure-on-demand)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
+# syntax=docker/dockerfile:1.6
 # Stage 1: build the fat jar with Gradle
 FROM eclipse-temurin:21-jdk AS build
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY . .
-# game-app/game-headed/build.gradle runs `git rev-list --count HEAD` at configuration time.
-# A fresh one-commit repo is enough to satisfy that call without bloating the build context.
-RUN git init -q \
- && git -c user.email=build@local -c user.name=build add -A \
- && git -c user.email=build@local -c user.name=build commit -q -m build
-RUN ./gradlew :game-app:ai-sidecar:installDist --no-daemon
+# --configure-on-demand keeps Gradle from configuring :game-app:game-headed
+# (which runs `git rev-list --count HEAD` at configuration time) since the
+# sidecar doesn't depend on it. BuildKit cache mounts persist Gradle's
+# user home and project cache across builds on the same host.
+RUN --mount=type=cache,target=/root/.gradle \
+    --mount=type=cache,target=/src/.gradle \
+    ./gradlew :game-app:ai-sidecar:installDist \
+        --no-daemon --parallel --configure-on-demand
 
 # Stage 2: runtime
 FROM eclipse-temurin:21-jre


### PR DESCRIPTION
Closes #6.

## Changes

1. **BuildKit cache mounts** on `/root/.gradle` and `/src/.gradle` so Gradle's user home and project cache persist across builds on the same host.
2. **`--configure-on-demand`** on the Gradle invocation so `:game-app:game-headed` is never configured (the sidecar doesn't depend on it).
3. **Deleted the git install + `git init` hack** from 75273636a. It existed only because `game-app/game-headed/build.gradle` runs `git rev-list --count HEAD` at configuration time — with configure-on-demand, that project is never evaluated, so git is no longer needed in the builder image.
4. Added `# syntax=docker/dockerfile:1.6` to enable cache-mount support.

## Verification

- [x] `docker build` succeeds (first build: **2m 1s**, unchanged from baseline)
- [x] Rebuild with a source change: **~14s** (target was 30s or less)
- [x] `docker run -d -p 8099:8099 ... && curl http://localhost:8099/health` returns `{"status":"ok"}`
- [x] Dockerfile no longer installs git or runs `git init`

## Out of scope

Per #6: no ghcr.io publishing, `--no-daemon` preserved.