### PR TITLE
feat(ai-sidecar): Phase 3 purchase decision (#1751)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionPlan.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionPlan.java
@@ -8,5 +8,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
   @JsonSubTypes.Type(value = SelectCasualtiesPlan.class, name = "select-casualties"),
   @JsonSubTypes.Type(value = RetreatPlan.class,          name = "retreat-or-press"),
   @JsonSubTypes.Type(value = ScramblePlan.class,         name = "scramble"),
+  @JsonSubTypes.Type(value = PurchasePlan.class,         name = "purchase"),
 })
-public sealed interface DecisionPlan permits SelectCasualtiesPlan, RetreatPlan, ScramblePlan {}
+public sealed interface DecisionPlan
+    permits SelectCasualtiesPlan, RetreatPlan, ScramblePlan, PurchasePlan {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionRequest.java
@@ -9,12 +9,16 @@ import org.triplea.ai.sidecar.wire.WireState;
   @JsonSubTypes.Type(value = SelectCasualtiesRequest.class, name = "select-casualties"),
   @JsonSubTypes.Type(value = RetreatQueryRequest.class, name = "retreat-or-press"),
   @JsonSubTypes.Type(value = ScrambleRequest.class, name = "scramble"),
-  @JsonSubTypes.Type(value = OffensiveRequest.class, name = "purchase"),
-  @JsonSubTypes.Type(value = OffensiveRequest.class, name = "combat-move"),
-  @JsonSubTypes.Type(value = OffensiveRequest.class, name = "noncombat-move"),
-  @JsonSubTypes.Type(value = OffensiveRequest.class, name = "place"),
+  @JsonSubTypes.Type(value = PurchaseRequest.class, name = "purchase"),
+  @JsonSubTypes.Type(value = OtherOffensiveRequest.class, name = "combat-move"),
+  @JsonSubTypes.Type(value = OtherOffensiveRequest.class, name = "noncombat-move"),
+  @JsonSubTypes.Type(value = OtherOffensiveRequest.class, name = "place"),
 })
 public sealed interface DecisionRequest
-    permits SelectCasualtiesRequest, RetreatQueryRequest, ScrambleRequest, OffensiveRequest {
+    permits SelectCasualtiesRequest,
+        RetreatQueryRequest,
+        ScrambleRequest,
+        PurchaseRequest,
+        OtherOffensiveRequest {
   WireState state();
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/OffensiveRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/OffensiveRequest.java
@@ -1,5 +1,0 @@
-package org.triplea.ai.sidecar.dto;
-
-import org.triplea.ai.sidecar.wire.WireState;
-
-public record OffensiveRequest(WireState state, String kind) implements DecisionRequest {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/OtherOffensiveRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/OtherOffensiveRequest.java
@@ -1,0 +1,18 @@
+package org.triplea.ai.sidecar.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.triplea.ai.sidecar.wire.WireState;
+
+/**
+ * Catch-all for offensive kinds not yet implemented on the sidecar. Phase 3 wires only {@code
+ * purchase}; {@code combat-move}, {@code noncombat-move}, {@code place} land here and return 501.
+ */
+public record OtherOffensiveRequest(String kind, WireState state) implements DecisionRequest {
+  @JsonCreator
+  public OtherOffensiveRequest(
+      @JsonProperty("kind") String kind, @JsonProperty("state") WireState state) {
+    this.kind = kind;
+    this.state = state;
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchaseOrder.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchaseOrder.java
@@ -1,0 +1,7 @@
+package org.triplea.ai.sidecar.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/** One entry in a purchase plan: {@code count} units of {@code unitType} to place at
+ * {@code placeTerritory} (nullable in Phase 3 — Phase 5 will populate it). */
+public record PurchaseOrder(String unitType, int count, @JsonInclude(JsonInclude.Include.NON_NULL) String placeTerritory) {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchasePlan.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchasePlan.java
@@ -1,0 +1,9 @@
+package org.triplea.ai.sidecar.dto;
+
+import java.util.List;
+
+/** Purchase decision plan. {@code buys} is an ordered list of {@link PurchaseOrder} entries,
+ * ordered by ProAi priority (Phase 3 reverse-order trim preserves priority). {@code repairs}
+ * is the captured repair bundle from the preceding {@code purchaseRepair()} call. */
+public record PurchasePlan(List<PurchaseOrder> buys, List<RepairOrder> repairs)
+    implements DecisionPlan {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchaseRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchaseRequest.java
@@ -1,0 +1,16 @@
+package org.triplea.ai.sidecar.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.triplea.ai.sidecar.wire.WireState;
+
+/**
+ * Request for the {@code purchase} decision kind. Phase 3 is the first offensive kind wired
+ * end-to-end; sidecar hydrates a cached {@code GameData} from {@code state} and invokes {@code
+ * AbstractProAi#purchase}.
+ */
+@JsonIgnoreProperties("kind")
+public record PurchaseRequest(WireState state) implements DecisionRequest {
+  public String kind() {
+    return "purchase";
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/RepairOrder.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/RepairOrder.java
@@ -1,0 +1,5 @@
+package org.triplea.ai.sidecar.dto;
+
+/** One repair order: fix {@code repairCount} damage on a factory (or other damageable infra) of
+ * {@code unitType} in {@code territory}. */
+public record RepairOrder(String territory, String unitType, int repairCount) {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
@@ -1,0 +1,225 @@
+package org.triplea.ai.sidecar.exec;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.NamedAttachable;
+import games.strategy.engine.data.ProductionRule;
+import games.strategy.engine.data.RepairRule;
+import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.Constants;
+import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.engine.delegate.IDelegate;
+import games.strategy.triplea.delegate.EndRoundDelegate;
+import games.strategy.triplea.delegate.MoveDelegate;
+import games.strategy.triplea.delegate.PlaceDelegate;
+import games.strategy.triplea.delegate.PoliticsDelegate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.triplea.ai.sidecar.dto.PurchaseOrder;
+import org.triplea.ai.sidecar.dto.PurchasePlan;
+import org.triplea.ai.sidecar.dto.PurchaseRequest;
+import org.triplea.ai.sidecar.dto.RepairOrder;
+import org.triplea.ai.sidecar.session.Session;
+import org.triplea.ai.sidecar.wire.WireStateApplier;
+import org.triplea.java.collections.IntegerMap;
+
+/**
+ * Runs {@link ProAi#invokePurchaseForSidecar} on the session's bounded offensive executor,
+ * captures the resulting {@code IntegerMap<ProductionRule>} via a {@link
+ * RecordingPurchaseDelegate}, trims the captured map to fit the session player's PU budget,
+ * and projects the result into a wire-shaped {@link PurchasePlan}.
+ *
+ * <h2>Why trim-to-fit is a necessary backstop (not a reimplementation)</h2>
+ *
+ * <p>TripleA's {@code ProPurchaseAi} consults a {@code ProResourceTracker} inside the
+ * per-territory purchase loop, but the final {@code IntegerMap<ProductionRule>} that is handed
+ * to {@code purchaseDelegate.purchase(...)} is produced by
+ * {@code ProPurchaseAi.populateProductionRuleMap} (see
+ * {@code game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java:2404-2429}):
+ * that method iterates {@code ProPurchaseOption}s and counts
+ * {@code ProPlaceTerritory.getPlaceUnits()} entries per option. It does <b>not</b>
+ * re-consult {@code ProResourceTracker} at aggregation time, so nothing forces the aggregated
+ * cost to equal the cost tracked during the loop.
+ *
+ * <p>The map produced by {@code populateProductionRuleMap} is then passed directly to
+ * {@code purchaseDelegate.purchase(purchaseMap)} at
+ * {@code ProPurchaseAi.java:251} (main purchase path) and {@code ProPurchaseAi.java:380}
+ * (upgrade / second-pass path), with no intervening validation. Neither
+ * {@code ai/pro/util/ProPurchaseUtils.java} nor {@code ai/pro/util/ProPurchaseValidationUtils.java}
+ * contains any clamp/trim/budget-check helper — a grep for {@code trim|clamp|budget|exceed}
+ * across both files returns zero hits. A 123 PU overrun against a 120 PU budget has been
+ * observed in practice (see Phase 3 spec §5 note); this is consistent with the gap described
+ * above.
+ *
+ * <p>The {@link #trimToFit} backstop implemented here is therefore <b>a necessary backstop,
+ * not a paraphrase of an existing TripleA routine</b>. It reads exactly the map that ProAi
+ * would have handed to the live purchase delegate and drops production-rule units from the
+ * lowest-priority end until the total PU cost fits the caller's budget.
+ *
+ * <p><b>Trim order:</b> reverse iteration over the captured {@code IntegerMap<ProductionRule>}.
+ * {@code populateProductionRuleMap} iterates {@code ProPurchaseOptionMap.getAllOptions()} in
+ * descending priority, so the resulting {@code IntegerMap} preserves that ordering; dropping
+ * from the tail therefore drops the lowest priority rules first.
+ */
+public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest, PurchasePlan> {
+
+  @Override
+  public PurchasePlan execute(final Session session, final PurchaseRequest request) {
+    final GameData data = session.gameData();
+    WireStateApplier.apply(data, request.state(), session.unitIdMap());
+
+    final GamePlayer player =
+        data.getPlayerList().getPlayerId(request.state().currentPlayer());
+    if (player == null) {
+      throw new IllegalArgumentException(
+          "Unknown player in PurchaseRequest: " + request.state().currentPlayer());
+    }
+
+    ExecutorSupport.ensureProAiInitialized(session, player);
+    // ProPurchaseAi.repair -> ProMatches.territoryIsNotConqueredOwnedLand reads the
+    // BattleTracker via GameData.getBattleDelegate(); the clone's internal GameDataUtils copy
+    // (GameDataManager save/load with withDelegates=true) only persists delegates that exist
+    // on the source, so we must pre-register move/place/battle before dispatching. Our
+    // CanonicalGameData.cloneForSession uses a raw ObjectOutputStream round-trip that wipes
+    // the transient delegates map (GameData.java:111).
+    ExecutorSupport.ensureBattleDelegate(data);
+    ensureDelegate(data, "move", "Move", new MoveDelegate());
+    ensureDelegate(data, "place", "Place", new PlaceDelegate());
+    ensureDelegate(data, "politics", "Politics", new PoliticsDelegate());
+    ensureDelegate(data, "endRound", "End Round", new EndRoundDelegate());
+
+    final Resource pus = data.getResourceList().getResourceOrThrow(Constants.PUS);
+    final int pusToSpend = player.getResources().getQuantity(pus);
+
+    final RecordingPurchaseDelegate recorder = new RecordingPurchaseDelegate();
+    final ProAi proAi = session.proAi();
+
+    final Future<Void> future =
+        session
+            .offensiveExecutor()
+            .submit(
+                () -> {
+                  proAi.invokePurchaseForSidecar(
+                      /* purchaseForBid */ false, pusToSpend, recorder, data, player);
+                  return null;
+                });
+    try {
+      future.get();
+    } catch (final InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("PurchaseExecutor interrupted", ie);
+    } catch (final ExecutionException ee) {
+      final Throwable cause = ee.getCause();
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      throw new RuntimeException("PurchaseExecutor failed", cause);
+    }
+
+    final IntegerMap<ProductionRule> captured = recorder.capturedPurchase();
+    final IntegerMap<ProductionRule> trimmed = trimToFit(captured, pusToSpend, pus);
+
+    final List<PurchaseOrder> buys = toPurchaseOrders(trimmed);
+    final List<RepairOrder> repairs = toRepairOrders(recorder.capturedRepair(), data);
+    return new PurchasePlan(buys, repairs);
+  }
+
+  /**
+   * Drop rules in reverse-priority order (iterating from the tail of the captured map) until
+   * the total PU cost fits {@code pusBudget}. See the class Javadoc for the justification.
+   */
+  static IntegerMap<ProductionRule> trimToFit(
+      final IntegerMap<ProductionRule> captured, final int pusBudget, final Resource pus) {
+    final IntegerMap<ProductionRule> result = new IntegerMap<>(captured);
+    final List<ProductionRule> order = new ArrayList<>(result.keySet());
+    int idx = order.size() - 1;
+    while (totalPuCost(result, pus) > pusBudget && idx >= 0) {
+      final ProductionRule rule = order.get(idx);
+      final int n = result.getInt(rule);
+      if (n > 0) {
+        result.put(rule, n - 1);
+        if (result.getInt(rule) == 0) {
+          result.removeKey(rule);
+          idx--;
+        }
+      } else {
+        idx--;
+      }
+    }
+    return result;
+  }
+
+  private static int totalPuCost(final IntegerMap<ProductionRule> map, final Resource pus) {
+    int sum = 0;
+    for (final ProductionRule rule : map.keySet()) {
+      sum += rule.getCosts().getInt(pus) * map.getInt(rule);
+    }
+    return sum;
+  }
+
+  private static List<PurchaseOrder> toPurchaseOrders(final IntegerMap<ProductionRule> map) {
+    final List<PurchaseOrder> out = new ArrayList<>();
+    for (final ProductionRule rule : map.keySet()) {
+      final int count = map.getInt(rule);
+      if (count <= 0) {
+        continue;
+      }
+      // A ProductionRule can in principle produce multiple results; in practice for Global
+      // 1940 each rule produces one UnitType. Take the first UnitType result and drop any
+      // non-unit (pure-resource) rules — those cannot be placed by Map Room's placement API.
+      NamedAttachable firstUnitResult = null;
+      for (final NamedAttachable na : rule.getResults().keySet()) {
+        if (na instanceof UnitType) {
+          firstUnitResult = na;
+          break;
+        }
+      }
+      if (firstUnitResult instanceof UnitType ut) {
+        out.add(new PurchaseOrder(ut.getName(), count, null));
+      }
+    }
+    return out;
+  }
+
+  private static List<RepairOrder> toRepairOrders(
+      final Map<Unit, IntegerMap<RepairRule>> map, final GameData data) {
+    final List<RepairOrder> out = new ArrayList<>();
+    for (final Map.Entry<Unit, IntegerMap<RepairRule>> entry : map.entrySet()) {
+      final Unit unit = entry.getKey();
+      final String territoryName = findTerritoryNameOf(data, unit);
+      final String unitTypeName = unit.getType().getName();
+      for (final RepairRule rule : entry.getValue().keySet()) {
+        final int count = entry.getValue().getInt(rule);
+        if (count <= 0) {
+          continue;
+        }
+        out.add(new RepairOrder(territoryName, unitTypeName, count));
+      }
+    }
+    return out;
+  }
+
+  private static void ensureDelegate(
+      final GameData data, final String name, final String displayName, final IDelegate delegate) {
+    if (data.getDelegateOptional(name).isPresent()) {
+      return;
+    }
+    delegate.initialize(name, displayName);
+    data.addDelegate(delegate);
+  }
+
+  private static String findTerritoryNameOf(final GameData data, final Unit unit) {
+    for (final Territory t : data.getMap().getTerritories()) {
+      if (t.getUnits().contains(unit)) {
+        return t.getName();
+      }
+    }
+    return "";
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingPurchaseDelegate.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingPurchaseDelegate.java
@@ -1,0 +1,126 @@
+package org.triplea.ai.sidecar.exec;
+
+import games.strategy.engine.data.ProductionRule;
+import games.strategy.engine.data.RepairRule;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.message.IRemote;
+import games.strategy.engine.posted.game.pbem.PbemMessagePoster;
+import games.strategy.net.websocket.ClientNetworkBridge;
+import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
+import java.io.Serializable;
+import java.util.Map;
+import org.triplea.java.collections.IntegerMap;
+
+/**
+ * {@link IPurchaseDelegate} stub that captures the {@code IntegerMap<ProductionRule>} handed to
+ * {@link #purchase} and the repair map handed to {@link #purchaseRepair}, while no-opping every
+ * other method on the interface. Used by {@code PurchaseExecutor} to intercept the side-effect
+ * output of {@code games.strategy.triplea.ai.pro.AbstractProAi#purchase} without mutating the
+ * session's {@link games.strategy.engine.data.GameData}.
+ *
+ * <p><b>Thread-safety:</b> not thread-safe. Each {@code PurchaseExecutor.execute} call creates a
+ * fresh instance and the session-scoped executor serialises access on the Java side.
+ */
+public final class RecordingPurchaseDelegate implements IPurchaseDelegate {
+
+  private IntegerMap<ProductionRule> capturedPurchase = new IntegerMap<>();
+  private Map<Unit, IntegerMap<RepairRule>> capturedRepair = Map.of();
+  private IDelegateBridge bridge;
+  private boolean hasPostedTurnSummary;
+  private String name = "recordingPurchase";
+  private String displayName = "Recording Purchase";
+
+  public IntegerMap<ProductionRule> capturedPurchase() {
+    return capturedPurchase;
+  }
+
+  public Map<Unit, IntegerMap<RepairRule>> capturedRepair() {
+    return capturedRepair;
+  }
+
+  @Override
+  public String purchase(final IntegerMap<ProductionRule> productionRules) {
+    this.capturedPurchase = new IntegerMap<>(productionRules);
+    return null;
+  }
+
+  @Override
+  public String purchaseRepair(final Map<Unit, IntegerMap<RepairRule>> productionRules) {
+    this.capturedRepair = Map.copyOf(productionRules);
+    return null;
+  }
+
+  @Override
+  public void setHasPostedTurnSummary(final boolean hasPostedTurnSummary) {
+    this.hasPostedTurnSummary = hasPostedTurnSummary;
+  }
+
+  @Override
+  public boolean getHasPostedTurnSummary() {
+    return hasPostedTurnSummary;
+  }
+
+  @Override
+  public boolean postTurnSummary(final PbemMessagePoster poster, final String title) {
+    return true;
+  }
+
+  @Override
+  public void initialize(final String name, final String displayName) {
+    this.name = name;
+    this.displayName = displayName;
+  }
+
+  @Override
+  public void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge) {
+    this.bridge = delegateBridge;
+  }
+
+  @Override
+  public void setDelegateBridgeAndPlayer(
+      final IDelegateBridge delegateBridge, final ClientNetworkBridge clientNetworkBridge) {
+    this.bridge = delegateBridge;
+  }
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void end() {}
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  @Override
+  public IDelegateBridge getBridge() {
+    return bridge;
+  }
+
+  @Override
+  public Serializable saveState() {
+    return new Serializable() {
+      private static final long serialVersionUID = 1L;
+    };
+  }
+
+  @Override
+  public void loadState(final Serializable state) {}
+
+  @Override
+  public Class<? extends IRemote> getRemoteType() {
+    return IPurchaseDelegate.class;
+  }
+
+  @Override
+  public boolean delegateCurrentlyRequiresUserInput() {
+    return false;
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import org.triplea.ai.sidecar.dto.DecisionPlan;
 import org.triplea.ai.sidecar.dto.DecisionRequest;
 import org.triplea.ai.sidecar.dto.OtherOffensiveRequest;
+import org.triplea.ai.sidecar.dto.PurchasePlan;
 import org.triplea.ai.sidecar.dto.PurchaseRequest;
 import org.triplea.ai.sidecar.dto.RetreatPlan;
 import org.triplea.ai.sidecar.dto.RetreatQueryRequest;
@@ -17,6 +18,7 @@ import org.triplea.ai.sidecar.dto.ScrambleRequest;
 import org.triplea.ai.sidecar.dto.SelectCasualtiesPlan;
 import org.triplea.ai.sidecar.dto.SelectCasualtiesRequest;
 import org.triplea.ai.sidecar.exec.DecisionExecutor;
+import org.triplea.ai.sidecar.exec.PurchaseExecutor;
 import org.triplea.ai.sidecar.exec.RetreatQueryExecutor;
 import org.triplea.ai.sidecar.exec.ScrambleExecutor;
 import org.triplea.ai.sidecar.exec.SelectCasualtiesExecutor;
@@ -44,14 +46,16 @@ public final class DecisionHandler implements HttpHandler {
       selectCasualtiesExecutor;
   private final DecisionExecutor<RetreatQueryRequest, RetreatPlan> retreatQueryExecutor;
   private final DecisionExecutor<ScrambleRequest, ScramblePlan> scrambleExecutor;
+  private final DecisionExecutor<PurchaseRequest, PurchasePlan> purchaseExecutor;
 
-  /** Production constructor — wires the real Phase-2 executors. */
+  /** Production constructor — wires the real Phase-2 and Phase-3 executors. */
   public DecisionHandler(final SessionRegistry registry) {
     this(
         registry,
         new SelectCasualtiesExecutor(),
         new RetreatQueryExecutor(),
-        new ScrambleExecutor());
+        new ScrambleExecutor(),
+        new PurchaseExecutor());
   }
 
   /** Test constructor — accepts executor stubs so handler logic can be exercised in isolation. */
@@ -59,11 +63,13 @@ public final class DecisionHandler implements HttpHandler {
       final SessionRegistry registry,
       final DecisionExecutor<SelectCasualtiesRequest, SelectCasualtiesPlan> selectCasualtiesExecutor,
       final DecisionExecutor<RetreatQueryRequest, RetreatPlan> retreatQueryExecutor,
-      final DecisionExecutor<ScrambleRequest, ScramblePlan> scrambleExecutor) {
+      final DecisionExecutor<ScrambleRequest, ScramblePlan> scrambleExecutor,
+      final DecisionExecutor<PurchaseRequest, PurchasePlan> purchaseExecutor) {
     this.registry = registry;
     this.selectCasualtiesExecutor = selectCasualtiesExecutor;
     this.retreatQueryExecutor = retreatQueryExecutor;
     this.scrambleExecutor = scrambleExecutor;
+    this.purchaseExecutor = purchaseExecutor;
   }
 
   @Override
@@ -112,10 +118,10 @@ public final class DecisionHandler implements HttpHandler {
           final ScramblePlan plan = scrambleExecutor.execute(session.get(), sr);
           writeJson(exchange, 200, JsonBodies.readyBody(plan));
         }
-        case PurchaseRequest pr -> writeJson(
-            exchange,
-            501,
-            JsonBodies.errorBodyWithKind("not-implemented", pr.kind()));
+        case PurchaseRequest pr -> {
+          final PurchasePlan plan = purchaseExecutor.execute(session.get(), pr);
+          writeJson(exchange, 200, JsonBodies.readyBody(plan));
+        }
         case OtherOffensiveRequest oo -> writeJson(
             exchange,
             501,

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
@@ -8,7 +8,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.triplea.ai.sidecar.dto.DecisionPlan;
 import org.triplea.ai.sidecar.dto.DecisionRequest;
-import org.triplea.ai.sidecar.dto.OffensiveRequest;
+import org.triplea.ai.sidecar.dto.OtherOffensiveRequest;
+import org.triplea.ai.sidecar.dto.PurchaseRequest;
 import org.triplea.ai.sidecar.dto.RetreatPlan;
 import org.triplea.ai.sidecar.dto.RetreatQueryRequest;
 import org.triplea.ai.sidecar.dto.ScramblePlan;
@@ -111,10 +112,14 @@ public final class DecisionHandler implements HttpHandler {
           final ScramblePlan plan = scrambleExecutor.execute(session.get(), sr);
           writeJson(exchange, 200, JsonBodies.readyBody(plan));
         }
-        case OffensiveRequest or -> writeJson(
+        case PurchaseRequest pr -> writeJson(
             exchange,
             501,
-            JsonBodies.errorBodyWithKind("not-implemented", or.kind()));
+            JsonBodies.errorBodyWithKind("not-implemented", pr.kind()));
+        case OtherOffensiveRequest oo -> writeJson(
+            exchange,
+            501,
+            JsonBodies.errorBodyWithKind("not-implemented", oo.kind()));
       }
     } catch (final IllegalArgumentException e) {
       writeJson(exchange, 400, JsonBodies.errorBody("bad-request"));

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/Session.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/Session.java
@@ -5,6 +5,7 @@ import games.strategy.triplea.ai.pro.ProAi;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Session state for a single AI sidecar nation/game.
@@ -16,6 +17,12 @@ import java.util.concurrent.ConcurrentMap;
  * ID, and kept stable across subsequent applies so that executors (Task 22+) can resolve wire
  * unit IDs back to live {@link games.strategy.engine.data.Unit} instances in the cloned {@link
  * GameData}.
+ *
+ * <p>The {@code offensiveExecutor} is a per-session single-threaded executor used to dispatch
+ * Phase 3 offensive (purchase / combat-move / noncombat-move / place) ProAi calls serially,
+ * ensuring ProAi state is never touched concurrently. The executor's worker thread is a daemon
+ * named {@code sidecar-offensive-<sessionId>} and is shut down when the session is released from
+ * the {@link SessionRegistry}.
  */
 public record Session(
     String sessionId,
@@ -23,12 +30,14 @@ public record Session(
     long seed,
     ProAi proAi,
     GameData gameData,
-    ConcurrentMap<String, UUID> unitIdMap) {
+    ConcurrentMap<String, UUID> unitIdMap,
+    ExecutorService offensiveExecutor) {
   public Session {
     Objects.requireNonNull(sessionId, "sessionId");
     Objects.requireNonNull(key, "key");
     Objects.requireNonNull(proAi, "proAi");
     Objects.requireNonNull(gameData, "gameData");
     Objects.requireNonNull(unitIdMap, "unitIdMap");
+    Objects.requireNonNull(offensiveExecutor, "offensiveExecutor");
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionRegistry.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionRegistry.java
@@ -5,6 +5,8 @@ import games.strategy.triplea.ai.pro.ProAi;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.triplea.ai.sidecar.CanonicalGameData;
 
 public final class SessionRegistry {
@@ -23,12 +25,20 @@ public final class SessionRegistry {
     }
     if (existing != null) {
       byId.remove(existing.sessionId());
+      existing.offensiveExecutor().shutdownNow();
     }
     final GameData data = canonical.cloneForSession();
     final ProAi proAi = new ProAi("sidecar-" + key.gameId() + "-" + key.nation(), key.nation());
     final String id = "s-" + UUID.randomUUID();
+    final ExecutorService offensiveExecutor =
+        Executors.newSingleThreadExecutor(
+            r -> {
+              final Thread t = new Thread(r, "sidecar-offensive-" + id);
+              t.setDaemon(true);
+              return t;
+            });
     final Session created =
-        new Session(id, key, seed, proAi, data, new ConcurrentHashMap<>());
+        new Session(id, key, seed, proAi, data, new ConcurrentHashMap<>(), offensiveExecutor);
     byKey.put(key, created);
     byId.put(id, created);
     return created;
@@ -44,6 +54,7 @@ public final class SessionRegistry {
       return false;
     }
     byKey.remove(removed.key(), removed);
+    removed.offensiveExecutor().shutdownNow();
     return true;
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/StepNameMapper.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/StepNameMapper.java
@@ -1,0 +1,33 @@
+package org.triplea.ai.sidecar.wire;
+
+import java.util.Map;
+
+/**
+ * Maps Map Room phase names (as carried in {@link WireState#phase()}) to the corresponding
+ * TripleA XML step display name for {@code GameSequence.setRoundAndStep}. The convention in
+ * TripleA's Global 1940 XML is {@code <PlayerName><CamelPhase>}, e.g. {@code GermansPurchase}
+ * or {@code GermansCombatMove}. Phases that Phase 3 does not wire ({@code tech},
+ * {@code intelligence}) are rejected — the sidecar should never receive a PurchaseRequest
+ * tagged with those phases.
+ *
+ * <p>This mapping is a contract between Map Room and the sidecar. Keep it in sync with the
+ * phase names in {@code packages/shared/src/engine/game-def.ts}.
+ */
+public final class StepNameMapper {
+  private static final Map<String, String> PHASE_SUFFIX =
+      Map.of(
+          "purchase", "Purchase",
+          "combatMove", "CombatMove",
+          "nonCombatMove", "NonCombatMove",
+          "place", "Place");
+
+  private StepNameMapper() {}
+
+  public static String toJavaStepName(String mapRoomPhase, String playerName) {
+    String suffix = PHASE_SUFFIX.get(mapRoomPhase);
+    if (suffix == null) {
+      throw new IllegalArgumentException("Unmapped Map Room phase: " + mapRoomPhase);
+    }
+    return playerName + suffix;
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -4,12 +4,15 @@ import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.attachments.TechAttachment;
+import games.strategy.triplea.delegate.battle.BattleDelegate;
+import games.strategy.triplea.delegate.battle.BattleTracker;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.util.ArrayList;
@@ -79,20 +82,153 @@ public final class WireStateApplier {
       gameData.performChange(changes);
     }
 
-    // Round / phase / currentPlayer are read-only during decision execution. We do not mutate
-    // the sequence; the caller is expected to already be invoking a ProAi method that matches
-    // the phase. Log a warning on mismatch to aid triage.
-    final int actualRound = gameData.getSequence().getRound();
-    if (actualRound != wire.round()) {
+    // Phase 3 branches: conquered-this-turn, factory operational damage, and round/step.
+    // These run AFTER the main CompositeChange has been performed so that any units the
+    // damage branch references are live on the board.
+    applyConqueredThisTurn(gameData, wire);
+    applyOperationalDamage(gameData, wire, unitIdMap);
+    // Round/step last — GameSequence mutation has no interaction with the earlier branches,
+    // but keeping it at the tail means nothing downstream can overwrite it.
+    applyRoundAndStep(gameData, wire);
+  }
+
+  /**
+   * Register every {@link WireTerritory#conqueredThisTurn()} territory with the session's
+   * {@link BattleTracker#getConquered() conquered} set so that TripleA predicates such as
+   * {@code AbstractPlaceDelegate.wasConquered(t)} gate placement / production as they would
+   * during a real turn.
+   *
+   * <p>We cannot use {@code ChangeFactory.attachmentPropertyChange} here because TripleA does
+   * not model conquered-this-turn as a {@link
+   * games.strategy.triplea.attachments.TerritoryAttachment} field — it lives entirely on the
+   * (transient) {@link BattleTracker}.
+   */
+  private static void applyConqueredThisTurn(final GameData gameData, final WireState wire) {
+    boolean needTracker = false;
+    for (final WireTerritory wt : wire.territories()) {
+      if (wt.conqueredThisTurn()) {
+        needTracker = true;
+        break;
+      }
+    }
+    if (!needTracker) {
+      return;
+    }
+    ensureBattleDelegate(gameData);
+    final BattleTracker tracker = gameData.getBattleDelegate().getBattleTracker();
+    for (final WireTerritory wt : wire.territories()) {
+      if (!wt.conqueredThisTurn()) {
+        continue;
+      }
+      final Territory t = gameData.getMap().getTerritoryOrNull(wt.territoryId());
+      if (t == null) {
+        continue;
+      }
+      tracker.getConquered().add(t);
+    }
+  }
+
+  /**
+   * Apply {@link WireUnit#bombingDamage()} to every unit on every territory whose wire damage
+   * differs from the live {@link Unit#getUnitDamage()} value. {@link
+   * ChangeFactory#bombingUnitDamage} semantics are <em>set, not add</em> — the {@link
+   * IntegerMap} values are absolute new damage counts.
+   */
+  private static void applyOperationalDamage(
+      final GameData gameData,
+      final WireState wire,
+      final ConcurrentMap<String, UUID> unitIdMap) {
+    for (final WireTerritory wt : wire.territories()) {
+      final Territory t = gameData.getMap().getTerritoryOrNull(wt.territoryId());
+      if (t == null) {
+        continue;
+      }
+      final IntegerMap<Unit> newDamage = new IntegerMap<>();
+      for (final WireUnit wu : wt.units()) {
+        final UUID uuid = unitIdMap.get(wu.unitId());
+        if (uuid == null) {
+          continue;
+        }
+        final Unit unit = findUnitById(t.getUnits(), uuid);
+        if (unit == null) {
+          continue;
+        }
+        if (wu.bombingDamage() != unit.getUnitDamage()) {
+          newDamage.put(unit, wu.bombingDamage());
+        }
+      }
+      if (!newDamage.isEmpty()) {
+        gameData.performChange(
+            ChangeFactory.bombingUnitDamage(newDamage, Collections.singletonList(t)));
+      }
+    }
+  }
+
+  /**
+   * Advance {@link GameData#getSequence()} to the wire-supplied round and step. This mirrors
+   * what {@code GameSequence.setRoundAndStep} does for save-game export: the {@code display
+   * name} lookup is case-insensitive and falls back to index 0 with an error log if no match
+   * is found — which is why the {@link StepNameMapper} contract is narrow.
+   */
+  private static void applyRoundAndStep(final GameData gameData, final WireState wire) {
+    // StepNameMapper only covers Phase 3 wire phases (purchase / combatMove / nonCombatMove /
+    // place). Legacy / defensive callers may send phase values like "combat" that pre-date
+    // Phase 3; for those we leave the sequence untouched and log a warning — the defensive
+    // executors already tolerate a stale round/step because they dispatch directly into ProAi.
+    final String javaStepName;
+    try {
+      javaStepName = StepNameMapper.toJavaStepName(wire.phase(), wire.currentPlayer());
+    } catch (final IllegalArgumentException e) {
       LOG.log(
           Level.WARNING,
           () ->
-              "WireState round ("
-                  + wire.round()
-                  + ") differs from GameData round ("
-                  + actualRound
-                  + ")");
+              "WireState phase '" + wire.phase() + "' not mappable; skipping round/step apply");
+      return;
     }
+    final GamePlayer player = gameData.getPlayerList().getPlayerId(wire.currentPlayer());
+    if (player == null) {
+      throw new IllegalArgumentException("Unknown player in WireState: " + wire.currentPlayer());
+    }
+    // GameSequence.setRoundAndStep compares against GameStep.getDisplayName() — which for
+    // Global 1940 falls back to the delegate's displayName ("Purchase Units" etc.) and is
+    // thus the same across all players that share that delegate. The XML step <em>name</em>
+    // ("germansPurchase") is what uniquely identifies the step; locate the target step by
+    // name, then feed its own getDisplayName() + player back into setRoundAndStep so the
+    // existing API resolves to the correct step index.
+    GameStep target = null;
+    for (final GameStep step : gameData.getSequence().getSteps()) {
+      if (javaStepName.equalsIgnoreCase(step.getName())
+          && player.equals(step.getPlayerId())) {
+        target = step;
+        break;
+      }
+    }
+    if (target == null) {
+      LOG.log(
+          Level.WARNING,
+          () ->
+              "No GameStep matched name '"
+                  + javaStepName
+                  + "' for player "
+                  + wire.currentPlayer()
+                  + "; leaving sequence untouched");
+      return;
+    }
+    gameData.getSequence().setRoundAndStep(wire.round(), target.getDisplayName(), player);
+  }
+
+  /**
+   * Re-register a fresh {@link BattleDelegate} if {@code postDeSerialize} cleared it on the
+   * cloned {@link GameData}. Mirrors {@code ExecutorSupport.ensureBattleDelegate} which lives
+   * in the {@code exec} package and is not visible here.
+   */
+  private static void ensureBattleDelegate(final GameData gameData) {
+    if (gameData.getDelegateOptional("battle").isPresent()) {
+      return;
+    }
+    final BattleDelegate delegate = new BattleDelegate();
+    delegate.initialize("battle", "Combat");
+    gameData.addDelegate(delegate);
   }
 
   private static void applyTerritory(
@@ -136,6 +272,12 @@ public final class WireStateApplier {
         }
       } else {
         unit = new Unit(uuid, type, wireOwner, gameData);
+        // Register with the central UnitsList so {@code GameData.getUnits().get(uuid)}
+        // resolves to this unit. The raw {@link Unit#Unit(UUID, UnitType, GamePlayer,
+        // GameData)} constructor does not do this registration — only {@link
+        // UnitType#create(int, GamePlayer, boolean)} does — and Phase 3 branches such as
+        // {@link ChangeFactory#bombingUnitDamage} look units up by UUID via UnitsList.
+        gameData.getUnits().put(unit);
         if (wu.hitsTaken() != unit.getHits()) {
           // Safe: unit is not yet attached to any territory, no listeners to bypass.
           unit.setHits(wu.hitsTaken());

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireTerritory.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireTerritory.java
@@ -1,5 +1,25 @@
 package org.triplea.ai.sidecar.wire;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
-public record WireTerritory(String territoryId, String owner, List<WireUnit> units) {}
+public record WireTerritory(
+    String territoryId, String owner, List<WireUnit> units, boolean conqueredThisTurn) {
+  @JsonCreator
+  public WireTerritory(
+      @JsonProperty("territoryId") final String territoryId,
+      @JsonProperty("owner") final String owner,
+      @JsonProperty("units") final List<WireUnit> units,
+      @JsonProperty("conqueredThisTurn") final Boolean conqueredThisTurn) {
+    this(
+        territoryId,
+        owner,
+        units == null ? List.of() : units,
+        Boolean.TRUE.equals(conqueredThisTurn));
+  }
+
+  public WireTerritory(final String territoryId, final String owner, final List<WireUnit> units) {
+    this(territoryId, owner, units, false);
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireUnit.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireUnit.java
@@ -4,14 +4,24 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record WireUnit(
-    String unitId, String unitType, int hitsTaken, int movesUsed) {
+    String unitId, String unitType, int hitsTaken, int movesUsed, int bombingDamage) {
   @JsonCreator
   public static WireUnit of(
       @JsonProperty("unitId") final String unitId,
       @JsonProperty("unitType") final String unitType,
       @JsonProperty("hitsTaken") final Integer hitsTaken,
-      @JsonProperty("movesUsed") final Integer movesUsed) {
+      @JsonProperty("movesUsed") final Integer movesUsed,
+      @JsonProperty("bombingDamage") final Integer bombingDamage) {
     return new WireUnit(
-        unitId, unitType, hitsTaken == null ? 0 : hitsTaken, movesUsed == null ? 0 : movesUsed);
+        unitId,
+        unitType,
+        hitsTaken == null ? 0 : hitsTaken,
+        movesUsed == null ? 0 : movesUsed,
+        bombingDamage == null ? 0 : bombingDamage);
+  }
+
+  public WireUnit(
+      final String unitId, final String unitType, final int hitsTaken, final int movesUsed) {
+    this(unitId, unitType, hitsTaken, movesUsed, 0);
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/Phase3PurchaseIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/Phase3PurchaseIntegrationTest.java
@@ -1,0 +1,179 @@
+package org.triplea.ai.sidecar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import games.strategy.triplea.settings.ClientSetting;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.http.HttpService;
+
+/**
+ * End-to-end integration test for Phase 3 purchase decisions.
+ *
+ * <p>Starts a real {@link HttpService} via {@link SidecarMain#startForTest} on port 0, creates a
+ * Germans session, then fires two purchase decision requests in sequence (cold then warm) against
+ * the real {@code PurchaseExecutor}/{@code ProAi} path. Timings are printed to stdout so they are
+ * visible in the Gradle test report.
+ *
+ * <p>Asserts:
+ * <ul>
+ *   <li>{@code status == "ready"}
+ *   <li>{@code plan.kind == "purchase"}
+ *   <li>{@code plan.buys} is a non-empty array (Germans always have PUs to spend on R1)
+ *   <li>{@code plan.repairs} is an array (may be empty — no factories damaged on R1)
+ * </ul>
+ */
+class Phase3PurchaseIntegrationTest {
+
+  private static HttpService svc;
+  private static HttpClient client;
+  private static String base;
+  private static String auth;
+  private static String sessionId;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** Germans is the purchasing nation; seed 42 gives deterministic ProAi decisions. */
+  private static final String NATION = "Germans";
+
+  /** Minimal purchase-phase WireState: empty territories/players, round 1, phase=purchase. */
+  private static final String PURCHASE_WIRE_STATE =
+      "{"
+          + "\"territories\":[],"
+          + "\"players\":[],"
+          + "\"round\":1,"
+          + "\"phase\":\"purchase\","
+          + "\"currentPlayer\":\""
+          + NATION
+          + "\""
+          + "}";
+
+  private static final String PURCHASE_DECISION_BODY =
+      "{\"kind\":\"purchase\",\"state\":" + PURCHASE_WIRE_STATE + "}";
+
+  @BeforeAll
+  static void startServiceAndCreateSession() throws Exception {
+    ClientSetting.setPreferences(new MemoryPreferences());
+
+    svc =
+        SidecarMain.startForTest(
+            Map.of("SIDECAR_BIND_HOST", "127.0.0.1", "SIDECAR_PORT", "0"));
+    final int port = svc.boundPort();
+    client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    base = "http://127.0.0.1:" + port;
+    auth = "Bearer dev-token";
+
+    final HttpResponse<String> create =
+        client.send(
+            HttpRequest.newBuilder(URI.create(base + "/session"))
+                .header("Authorization", auth)
+                .POST(
+                    HttpRequest.BodyPublishers.ofString(
+                        "{\"gameId\":\"integration-purchase\",\"nation\":\""
+                            + NATION
+                            + "\",\"seed\":42}"))
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertEquals(200, create.statusCode(), "Session create must return 200");
+    sessionId = extractField(create.body(), "sessionId");
+    assertNotNull(sessionId, "sessionId must be present in create response");
+  }
+
+  @AfterAll
+  static void stopService() {
+    if (svc != null) {
+      svc.stop();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 1: cold call — first invocation loads game data from canonical clone
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void purchase_coldCall_returns200WithNonEmptyBuys() throws Exception {
+    final long start = System.nanoTime();
+    final HttpResponse<String> resp = postDecision(PURCHASE_DECISION_BODY);
+    final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+    System.out.println("[Phase3PurchaseIntegrationTest] cold call elapsed: " + elapsedMs + " ms");
+
+    assertEquals(200, resp.statusCode(), "purchase must return 200; body=" + resp.body());
+
+    final JsonNode envelope = MAPPER.readTree(resp.body());
+    assertEquals(
+        "ready", envelope.path("status").asText(), "envelope status must be 'ready'");
+
+    final JsonNode plan = envelope.path("plan");
+    assertEquals("purchase", plan.path("kind").asText(), "plan.kind must be 'purchase'");
+
+    assertTrue(plan.path("buys").isArray(), "plan.buys must be an array");
+    assertTrue(plan.path("repairs").isArray(), "plan.repairs must be an array");
+
+    // Germans always have PUs to spend on round 1 — a completely empty buy list is unexpected.
+    assertTrue(
+        plan.path("buys").size() > 0,
+        "Germans must buy at least one unit on round 1; buys=" + plan.path("buys"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 2: warm call — second invocation (session already initialised)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void purchase_warmCall_returns200WithNonEmptyBuys() throws Exception {
+    // Ensure the cold path has been exercised first (test ordering not guaranteed by JUnit, but
+    // both tests share the same session; the warm call may in fact run first — ProAi handles
+    // repeated calls on the same GameData clone correctly because PurchaseExecutor calls
+    // WireStateApplier.apply() at the top of each execute() invocation).
+    final long start = System.nanoTime();
+    final HttpResponse<String> resp = postDecision(PURCHASE_DECISION_BODY);
+    final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+    System.out.println("[Phase3PurchaseIntegrationTest] warm call elapsed: " + elapsedMs + " ms");
+
+    assertEquals(200, resp.statusCode(), "purchase must return 200 on warm call; body=" + resp.body());
+
+    final JsonNode envelope = MAPPER.readTree(resp.body());
+    assertEquals("ready", envelope.path("status").asText());
+
+    final JsonNode plan = envelope.path("plan");
+    assertEquals("purchase", plan.path("kind").asText());
+    assertTrue(plan.path("buys").isArray(), "plan.buys must be an array");
+    assertTrue(plan.path("repairs").isArray(), "plan.repairs must be an array");
+    assertTrue(
+        plan.path("buys").size() > 0,
+        "warm call: Germans must still buy at least one unit; buys=" + plan.path("buys"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private HttpResponse<String> postDecision(final String body) throws Exception {
+    return client.send(
+        HttpRequest.newBuilder(URI.create(base + "/session/" + sessionId + "/decision"))
+            .header("Authorization", auth)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build(),
+        HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static String extractField(final String json, final String field) throws Exception {
+    final JsonNode node = MAPPER.readTree(json);
+    final JsonNode value = node.get(field);
+    return value != null && !value.isNull() ? value.asText() : null;
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarIntegrationTest.java
@@ -60,7 +60,7 @@ class SidecarIntegrationTest {
               HttpResponse.BodyHandlers.ofString());
       assertEquals(204, update.statusCode());
 
-      // 3. decision → 501
+      // 3. decision → 200 (purchase is now wired to PurchaseExecutor)
       final HttpResponse<String> decision =
           client.send(
               HttpRequest.newBuilder(URI.create(base + "/session/" + sessionId + "/decision"))
@@ -68,8 +68,9 @@ class SidecarIntegrationTest {
                   .POST(HttpRequest.BodyPublishers.ofString(DECISION_BODY))
                   .build(),
               HttpResponse.BodyHandlers.ofString());
-      assertEquals(501, decision.statusCode());
-      assertTrue(decision.body().contains("not-implemented"));
+      assertEquals(200, decision.statusCode());
+      assertTrue(decision.body().contains("\"status\":\"ready\""));
+      assertTrue(decision.body().contains("\"kind\":\"purchase\""));
 
       // 4. delete
       final HttpResponse<String> delete =

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchasePlanJsonTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchasePlanJsonTest.java
@@ -1,0 +1,28 @@
+package org.triplea.ai.sidecar.dto;
+
+import static org.junit.jupiter.api.Assertions.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PurchasePlanJsonTest {
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void purchasePlanRoundTripsWithKindDiscriminator() throws Exception {
+    PurchasePlan plan = new PurchasePlan(
+        List.of(
+            new PurchaseOrder("infantry", 3, null),
+            new PurchaseOrder("armour", 1, null)),
+        List.of(new RepairOrder("Germany", "factory_major", 2)));
+    String json = mapper.writeValueAsString((DecisionPlan) plan);
+    assertTrue(json.contains("\"kind\":\"purchase\""));
+    DecisionPlan decoded = mapper.readValue(json, DecisionPlan.class);
+    assertInstanceOf(PurchasePlan.class, decoded);
+    PurchasePlan back = (PurchasePlan) decoded;
+    assertEquals(2, back.buys().size());
+    assertEquals("infantry", back.buys().get(0).unitType());
+    assertEquals(3, back.buys().get(0).count());
+    assertEquals("Germany", back.repairs().get(0).territory());
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchaseRequestJsonTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchaseRequestJsonTest.java
@@ -1,0 +1,32 @@
+package org.triplea.ai.sidecar.dto;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class PurchaseRequestJsonTest {
+  @Test
+  void purchaseRequestDeserialisesThroughSealedDecisionRequest() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    String json =
+        "{\"kind\":\"purchase\",\"state\":{"
+            + "\"territories\":[],\"players\":[],\"round\":1,"
+            + "\"phase\":\"purchase\",\"currentPlayer\":\"Germans\"}}";
+    DecisionRequest req = mapper.readValue(json, DecisionRequest.class);
+    assertInstanceOf(PurchaseRequest.class, req);
+    assertEquals("Germans", ((PurchaseRequest) req).state().currentPlayer());
+  }
+
+  @Test
+  void combatMoveDeserialisesAsOtherOffensive() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    String json =
+        "{\"kind\":\"combat-move\",\"state\":{"
+            + "\"territories\":[],\"players\":[],\"round\":1,"
+            + "\"phase\":\"combatMove\",\"currentPlayer\":\"Germans\"}}";
+    DecisionRequest req = mapper.readValue(json, DecisionRequest.class);
+    assertInstanceOf(OtherOffensiveRequest.class, req);
+    assertEquals("combat-move", ((OtherOffensiveRequest) req).kind());
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ExecutorSupportTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ExecutorSupportTest.java
@@ -67,7 +67,8 @@ class ExecutorSupportTest {
             42L,
             proAi,
             data,
-            new ConcurrentHashMap<>());
+            new ConcurrentHashMap<>(),
+            Executors.newSingleThreadExecutor());
 
     final GamePlayer player = data.getPlayerList().getPlayerId("Germans");
     assertThat(player).as("Germans player must exist in canonical game data").isNotNull();

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
@@ -1,0 +1,127 @@
+package org.triplea.ai.sidecar.exec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.NamedAttachable;
+import games.strategy.engine.data.ProductionRule;
+import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.triplea.Constants;
+import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.dto.PurchaseOrder;
+import org.triplea.ai.sidecar.dto.PurchasePlan;
+import org.triplea.ai.sidecar.dto.PurchaseRequest;
+import org.triplea.ai.sidecar.session.Session;
+import org.triplea.ai.sidecar.session.SessionKey;
+import org.triplea.ai.sidecar.wire.WireState;
+
+class PurchaseExecutorTest {
+
+  private static CanonicalGameData canonical;
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+  }
+
+  private Session freshSession(final String nation) {
+    final GameData data = canonical.cloneForSession();
+    final ProAi proAi = new ProAi("sidecar-test-" + nation, nation);
+    return new Session(
+        "s-test-" + UUID.randomUUID(),
+        new SessionKey("g1", nation),
+        42L,
+        proAi,
+        data,
+        new ConcurrentHashMap<>(),
+        Executors.newSingleThreadExecutor());
+  }
+
+  private static PurchaseRequest purchaseRequestFor(final String nation) {
+    return new PurchaseRequest(
+        new WireState(List.of(), List.of(), 1, "purchase", nation));
+  }
+
+  private static int playerPus(final GameData data, final String nation) {
+    final GamePlayer p = data.getPlayerList().getPlayerId(nation);
+    final Resource pus = data.getResourceList().getResourceOrThrow(Constants.PUS);
+    return p.getResources().getQuantity(pus);
+  }
+
+  private static int totalCost(final GameData data, final PurchasePlan plan) {
+    final Resource pus = data.getResourceList().getResourceOrThrow(Constants.PUS);
+    int sum = 0;
+    for (final PurchaseOrder order : plan.buys()) {
+      final ProductionRule rule = findRuleForUnitType(data, order.unitType());
+      if (rule == null) {
+        continue;
+      }
+      sum += rule.getCosts().getInt(pus) * order.count();
+    }
+    return sum;
+  }
+
+  private static ProductionRule findRuleForUnitType(final GameData data, final String unitTypeName) {
+    for (final ProductionRule rule : data.getProductionRuleList().getProductionRules()) {
+      for (final NamedAttachable result : rule.getResults().keySet()) {
+        if (result instanceof UnitType ut && ut.getName().equals(unitTypeName)) {
+          return rule;
+        }
+      }
+    }
+    return null;
+  }
+
+  @Test
+  void returnsNonEmptyPlanForTurn1Germans() throws Exception {
+    final Session session = freshSession("Germans");
+    final PurchasePlan plan = new PurchaseExecutor().execute(session, purchaseRequestFor("Germans"));
+
+    assertThat(plan.buys()).isNotEmpty();
+    final int budget = playerPus(session.gameData(), "Germans");
+    assertThat(totalCost(session.gameData(), plan)).isLessThanOrEqualTo(budget);
+  }
+
+  @Test
+  void trimToFitClampsWhenProAiOverruns() throws Exception {
+    final Session session = freshSession("Germans");
+    final GameData data = session.gameData();
+    final GamePlayer germans = data.getPlayerList().getPlayerId("Germans");
+    final Resource pus = data.getResourceList().getResourceOrThrow(Constants.PUS);
+    final int current = germans.getResources().getQuantity(pus);
+    // Zero out Germans' PUs so any ProAi overrun is clamped to empty by trimToFit.
+    data.performChange(ChangeFactory.changeResourcesChange(germans, pus, -current));
+
+    final PurchasePlan plan = new PurchaseExecutor().execute(session, purchaseRequestFor("Germans"));
+
+    assertThat(totalCost(data, plan)).isEqualTo(0);
+  }
+
+  @Test
+  void translatesProductionRuleToUnitTypeName() throws Exception {
+    final Session session = freshSession("Germans");
+    final PurchasePlan plan = new PurchaseExecutor().execute(session, purchaseRequestFor("Germans"));
+
+    for (final PurchaseOrder order : plan.buys()) {
+      assertThat(order.unitType()).isNotNull();
+      assertThat(order.count()).isGreaterThan(0);
+      // The unit type must resolve to a real ProductionRule on the canonical map.
+      assertThat(findRuleForUnitType(session.gameData(), order.unitType()))
+          .as("unit type %s has a production rule", order.unitType())
+          .isNotNull();
+    }
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/RecordingPurchaseDelegateTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/RecordingPurchaseDelegateTest.java
@@ -1,0 +1,59 @@
+package org.triplea.ai.sidecar.exec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.ProductionRule;
+import games.strategy.engine.data.RepairRule;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.java.collections.IntegerMap;
+
+class RecordingPurchaseDelegateTest {
+
+  private static CanonicalGameData canonical;
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+  }
+
+  @Test
+  void capturesPurchaseMap() {
+    final GameData data = canonical.cloneForSession();
+    final RecordingPurchaseDelegate d = new RecordingPurchaseDelegate();
+    final IntegerMap<ProductionRule> input = new IntegerMap<>();
+    final ProductionRule anyRule =
+        data.getProductionRuleList().getProductionRules().iterator().next();
+    input.add(anyRule, 4);
+    assertNull(d.purchase(input));
+    assertEquals(4, d.capturedPurchase().getInt(anyRule));
+  }
+
+  @Test
+  void capturesRepairMap() {
+    final RecordingPurchaseDelegate d = new RecordingPurchaseDelegate();
+    final Map<Unit, IntegerMap<RepairRule>> input = Map.of();
+    assertNull(d.purchaseRepair(input));
+    assertNotNull(d.capturedRepair());
+  }
+
+  @Test
+  void noOpMethodsDoNotThrow() {
+    final RecordingPurchaseDelegate d = new RecordingPurchaseDelegate();
+    d.start();
+    d.end();
+    d.setHasPostedTurnSummary(true);
+    assertFalse(d.delegateCurrentlyRequiresUserInput());
+    assertNotNull(d.saveState());
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/RetreatQueryExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/RetreatQueryExecutorTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
@@ -43,7 +44,8 @@ class RetreatQueryExecutorTest {
         42L,
         proAi,
         data,
-        new ConcurrentHashMap<>());
+        new ConcurrentHashMap<>(),
+        Executors.newSingleThreadExecutor());
   }
 
   // ------------------------------------------------------------------------

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ScrambleExecutorBenchmark.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ScrambleExecutorBenchmark.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -108,7 +109,8 @@ class ScrambleExecutorBenchmark {
         42L,
         proAi,
         data,
-        new ConcurrentHashMap<>());
+        new ConcurrentHashMap<>(),
+        Executors.newSingleThreadExecutor());
   }
 
   private static ScrambleRequest buildRequest(final String tag) {

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ScrambleExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ScrambleExecutorTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
@@ -44,7 +45,8 @@ class ScrambleExecutorTest {
         42L,
         proAi,
         data,
-        new ConcurrentHashMap<>());
+        new ConcurrentHashMap<>(),
+        Executors.newSingleThreadExecutor());
   }
 
   // ------------------------------------------------------------------------

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/SelectCasualtiesExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/SelectCasualtiesExecutorTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
@@ -43,7 +44,8 @@ class SelectCasualtiesExecutorTest {
         42L,
         proAi,
         data,
-        new ConcurrentHashMap<>());
+        new ConcurrentHashMap<>(),
+        Executors.newSingleThreadExecutor());
   }
 
   private static WireState wireStateWithGermanStack(final List<WireUnit> units) {

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerPurchaseTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerPurchaseTest.java
@@ -1,0 +1,182 @@
+package org.triplea.ai.sidecar.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.dto.PurchaseOrder;
+import org.triplea.ai.sidecar.dto.PurchasePlan;
+import org.triplea.ai.sidecar.dto.PurchaseRequest;
+import org.triplea.ai.sidecar.dto.RetreatPlan;
+import org.triplea.ai.sidecar.dto.RetreatQueryRequest;
+import org.triplea.ai.sidecar.dto.ScramblePlan;
+import org.triplea.ai.sidecar.dto.ScrambleRequest;
+import org.triplea.ai.sidecar.dto.SelectCasualtiesPlan;
+import org.triplea.ai.sidecar.dto.SelectCasualtiesRequest;
+import org.triplea.ai.sidecar.exec.DecisionExecutor;
+import org.triplea.ai.sidecar.session.Session;
+import org.triplea.ai.sidecar.session.SessionKey;
+import org.triplea.ai.sidecar.session.SessionRegistry;
+
+/**
+ * Tests that {@link DecisionHandler} correctly dispatches purchase decisions to {@link
+ * org.triplea.ai.sidecar.exec.PurchaseExecutor} and wraps the result in the ready envelope.
+ *
+ * <p>Uses a stub purchase executor to keep this a wire-format / dispatch test (not a ProAi
+ * integration test). The stub returns a fixed {@link PurchasePlan} with one buy and no repairs.
+ */
+class DecisionHandlerPurchaseTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+  }
+
+  private static final String EMPTY_STATE =
+      "\"state\":{\"territories\":[],\"players\":[],\"round\":1,"
+          + "\"phase\":\"purchase\",\"currentPlayer\":\"Germans\"}";
+
+  private static final String PURCHASE_BODY =
+      "{\"kind\":\"purchase\"," + EMPTY_STATE + "}";
+
+  private SessionRegistry newRegistry() {
+    return new SessionRegistry(CanonicalGameData.load());
+  }
+
+  private Session newSession(final SessionRegistry registry) {
+    return registry.createOrGet(new SessionKey("g-purchase-test", "Germans"), 42L);
+  }
+
+  /**
+   * Creates a {@link DecisionHandler} with stub Phase-2 executors that throw on invocation, and
+   * the supplied purchase executor stub.
+   */
+  private DecisionHandler handlerWithPurchaseStub(
+      final SessionRegistry registry,
+      final DecisionExecutor<PurchaseRequest, PurchasePlan> purchaseExecutor) {
+    return new DecisionHandler(
+        registry,
+        (session, req) -> { throw new AssertionError("selectCasualties must not be called"); },
+        (session, req) -> { throw new AssertionError("retreat must not be called"); },
+        (session, req) -> { throw new AssertionError("scramble must not be called"); },
+        purchaseExecutor);
+  }
+
+  // -------------------------------------------------------------------------
+  // Happy path: purchase stub returns a plan → 200 + status=ready + plan.kind=purchase
+  // -------------------------------------------------------------------------
+
+  @Test
+  void purchase_success_returns200WithReadyEnvelope() throws Exception {
+    final SessionRegistry registry = newRegistry();
+    final Session s = newSession(registry);
+
+    final PurchasePlan fixedPlan =
+        new PurchasePlan(List.of(new PurchaseOrder("infantry", 3, null)), List.of());
+
+    final DecisionHandler h = handlerWithPurchaseStub(registry, (session, req) -> fixedPlan);
+
+    final FakeHttpExchange ex =
+        new FakeHttpExchange("POST", "/session/" + s.sessionId() + "/decision", PURCHASE_BODY);
+    h.handle(ex);
+
+    assertEquals(200, ex.responseCode(), "purchase decision must return 200");
+
+    final JsonNode root = MAPPER.readTree(ex.responseBodyString());
+    assertEquals("ready", root.path("status").asText(), "envelope status must be 'ready'");
+    assertTrue(root.has("plan"), "envelope must have 'plan'");
+
+    final JsonNode plan = root.path("plan");
+    assertEquals("purchase", plan.path("kind").asText(), "plan.kind must be 'purchase'");
+    assertTrue(plan.path("buys").isArray(), "plan.buys must be an array");
+    assertTrue(plan.path("repairs").isArray(), "plan.repairs must be an array");
+  }
+
+  @Test
+  void purchase_success_buysAndRepairsPresent() throws Exception {
+    final SessionRegistry registry = newRegistry();
+    final Session s = newSession(registry);
+
+    final PurchasePlan fixedPlan =
+        new PurchasePlan(
+            List.of(new PurchaseOrder("infantry", 2, null), new PurchaseOrder("artillery", 1, null)),
+            List.of());
+
+    final DecisionHandler h = handlerWithPurchaseStub(registry, (session, req) -> fixedPlan);
+
+    final FakeHttpExchange ex =
+        new FakeHttpExchange("POST", "/session/" + s.sessionId() + "/decision", PURCHASE_BODY);
+    h.handle(ex);
+
+    assertEquals(200, ex.responseCode());
+    final JsonNode plan = MAPPER.readTree(ex.responseBodyString()).path("plan");
+
+    assertTrue(plan.path("buys").isArray(), "plan.buys must be array");
+    assertTrue(plan.path("repairs").isArray(), "plan.repairs must be array");
+    assertEquals(2, plan.path("buys").size(), "buys must contain 2 entries");
+    assertEquals(0, plan.path("repairs").size(), "repairs must be empty");
+  }
+
+  @Test
+  void purchase_emptyPlan_returns200WithEmptyArrays() throws Exception {
+    final SessionRegistry registry = newRegistry();
+    final Session s = newSession(registry);
+
+    final PurchasePlan emptyPlan = new PurchasePlan(List.of(), List.of());
+    final DecisionHandler h = handlerWithPurchaseStub(registry, (session, req) -> emptyPlan);
+
+    final FakeHttpExchange ex =
+        new FakeHttpExchange("POST", "/session/" + s.sessionId() + "/decision", PURCHASE_BODY);
+    h.handle(ex);
+
+    assertEquals(200, ex.responseCode());
+    final JsonNode plan = MAPPER.readTree(ex.responseBodyString()).path("plan");
+    assertEquals("purchase", plan.path("kind").asText());
+    assertEquals(0, plan.path("buys").size(), "empty buys must still be an array");
+    assertEquals(0, plan.path("repairs").size(), "empty repairs must still be an array");
+  }
+
+  // -------------------------------------------------------------------------
+  // Verify Phase-2 defensive executors still route correctly (no regression)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void selectCasualties_stillRoutedCorrectly_purchaseNotInvoked() throws Exception {
+    final SessionRegistry registry = newRegistry();
+    final Session s = newSession(registry);
+
+    final String selectCasualtiesBody =
+        "{\"kind\":\"select-casualties\","
+            + EMPTY_STATE.replace("\"phase\":\"purchase\"", "\"phase\":\"combat\"")
+            + ",\"battle\":{\"battleId\":\"b1\",\"territory\":\"Egypt\","
+            + "\"attackerNation\":\"British\",\"defenderNation\":\"Germans\","
+            + "\"hitCount\":0,\"selectFrom\":[],\"friendlyUnits\":[],\"enemyUnits\":[],"
+            + "\"isAmphibious\":false,\"amphibiousLandAttackers\":[],"
+            + "\"defaultCasualties\":[],\"allowMultipleHitsPerUnit\":false}}";
+
+    final DecisionHandler h =
+        new DecisionHandler(
+            registry,
+            (session, req) -> new SelectCasualtiesPlan(List.of(), List.of()),
+            (session, req) -> { throw new AssertionError("retreat must not be called"); },
+            (session, req) -> { throw new AssertionError("scramble must not be called"); },
+            (session, req) -> { throw new AssertionError("purchase must not be called"); });
+
+    final FakeHttpExchange ex =
+        new FakeHttpExchange(
+            "POST", "/session/" + s.sessionId() + "/decision", selectCasualtiesBody);
+    h.handle(ex);
+
+    assertEquals(200, ex.responseCode());
+    assertEquals("ready", MAPPER.readTree(ex.responseBodyString()).path("status").asText());
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
 import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.dto.PurchasePlan;
+import org.triplea.ai.sidecar.dto.PurchaseRequest;
 import org.triplea.ai.sidecar.dto.RetreatPlan;
 import org.triplea.ai.sidecar.dto.RetreatQueryRequest;
 import org.triplea.ai.sidecar.dto.ScramblePlan;
@@ -70,7 +72,8 @@ class DecisionHandlerTest {
       final DecisionExecutor<SelectCasualtiesRequest, SelectCasualtiesPlan> sc,
       final DecisionExecutor<RetreatQueryRequest, RetreatPlan> rq,
       final DecisionExecutor<ScrambleRequest, ScramblePlan> sr) {
-    return new DecisionHandler(registry, sc, rq, sr);
+    return new DecisionHandler(
+        registry, sc, rq, sr, (session, req) -> new PurchasePlan(List.of(), List.of()));
   }
 
   // ---------------------------------------------------------------------
@@ -175,7 +178,9 @@ class DecisionHandlerTest {
 
   @Test
   void offensiveKinds_return501() throws Exception {
-    for (final String kind : new String[] {"purchase", "combat-move", "noncombat-move", "place"}) {
+    // purchase is now wired to PurchaseExecutor (returns 200); only remaining offensive
+    // kinds that are still unimplemented return 501.
+    for (final String kind : new String[] {"combat-move", "noncombat-move", "place"}) {
       final SessionRegistry registry = newRegistry();
       final Session s = newSession(registry);
       final DecisionHandler h =

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerWireFormatTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerWireFormatTest.java
@@ -16,6 +16,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
 import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.dto.PurchaseOrder;
+import org.triplea.ai.sidecar.dto.PurchasePlan;
+import org.triplea.ai.sidecar.dto.PurchaseRequest;
 import org.triplea.ai.sidecar.dto.RetreatPlan;
 import org.triplea.ai.sidecar.dto.RetreatQueryRequest;
 import org.triplea.ai.sidecar.dto.ScramblePlan;
@@ -92,7 +95,11 @@ class DecisionHandlerWireFormatTest {
       final DecisionExecutor<SelectCasualtiesRequest, SelectCasualtiesPlan> sc,
       final DecisionExecutor<RetreatQueryRequest, RetreatPlan> rq,
       final DecisionExecutor<ScrambleRequest, ScramblePlan> sr) {
-    return new DecisionHandler(registry, sc, rq, sr);
+    // Default purchase stub: returns an empty plan so wire-format tests that don't exercise
+    // purchase still compile and route correctly.
+    return new DecisionHandler(
+        registry, sc, rq, sr,
+        (session, req) -> new PurchasePlan(List.of(), List.of()));
   }
 
   private JsonNode responseJson(final FakeHttpExchange ex) throws Exception {
@@ -214,13 +221,42 @@ class DecisionHandlerWireFormatTest {
   }
 
   // ---------------------------------------------------------------------
-  // Offensive kinds → 501 with status=error, error=not-implemented, kind=<kind>
+  // Purchase → 200 with status=ready, plan.kind=purchase (Phase 3 wired)
   // ---------------------------------------------------------------------
 
   @Test
-  void purchase_501_wireShape() throws Exception {
-    assertOffensive501Shape("purchase");
+  void purchase_200_wireShape() throws Exception {
+    final SessionRegistry registry = newRegistry();
+    final Session s = newSession(registry);
+    final PurchasePlan fixedPlan =
+        new PurchasePlan(List.of(new PurchaseOrder("infantry", 1, null)), List.of());
+    final DecisionHandler h =
+        new DecisionHandler(
+            registry,
+            (session, req) -> { throw new AssertionError(); },
+            (session, req) -> { throw new AssertionError(); },
+            (session, req) -> { throw new AssertionError(); },
+            (session, req) -> fixedPlan);
+
+    final FakeHttpExchange ex =
+        new FakeHttpExchange("POST", "/session/" + s.sessionId() + "/decision", offensiveBody("purchase"));
+    h.handle(ex);
+
+    assertEquals(200, ex.responseCode(), "purchase must return 200");
+    final JsonNode root = responseJson(ex);
+    assertEquals("ready", root.path("status").asText(), "status must be 'ready'");
+    assertTrue(root.has("plan"), "root must have 'plan'");
+    assertFalse(root.has("error"), "success body must not have 'error'");
+
+    final JsonNode plan = root.path("plan");
+    assertEquals("purchase", plan.path("kind").asText(), "plan.kind must be 'purchase'");
+    assertTrue(plan.path("buys").isArray(), "plan.buys must be array");
+    assertTrue(plan.path("repairs").isArray(), "plan.repairs must be array");
   }
+
+  // ---------------------------------------------------------------------
+  // Remaining offensive kinds → 501 with status=error, error=not-implemented, kind=<kind>
+  // ---------------------------------------------------------------------
 
   @Test
   void combatMove_501_wireShape() throws Exception {

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionOffensiveExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionOffensiveExecutorTest.java
@@ -1,0 +1,34 @@
+package org.triplea.ai.sidecar.session;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+
+class SessionOffensiveExecutorTest {
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+  }
+
+  @Test
+  void sessionHasSingleThreadOffensiveExecutor() throws Exception {
+    final SessionRegistry reg = new SessionRegistry(CanonicalGameData.load());
+    final Session s = reg.createOrGet(new SessionKey("g-1", "Germans"), 42L);
+    assertNotNull(s.offensiveExecutor());
+    final Future<String> f =
+        s.offensiveExecutor().submit(() -> Thread.currentThread().getName());
+    final String threadName = f.get();
+    assertTrue(
+        threadName.contains("sidecar-offensive-" + s.sessionId()),
+        "thread was " + threadName);
+    assertTrue(reg.delete(s.sessionId()));
+    assertTrue(s.offensiveExecutor().isShutdown());
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionTest.java
@@ -7,6 +7,8 @@ import games.strategy.engine.data.GameData;
 import games.strategy.triplea.ai.pro.ProAi;
 import games.strategy.triplea.settings.ClientSetting;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
@@ -24,19 +26,25 @@ class SessionTest {
     final CanonicalGameData canonical = CanonicalGameData.load();
     final GameData data = canonical.cloneForSession();
     final ProAi proAi = new ProAi("session-test", "Germans");
-    final Session s =
-        new Session(
-            "s-1",
-            new SessionKey("g-1", "Germans"),
-            42L,
-            proAi,
-            data,
-            new ConcurrentHashMap<>());
-    assertEquals("s-1", s.sessionId());
-    assertEquals("g-1", s.key().gameId());
-    assertEquals("Germans", s.key().nation());
-    assertEquals(42L, s.seed());
-    assertNotNull(s.proAi());
-    assertNotNull(s.gameData());
+    final ExecutorService exec = Executors.newSingleThreadExecutor();
+    try {
+      final Session s =
+          new Session(
+              "s-1",
+              new SessionKey("g-1", "Germans"),
+              42L,
+              proAi,
+              data,
+              new ConcurrentHashMap<>(),
+              exec);
+      assertEquals("s-1", s.sessionId());
+      assertEquals("g-1", s.key().gameId());
+      assertEquals("Germans", s.key().nation());
+      assertEquals(42L, s.seed());
+      assertNotNull(s.proAi());
+      assertNotNull(s.gameData());
+    } finally {
+      exec.shutdownNow();
+    }
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/StepNameMapperTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/StepNameMapperTest.java
@@ -1,0 +1,32 @@
+package org.triplea.ai.sidecar.wire;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+class StepNameMapperTest {
+  @Test
+  void mapsPurchasePhaseToPurchaseStep() {
+    assertEquals("GermansPurchase", StepNameMapper.toJavaStepName("purchase", "Germans"));
+  }
+
+  @Test
+  void mapsCombatMovePhaseToCombatMoveStep() {
+    assertEquals("GermansCombatMove", StepNameMapper.toJavaStepName("combatMove", "Germans"));
+  }
+
+  @Test
+  void mapsNonCombatMovePhaseToNonCombatMoveStep() {
+    assertEquals("GermansNonCombatMove", StepNameMapper.toJavaStepName("nonCombatMove", "Germans"));
+  }
+
+  @Test
+  void mapsPlacePhaseToPlaceStep() {
+    assertEquals("GermansPlace", StepNameMapper.toJavaStepName("place", "Germans"));
+  }
+
+  @Test
+  void unknownPhaseThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> StepNameMapper.toJavaStepName("mystery", "Germans"));
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierPhase3Test.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierPhase3Test.java
@@ -1,0 +1,92 @@
+package org.triplea.ai.sidecar.wire;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.delegate.battle.BattleTracker;
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+
+/**
+ * Phase 3, Task 5: verifies the three new {@link WireStateApplier} branches — round/step,
+ * conqueredThisTurn, and factory operational damage.
+ */
+class WireStateApplierPhase3Test {
+
+  private static CanonicalGameData canonical;
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+  }
+
+  private GameData fresh() {
+    return canonical.cloneForSession();
+  }
+
+  private ConcurrentMap<String, UUID> freshIdMap() {
+    return new ConcurrentHashMap<>();
+  }
+
+  @Test
+  void appliesRoundAndStep() {
+    final GameData gd = fresh();
+    final WireState wire =
+        new WireState(List.of(), List.of(), 3, "purchase", "Germans");
+    WireStateApplier.apply(gd, wire, freshIdMap());
+    assertThat(gd.getSequence().getRound()).isEqualTo(3);
+    // Uniquely identify the step via its XML name attribute + player. GameStep.getDisplayName
+    // in Global 1940 resolves to the delegate's display ("Purchase Units") and is shared
+    // across players, so the name attribute ("germansPurchase") is the real key.
+    assertThat(gd.getSequence().getStep().getName()).isEqualToIgnoringCase("GermansPurchase");
+    assertThat(gd.getSequence().getStep().getPlayerId().getName()).isEqualTo("Germans");
+  }
+
+  @Test
+  void marksConqueredTerritory() {
+    final GameData gd = fresh();
+    final WireTerritory egypt =
+        new WireTerritory("Egypt", "Germans", List.of(), true);
+    final WireState wire =
+        new WireState(List.of(egypt), List.of(), 3, "purchase", "Germans");
+    WireStateApplier.apply(gd, wire, freshIdMap());
+
+    final Territory egyptT = gd.getMap().getTerritoryOrThrow("Egypt");
+    final BattleTracker tracker = gd.getBattleDelegate().getBattleTracker();
+    assertThat(tracker.wasConquered(egyptT)).isTrue();
+    assertThat(egyptT.getOwner().getName()).isEqualTo("Germans");
+  }
+
+  @Test
+  void appliesOperationalDamageToFactory() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    // Germany starts with a factory_major in Global 1940 + infantry etc. To keep the sync
+    // minimal and deterministic, send just the factory via the wire and assert the freshly-
+    // placed unit ends up with the bombing damage applied.
+    final WireUnit wu = new WireUnit("u-factory-1", "factory_major", 0, 0, 2);
+    final WireTerritory wt =
+        new WireTerritory("Germany", "Germans", List.of(wu), false);
+    final WireState wire =
+        new WireState(List.of(wt), List.of(), 3, "purchase", "Germans");
+    WireStateApplier.apply(gd, wire, idMap);
+
+    final Territory germany = gd.getMap().getTerritoryOrThrow("Germany");
+    final Unit factory =
+        germany.getUnits().stream()
+            .filter(u -> u.getType().getName().startsWith("factory"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(factory.getUnitDamage()).isEqualTo(2);
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateJsonFieldsTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateJsonFieldsTest.java
@@ -1,0 +1,37 @@
+package org.triplea.ai.sidecar.wire;
+
+import static org.junit.jupiter.api.Assertions.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class WireStateJsonFieldsTest {
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void wireTerritoryConqueredThisTurnDefaultsFalse() throws Exception {
+    String json = "{\"territoryId\":\"Egypt\",\"owner\":\"British\",\"units\":[]}";
+    WireTerritory t = mapper.readValue(json, WireTerritory.class);
+    assertFalse(t.conqueredThisTurn());
+  }
+
+  @Test
+  void wireTerritoryConqueredThisTurnHonoured() throws Exception {
+    String json = "{\"territoryId\":\"Egypt\",\"owner\":\"Germans\",\"units\":[],\"conqueredThisTurn\":true}";
+    WireTerritory t = mapper.readValue(json, WireTerritory.class);
+    assertTrue(t.conqueredThisTurn());
+  }
+
+  @Test
+  void wireUnitBombingDamageDefaultsZero() throws Exception {
+    String json = "{\"unitId\":\"u1\",\"unitType\":\"factory_major\"}";
+    WireUnit u = mapper.readValue(json, WireUnit.class);
+    assertEquals(0, u.bombingDamage());
+  }
+
+  @Test
+  void wireUnitBombingDamageHonoured() throws Exception {
+    String json = "{\"unitId\":\"u1\",\"unitType\":\"factory_major\",\"bombingDamage\":3}";
+    WireUnit u = mapper.readValue(json, WireUnit.class);
+    assertEquals(3, u.bombingDamage());
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -264,6 +264,23 @@ public abstract class AbstractProAi extends AbstractAi {
     ProLogger.info(player.getName() + " time for purchase=" + (System.currentTimeMillis() - start));
   }
 
+  /**
+   * Public bridge to the {@code protected} {@link #purchase} entry point for the AI sidecar.
+   *
+   * <p>The sidecar's {@code PurchaseExecutor} lives in a separate package
+   * ({@code org.triplea.ai.sidecar.exec}) and therefore cannot invoke {@link #purchase}
+   * directly. This method is a thin delegation with no additional behaviour — keep it that
+   * way. All purchase logic belongs in {@link #purchase}.
+   */
+  public void invokePurchaseForSidecar(
+      final boolean purchaseForBid,
+      final int pusToSpend,
+      final IPurchaseDelegate purchaseDelegate,
+      final GameData data,
+      final GamePlayer player) {
+    purchase(purchaseForBid, pusToSpend, purchaseDelegate, data, player);
+  }
+
   private GameData copyData(GameData data) {
     GameDataManager.Options options = GameDataManager.Options.builder().withDelegates(true).build();
     GameData dataCopy = GameDataUtils.cloneGameData(data, options).orElse(null);


### PR DESCRIPTION
## Summary
- First offensive IPlayer kind on the sidecar: `purchase`
- `PurchaseExecutor` runs `AbstractProAi.invokePurchaseForSidecar()` on a per-session bounded executor
- `RecordingPurchaseDelegate` captures the `IntegerMap<ProductionRule>` + repair map
- Trim-to-fit backstop documented in `PurchaseExecutor` Javadoc with file+line citations (`ProPurchaseAi.java:2404-2429`, `:251`, `:380`)
- `WireStateApplier` extensions: round/step sync, conquered flag (via BattleTracker), operational damage
- DTO split: `PurchaseRequest` peels out of former `OffensiveRequest`; `OtherOffensiveRequest` absorbs the still-501 three
- Per-session `offensiveExecutor` daemon thread (`sidecar-offensive-{sessionId}`), shutdown in `SessionRegistry.delete`
- `:phase3` image built locally and smoke-tested (`/health` returns 200); push to `ghcr.io/map-room/ai-sidecar:phase3` blocked pending registry auth

Part of map-room/map-room#1734. Paired with map-room/map-room#1751 (Map Room dispatch PR to follow).

## Test plan
- [x] Full sidecar test suite: `./gradlew :game-app:ai-sidecar:test`
- [x] Game-core regression: `./gradlew :game-app:game-core:test --tests *ProPurchaseAi*` (no `AbstractProAi` test class exists; bridge tested via ProPurchaseAiTest)
- [x] Phase3PurchaseIntegrationTest end-to-end (cold ~14s, warm ~13s logged)
- [x] `:phase3` image smoke (`/health` returns 200)
- [ ] 🧑 Manual: Push `:phase3` image to `ghcr.io/map-room/ai-sidecar:phase3` (registry auth blocked — needs credentials)
- [ ] 🧑 Manual: Map Room PR integration test against this image (handled in map-room/map-room#1751)