### PR TITLE
feat(ai-sidecar): combat-move executor + RecordingMoveDelegate with SBR partition

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/CombatMoveOrder.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/CombatMoveOrder.java
@@ -1,0 +1,11 @@
+package org.triplea.ai.sidecar.dto;
+
+import java.util.List;
+
+/**
+ * A single unit-movement order projected from a TripleA {@code MoveDescription}.
+ *
+ * <p>{@code unitIds} are Map Room wire IDs (the string keys from the wire state), not Java UUIDs.
+ * {@code from} and {@code to} are territory names as they appear in the canonical map.
+ */
+public record CombatMoveOrder(List<String> unitIds, String from, String to) {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/CombatMovePlan.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/CombatMovePlan.java
@@ -1,0 +1,17 @@
+package org.triplea.ai.sidecar.dto;
+
+import java.util.List;
+
+/**
+ * Response for the {@code combat-move} decision kind.
+ *
+ * <p>{@code moves} contains standard (non-bombing) move orders (batches 1–3 from
+ * {@code ProCombatMoveAi.doMove}). {@code sbrMoves} contains strategic-bombing-raid orders (batch
+ * 4, where {@code AbstractProAi#shouldBomberBomb} returned {@code true} at capture time).
+ */
+public record CombatMovePlan(List<CombatMoveOrder> moves, List<CombatMoveOrder> sbrMoves)
+    implements DecisionPlan {
+  public String kind() {
+    return "combat-move";
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/CombatMoveRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/CombatMoveRequest.java
@@ -1,0 +1,16 @@
+package org.triplea.ai.sidecar.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.triplea.ai.sidecar.wire.WireState;
+
+/**
+ * Request for the {@code combat-move} decision kind. The sidecar restores the
+ * {@code storedCombatMoveMap} from the session snapshot and calls
+ * {@code AbstractProAi#invokeCombatMoveForSidecar} to produce the move list.
+ */
+@JsonIgnoreProperties("kind")
+public record CombatMoveRequest(WireState state) implements DecisionRequest {
+  public String kind() {
+    return "combat-move";
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionPlan.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionPlan.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
   @JsonSubTypes.Type(value = RetreatPlan.class,          name = "retreat-or-press"),
   @JsonSubTypes.Type(value = ScramblePlan.class,         name = "scramble"),
   @JsonSubTypes.Type(value = PurchasePlan.class,         name = "purchase"),
+  @JsonSubTypes.Type(value = CombatMovePlan.class,       name = "combat-move"),
 })
 public sealed interface DecisionPlan
-    permits SelectCasualtiesPlan, RetreatPlan, ScramblePlan, PurchasePlan {}
+    permits SelectCasualtiesPlan, RetreatPlan, ScramblePlan, PurchasePlan, CombatMovePlan {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionRequest.java
@@ -10,7 +10,7 @@ import org.triplea.ai.sidecar.wire.WireState;
   @JsonSubTypes.Type(value = RetreatQueryRequest.class, name = "retreat-or-press"),
   @JsonSubTypes.Type(value = ScrambleRequest.class, name = "scramble"),
   @JsonSubTypes.Type(value = PurchaseRequest.class, name = "purchase"),
-  @JsonSubTypes.Type(value = OtherOffensiveRequest.class, name = "combat-move"),
+  @JsonSubTypes.Type(value = CombatMoveRequest.class,     name = "combat-move"),
   @JsonSubTypes.Type(value = OtherOffensiveRequest.class, name = "noncombat-move"),
   @JsonSubTypes.Type(value = OtherOffensiveRequest.class, name = "place"),
 })
@@ -19,6 +19,7 @@ public sealed interface DecisionRequest
         RetreatQueryRequest,
         ScrambleRequest,
         PurchaseRequest,
+        CombatMoveRequest,
         OtherOffensiveRequest {
   WireState state();
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/CombatMoveExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/CombatMoveExecutor.java
@@ -1,0 +1,133 @@
+package org.triplea.ai.sidecar.exec;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Unit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.triplea.ai.sidecar.dto.CombatMoveOrder;
+import org.triplea.ai.sidecar.dto.CombatMovePlan;
+import org.triplea.ai.sidecar.dto.CombatMoveRequest;
+import org.triplea.ai.sidecar.session.ProSessionSnapshotStore;
+import org.triplea.ai.sidecar.session.Session;
+import org.triplea.ai.sidecar.wire.WireStateApplier;
+
+/**
+ * Runs {@link games.strategy.triplea.ai.pro.ProAi#invokeCombatMoveForSidecar} on the session's
+ * bounded offensive executor, captures every {@link games.strategy.engine.data.MoveDescription}
+ * via a {@link RecordingMoveDelegate}, partitions captured moves into standard moves and
+ * strategic-bombing-raid moves, and projects each to a wire-shaped {@link CombatMoveOrder}.
+ *
+ * <h2>Ordering contract</h2>
+ *
+ * <p>Before dispatching to the ProAi this executor enforces the contract established in #1763:
+ * <ol>
+ *   <li>Load the session snapshot (if present) and call
+ *       {@link ProSessionSnapshotStore#restoreUnitIdMap} — pre-seeds the live {@code unitIdMap}
+ *       so that {@code computeIfAbsent} inside {@link WireStateApplier} assigns the same UUIDs
+ *       that the purchase snapshot used, not fresh random ones.
+ *   <li>{@link WireStateApplier#apply} — hydrates live {@link GameData} from wire state.
+ *   <li>{@link games.strategy.triplea.ai.pro.ProAi#restoreCombatMoveMapFromSnapshot} — restores
+ *       {@code storedCombatMoveMap} from the snapshot. No-op if it was already populated in this
+ *       JVM session (purchase ran in the same process).
+ *   <li>Submit {@code invokeCombatMoveForSidecar} to the session's single-threaded executor.
+ * </ol>
+ */
+public final class CombatMoveExecutor implements DecisionExecutor<CombatMoveRequest, CombatMovePlan> {
+
+  private final ProSessionSnapshotStore snapshotStore;
+
+  public CombatMoveExecutor(final ProSessionSnapshotStore snapshotStore) {
+    this.snapshotStore = snapshotStore;
+  }
+
+  @Override
+  public CombatMovePlan execute(final Session session, final CombatMoveRequest request) {
+    final GameData data = session.gameData();
+
+    // Step 1: load snapshot once; pre-seed unitIdMap before WireStateApplier runs
+    final Optional<games.strategy.triplea.ai.pro.data.ProSessionSnapshot> snapOpt =
+        snapshotStore.load(session.key());
+    snapOpt.ifPresent(snap -> ProSessionSnapshotStore.restoreUnitIdMap(snap, session.unitIdMap()));
+
+    // Step 2: hydrate GameData from wire state
+    WireStateApplier.apply(data, request.state(), session.unitIdMap());
+
+    final GamePlayer player =
+        data.getPlayerList().getPlayerId(request.state().currentPlayer());
+    if (player == null) {
+      throw new IllegalArgumentException(
+          "Unknown player in CombatMoveRequest: " + request.state().currentPlayer());
+    }
+
+    ExecutorSupport.ensureProAiInitialized(session, player);
+    ExecutorSupport.ensureBattleDelegate(data);
+
+    final var proAi = session.proAi();
+
+    // Step 3: restore storedCombatMoveMap (no-op if already populated this JVM session)
+    snapOpt.ifPresent(snap -> proAi.restoreCombatMoveMapFromSnapshot(snap, data));
+
+    if (proAi.storedCombatMoveMapIsNull()) {
+      throw new IllegalStateException(
+          "storedCombatMoveMap is null for session " + session.key()
+              + " — purchase must run before combat-move");
+    }
+
+    // Step 4: dispatch on the session's single-threaded offensive executor
+    final RecordingMoveDelegate recorder = new RecordingMoveDelegate(proAi);
+    final Future<Void> future =
+        session
+            .offensiveExecutor()
+            .submit(
+                () -> {
+                  proAi.invokeCombatMoveForSidecar(recorder, data, player);
+                  return null;
+                });
+    try {
+      future.get();
+    } catch (final InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("CombatMoveExecutor interrupted", ie);
+    } catch (final ExecutionException ee) {
+      final Throwable cause = ee.getCause();
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      throw new RuntimeException("CombatMoveExecutor failed", cause);
+    }
+
+    // Build reverse map: UUID → wireId (needed to project Unit references back to wire IDs)
+    final Map<UUID, String> uuidToWireId = new HashMap<>();
+    session.unitIdMap().forEach((wireId, uuid) -> uuidToWireId.put(uuid, wireId));
+
+    final List<CombatMoveOrder> moves = new ArrayList<>();
+    final List<CombatMoveOrder> sbrMoves = new ArrayList<>();
+
+    for (final RecordingMoveDelegate.CapturedMove captured : recorder.captured()) {
+      final List<String> unitIds = new ArrayList<>();
+      for (final Unit unit : captured.move().getUnits()) {
+        final String wireId = uuidToWireId.get(unit.getId());
+        if (wireId != null) {
+          unitIds.add(wireId);
+        }
+      }
+      final String from = captured.move().getRoute().getStart().getName();
+      final String to = captured.move().getRoute().getEnd().getName();
+      final CombatMoveOrder order = new CombatMoveOrder(unitIds, from, to);
+      if (captured.isBombing()) {
+        sbrMoves.add(order);
+      } else {
+        moves.add(order);
+      }
+    }
+
+    return new CombatMovePlan(moves, sbrMoves);
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingMoveDelegate.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingMoveDelegate.java
@@ -1,0 +1,170 @@
+package org.triplea.ai.sidecar.exec;
+
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.MoveDescription;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.message.IRemote;
+import games.strategy.engine.posted.game.pbem.PbemMessagePoster;
+import games.strategy.net.websocket.ClientNetworkBridge;
+import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.delegate.UndoableMove;
+import games.strategy.triplea.delegate.remote.IMoveDelegate;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * {@link IMoveDelegate} stub that captures every {@link MoveDescription} handed to
+ * {@link #performMove}, tagging each one with whether it is a strategic-bombing-raid move via
+ * {@link ProAi#shouldBomberBomb}. Used by {@link CombatMoveExecutor} to intercept the side-effect
+ * output of {@link games.strategy.triplea.ai.pro.AbstractProAi#invokeCombatMoveForSidecar} without
+ * mutating the session's {@link games.strategy.engine.data.GameData}.
+ *
+ * <p>{@link ProAi#shouldBomberBomb} is sampled at capture time because
+ * {@code ProCombatMoveAi.isBombing} is set to {@code true} exactly during the
+ * {@code calculateBombingRoutes} batch call (batch 4 of the four sequential
+ * {@code ProMoveUtils.doMove} calls in {@code doMove}) and reset to {@code false} immediately
+ * after. The flag is therefore live and correct at the moment {@code performMove} fires.
+ *
+ * <p><b>Thread-safety:</b> not thread-safe. Each {@link CombatMoveExecutor#execute} call creates
+ * a fresh instance; the session-scoped executor serialises access on the Java side.
+ */
+public final class RecordingMoveDelegate implements IMoveDelegate {
+
+  /**
+   * A single captured move together with its bombing classification at the time of capture.
+   *
+   * @param move the raw {@link MoveDescription} handed to the delegate
+   * @param isBombing {@code true} when the move was issued during the SBR batch
+   */
+  public record CapturedMove(MoveDescription move, boolean isBombing) {}
+
+  private final Predicate<Territory> bombingCheck;
+  private final List<CapturedMove> captured = new ArrayList<>();
+  private IDelegateBridge bridge;
+  private String name = "recordingMove";
+  private String displayName = "Recording Move";
+
+  public RecordingMoveDelegate(final ProAi proAi) {
+    this.bombingCheck = proAi::shouldBomberBomb;
+  }
+
+  /** Package-private constructor for unit tests that don't need a real {@link ProAi}. */
+  RecordingMoveDelegate(final Predicate<Territory> bombingCheck) {
+    this.bombingCheck = bombingCheck;
+  }
+
+  /** Returns an unmodifiable snapshot of all captured moves in call order. */
+  public List<CapturedMove> captured() {
+    return List.copyOf(captured);
+  }
+
+  @Override
+  public Optional<String> performMove(final MoveDescription move) {
+    final Territory end = move.getRoute().getEnd();
+    captured.add(new CapturedMove(move, bombingCheck.test(end)));
+    return Optional.empty();
+  }
+
+  // ---- IMoveDelegate no-ops ----
+
+  @Override
+  public Collection<Territory> getTerritoriesWhereAirCantLand(final GamePlayer player) {
+    return List.of();
+  }
+
+  @Override
+  public Collection<Territory> getTerritoriesWhereAirCantLand() {
+    return List.of();
+  }
+
+  @Override
+  public Collection<Territory> getTerritoriesWhereUnitsCantFight() {
+    return List.of();
+  }
+
+  @Override
+  public List<UndoableMove> getMovesMade() {
+    return List.of();
+  }
+
+  @Override
+  public String undoMove(final int moveIndex) {
+    return null;
+  }
+
+  @Override
+  public void setHasPostedTurnSummary(final boolean hasPostedTurnSummary) {}
+
+  @Override
+  public boolean getHasPostedTurnSummary() {
+    return false;
+  }
+
+  @Override
+  public boolean postTurnSummary(final PbemMessagePoster poster, final String title) {
+    return true;
+  }
+
+  @Override
+  public void initialize(final String name, final String displayName) {
+    this.name = name;
+    this.displayName = displayName;
+  }
+
+  @Override
+  public void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge) {
+    this.bridge = delegateBridge;
+  }
+
+  @Override
+  public void setDelegateBridgeAndPlayer(
+      final IDelegateBridge delegateBridge, final ClientNetworkBridge clientNetworkBridge) {
+    this.bridge = delegateBridge;
+  }
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void end() {}
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  @Override
+  public IDelegateBridge getBridge() {
+    return bridge;
+  }
+
+  @Override
+  public Serializable saveState() {
+    return new Serializable() {
+      private static final long serialVersionUID = 1L;
+    };
+  }
+
+  @Override
+  public void loadState(final Serializable state) {}
+
+  @Override
+  public Class<? extends IRemote> getRemoteType() {
+    return IMoveDelegate.class;
+  }
+
+  @Override
+  public boolean delegateCurrentlyRequiresUserInput() {
+    return false;
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import org.triplea.ai.sidecar.dto.CombatMovePlan;
+import org.triplea.ai.sidecar.dto.CombatMoveRequest;
 import org.triplea.ai.sidecar.dto.DecisionPlan;
 import org.triplea.ai.sidecar.dto.DecisionRequest;
 import org.triplea.ai.sidecar.dto.OtherOffensiveRequest;
@@ -17,6 +19,7 @@ import org.triplea.ai.sidecar.dto.ScramblePlan;
 import org.triplea.ai.sidecar.dto.ScrambleRequest;
 import org.triplea.ai.sidecar.dto.SelectCasualtiesPlan;
 import org.triplea.ai.sidecar.dto.SelectCasualtiesRequest;
+import org.triplea.ai.sidecar.exec.CombatMoveExecutor;
 import org.triplea.ai.sidecar.exec.DecisionExecutor;
 import org.triplea.ai.sidecar.exec.PurchaseExecutor;
 import org.triplea.ai.sidecar.exec.RetreatQueryExecutor;
@@ -35,7 +38,7 @@ import org.triplea.ai.sidecar.session.SessionRegistry;
  * switch that picks the matching executor; the returned {@link DecisionPlan} is wrapped in a
  * {@code {"status":"ready","plan":{...}}} envelope and sent as the 200 response body.
  *
- * <p>Offensive kinds (purchase/combat-move/noncombat-move/place) return 501 with a
+ * <p>Offensive kinds not yet implemented (noncombat-move/place) return 501 with a
  * {@code {"status":"error","error":"not-implemented","kind":"<kind>"}} body.
  */
 public final class DecisionHandler implements HttpHandler {
@@ -48,6 +51,7 @@ public final class DecisionHandler implements HttpHandler {
   private final DecisionExecutor<RetreatQueryRequest, RetreatPlan> retreatQueryExecutor;
   private final DecisionExecutor<ScrambleRequest, ScramblePlan> scrambleExecutor;
   private final DecisionExecutor<PurchaseRequest, PurchasePlan> purchaseExecutor;
+  private final DecisionExecutor<CombatMoveRequest, CombatMovePlan> combatMoveExecutor;
 
   /** Production constructor — wires the real Phase-2 and Phase-3 executors. */
   public DecisionHandler(final SessionRegistry registry) {
@@ -56,7 +60,8 @@ public final class DecisionHandler implements HttpHandler {
         new SelectCasualtiesExecutor(),
         new RetreatQueryExecutor(),
         new ScrambleExecutor(),
-        new PurchaseExecutor(registry.snapshotStore()));
+        new PurchaseExecutor(registry.snapshotStore()),
+        new CombatMoveExecutor(registry.snapshotStore()));
   }
 
   /**
@@ -74,21 +79,46 @@ public final class DecisionHandler implements HttpHandler {
         selectCasualtiesExecutor,
         retreatQueryExecutor,
         scrambleExecutor,
-        new PurchaseExecutor(snapshotStore));
+        new PurchaseExecutor(snapshotStore),
+        new CombatMoveExecutor(snapshotStore));
   }
 
-  /** Test constructor — accepts executor stubs so handler logic can be exercised in isolation. */
+  /**
+   * Test constructor — accepts executor stubs so handler logic can be exercised in isolation.
+   * Combat-move defaults to a stub that throws {@link AssertionError}; use the 6-arg overload to
+   * inject a real or custom combat-move executor.
+   */
   public DecisionHandler(
       final SessionRegistry registry,
       final DecisionExecutor<SelectCasualtiesRequest, SelectCasualtiesPlan> selectCasualtiesExecutor,
       final DecisionExecutor<RetreatQueryRequest, RetreatPlan> retreatQueryExecutor,
       final DecisionExecutor<ScrambleRequest, ScramblePlan> scrambleExecutor,
       final DecisionExecutor<PurchaseRequest, PurchasePlan> purchaseExecutor) {
+    this(
+        registry,
+        selectCasualtiesExecutor,
+        retreatQueryExecutor,
+        scrambleExecutor,
+        purchaseExecutor,
+        (session, req) -> {
+          throw new AssertionError("CombatMoveExecutor was called unexpectedly");
+        });
+  }
+
+  /** Test constructor — full control over all executors. */
+  public DecisionHandler(
+      final SessionRegistry registry,
+      final DecisionExecutor<SelectCasualtiesRequest, SelectCasualtiesPlan> selectCasualtiesExecutor,
+      final DecisionExecutor<RetreatQueryRequest, RetreatPlan> retreatQueryExecutor,
+      final DecisionExecutor<ScrambleRequest, ScramblePlan> scrambleExecutor,
+      final DecisionExecutor<PurchaseRequest, PurchasePlan> purchaseExecutor,
+      final DecisionExecutor<CombatMoveRequest, CombatMovePlan> combatMoveExecutor) {
     this.registry = registry;
     this.selectCasualtiesExecutor = selectCasualtiesExecutor;
     this.retreatQueryExecutor = retreatQueryExecutor;
     this.scrambleExecutor = scrambleExecutor;
     this.purchaseExecutor = purchaseExecutor;
+    this.combatMoveExecutor = combatMoveExecutor;
   }
 
   @Override
@@ -139,6 +169,10 @@ public final class DecisionHandler implements HttpHandler {
         }
         case PurchaseRequest pr -> {
           final PurchasePlan plan = purchaseExecutor.execute(session.get(), pr);
+          writeJson(exchange, 200, JsonBodies.readyBody(plan));
+        }
+        case CombatMoveRequest cm -> {
+          final CombatMovePlan plan = combatMoveExecutor.execute(session.get(), cm);
           writeJson(exchange, 200, JsonBodies.readyBody(plan));
         }
         case OtherOffensiveRequest oo -> writeJson(

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchaseRequestJsonTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchaseRequestJsonTest.java
@@ -19,14 +19,15 @@ class PurchaseRequestJsonTest {
   }
 
   @Test
-  void combatMoveDeserialisesAsOtherOffensive() throws Exception {
+  void combatMoveDeserialisesAsCombatMoveRequest() throws Exception {
     ObjectMapper mapper = new ObjectMapper();
     String json =
         "{\"kind\":\"combat-move\",\"state\":{"
             + "\"territories\":[],\"players\":[],\"round\":1,"
             + "\"phase\":\"combatMove\",\"currentPlayer\":\"Germans\"}}";
     DecisionRequest req = mapper.readValue(json, DecisionRequest.class);
-    assertInstanceOf(OtherOffensiveRequest.class, req);
-    assertEquals("combat-move", ((OtherOffensiveRequest) req).kind());
+    assertInstanceOf(CombatMoveRequest.class, req);
+    assertEquals("Germans", ((CombatMoveRequest) req).state().currentPlayer());
+    assertEquals("combat-move", ((CombatMoveRequest) req).kind());
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/CombatMoveExecutorIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/CombatMoveExecutorIntegrationTest.java
@@ -1,0 +1,92 @@
+package org.triplea.ai.sidecar.exec;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.settings.ClientSetting;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.dto.CombatMovePlan;
+import org.triplea.ai.sidecar.dto.CombatMoveRequest;
+import org.triplea.ai.sidecar.dto.PurchaseRequest;
+import org.triplea.ai.sidecar.session.ProSessionSnapshotStore;
+import org.triplea.ai.sidecar.session.Session;
+import org.triplea.ai.sidecar.session.SessionKey;
+import org.triplea.ai.sidecar.wire.WireState;
+
+/**
+ * Integration test for {@link CombatMoveExecutor}. Runs a real purchase first (which populates
+ * {@code storedCombatMoveMap} via {@code think()}) then a real combat-move on the same session,
+ * asserting that the returned plan contains at least one non-SBR move.
+ */
+class CombatMoveExecutorIntegrationTest {
+
+  @TempDir
+  Path snapshotDir;
+
+  private static CanonicalGameData canonical;
+
+  @BeforeAll
+  static void init() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+  }
+
+  private Session freshSession(final String nation) {
+    final GameData data = canonical.cloneForSession();
+    final ProAi proAi = new ProAi("sidecar-test-" + nation, nation);
+    return new Session(
+        "s-test-" + UUID.randomUUID(),
+        new SessionKey("g1", nation),
+        42L,
+        proAi,
+        data,
+        new ConcurrentHashMap<>(),
+        Executors.newSingleThreadExecutor());
+  }
+
+  @Test
+  void germansHaveNonEmptyCombatMovesAfterPurchase() {
+    final ProSessionSnapshotStore store = new ProSessionSnapshotStore(snapshotDir);
+    final Session session = freshSession("Germans");
+
+    // Run purchase — this calls think() which populates storedCombatMoveMap
+    final PurchaseExecutor purchaseExecutor = new PurchaseExecutor(store);
+    purchaseExecutor.execute(session,
+        new PurchaseRequest(new WireState(List.of(), List.of(), 1, "purchase", "Germans")));
+
+    // storedCombatMoveMap is now set; run combat-move on same session
+    final CombatMoveExecutor combatMoveExecutor = new CombatMoveExecutor(store);
+    final CombatMovePlan plan = combatMoveExecutor.execute(session,
+        new CombatMoveRequest(new WireState(List.of(), List.of(), 1, "combat-move", "Germans")));
+
+    assertNotNull(plan);
+    // Germans on turn 1 have combat moves (they border enemy territories)
+    assertFalse(plan.moves().isEmpty(),
+        "Germans should have at least one combat move on turn 1; got: " + plan.moves());
+  }
+
+  @Test
+  void combatMovePlanHasCorrectKind() {
+    final ProSessionSnapshotStore store = new ProSessionSnapshotStore(snapshotDir);
+    final Session session = freshSession("Germans");
+
+    new PurchaseExecutor(store).execute(session,
+        new PurchaseRequest(new WireState(List.of(), List.of(), 1, "purchase", "Germans")));
+
+    final CombatMovePlan plan = new CombatMoveExecutor(store).execute(session,
+        new CombatMoveRequest(new WireState(List.of(), List.of(), 1, "combat-move", "Germans")));
+
+    assertNotNull(plan, "plan must not be null");
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ProSessionSnapshotRoundTripTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ProSessionSnapshotRoundTripTest.java
@@ -226,6 +226,65 @@ class ProSessionSnapshotRoundTripTest {
         "restoreCombatMoveMapFromSnapshot must populate storedCombatMoveMap");
   }
 
+  /**
+   * Stale-transport resilience: a {@code storedCombatMoveMap} snapshot whose
+   * {@code amphibAttackMap} references a transport UUID that is absent from the live
+   * {@link GameData} must not throw — the defensive drop in
+   * {@link AbstractProAi#restoreCombatMoveMapFromSnapshot} silently omits that entry.
+   */
+  @Test
+  void staleCombatMoveMapTransportUuidIsDroppedSilently() {
+    final String staleTransportUuid = UUID.randomUUID().toString();
+    final ProTerritorySnapshot snapWithStale = new ProTerritorySnapshot(
+        List.of(),
+        List.of(),
+        // amphibAttackMap carries a stale transport UUID
+        Map.of(staleTransportUuid, List.of(UUID.randomUUID().toString())),
+        Map.of(staleTransportUuid, "Sea Zone 5"),
+        Map.of());
+
+    final ProSessionSnapshot snap = new ProSessionSnapshot(
+        Map.of("Germany", snapWithStale),
+        Map.of(),
+        Map.of(),
+        Map.of());
+
+    final ProAi freshProAi = new ProAi("test-stale", "Germans");
+    final GameData data;
+    try {
+      data = CanonicalGameData.load().cloneForSession();
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    // Must not throw even though the transport UUID is unknown in GameData
+    freshProAi.restoreCombatMoveMapFromSnapshot(snap, data);
+
+    // storedCombatMoveMap should be populated (the territory entry survives)
+    final java.lang.reflect.Field combatField;
+    try {
+      combatField = AbstractProAi.class.getDeclaredField("storedCombatMoveMap");
+      combatField.setAccessible(true);
+      final Object restored = combatField.get(freshProAi);
+      assertNotNull(restored, "storedCombatMoveMap must be populated even when transport is stale");
+      // The territory entry is present, but the amphibAttackMap for it must be empty
+      // (stale transport was dropped)
+      @SuppressWarnings("unchecked")
+      final java.util.Map<games.strategy.engine.data.Territory,
+          games.strategy.triplea.ai.pro.data.ProTerritory> combatMap =
+          (java.util.Map<games.strategy.engine.data.Territory,
+              games.strategy.triplea.ai.pro.data.ProTerritory>) restored;
+      assertFalse(combatMap.isEmpty(),
+          "storedCombatMoveMap must have an entry for Eastern Germany");
+      final games.strategy.triplea.ai.pro.data.ProTerritory pt =
+          combatMap.values().iterator().next();
+      assertTrue(pt.getAmphibAttackMap().isEmpty(),
+          "stale transport entry must be absent from restored amphibAttackMap");
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   private static List<Field> getAllFields(final Class<?> cls) {
     final List<Field> fields = new ArrayList<>(Arrays.asList(cls.getDeclaredFields()));
     Class<?> parent = cls.getSuperclass();

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/RecordingMoveDelegateTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/RecordingMoveDelegateTest.java
@@ -1,0 +1,86 @@
+package org.triplea.ai.sidecar.exec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.MoveDescription;
+import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.triplea.ai.sidecar.CanonicalGameData;
+
+/**
+ * Unit tests for {@link RecordingMoveDelegate}. Verifies capture order and SBR partition using
+ * the package-private {@code Predicate<Territory>} constructor to avoid needing a live
+ * {@link games.strategy.triplea.ai.pro.ProAi} instance.
+ */
+class RecordingMoveDelegateTest {
+
+  private static GameData data;
+  private static Territory germany;
+  private static Territory poland;
+  private static Territory ukraine;
+
+  @BeforeAll
+  static void loadData() throws Exception {
+    data = CanonicalGameData.load().cloneForSession();
+    germany = data.getMap().getTerritoryOrNull("Germany");
+    poland  = data.getMap().getTerritoryOrNull("Poland");
+    ukraine = data.getMap().getTerritoryOrNull("Ukraine");
+  }
+
+  @Test
+  void capturesMovesInOrder() {
+    final RecordingMoveDelegate delegate = new RecordingMoveDelegate(t -> false);
+    final MoveDescription m1 = new MoveDescription(List.of(), new Route(germany, poland));
+    final MoveDescription m2 = new MoveDescription(List.of(), new Route(poland, ukraine));
+
+    assertEquals(Optional.empty(), delegate.performMove(m1));
+    assertEquals(Optional.empty(), delegate.performMove(m2));
+
+    final List<RecordingMoveDelegate.CapturedMove> captured = delegate.captured();
+    assertEquals(2, captured.size());
+    assertEquals(m1, captured.get(0).move());
+    assertEquals(m2, captured.get(1).move());
+  }
+
+  @Test
+  void partitionsNonBombingMoves() {
+    final RecordingMoveDelegate delegate = new RecordingMoveDelegate(t -> false);
+    delegate.performMove(new MoveDescription(List.of(), new Route(germany, poland)));
+    delegate.performMove(new MoveDescription(List.of(), new Route(germany, ukraine)));
+
+    assertTrue(delegate.captured().stream().noneMatch(RecordingMoveDelegate.CapturedMove::isBombing),
+        "all moves should be non-bombing when predicate returns false");
+  }
+
+  @Test
+  void partitionsBombingMovesByEndTerritory() {
+    // Bombing predicate: only ukraine is an SBR target
+    final Set<Territory> sbrTargets = Set.of(ukraine);
+    final RecordingMoveDelegate delegate = new RecordingMoveDelegate(sbrTargets::contains);
+
+    delegate.performMove(new MoveDescription(List.of(), new Route(germany, poland)));  // not SBR
+    delegate.performMove(new MoveDescription(List.of(), new Route(germany, ukraine))); // SBR
+
+    final List<RecordingMoveDelegate.CapturedMove> captured = delegate.captured();
+    assertFalse(captured.get(0).isBombing(), "poland move must not be bombing");
+    assertTrue(captured.get(1).isBombing(), "ukraine move must be bombing");
+  }
+
+  @Test
+  void capturedListIsImmutable() {
+    final RecordingMoveDelegate delegate = new RecordingMoveDelegate(t -> false);
+    delegate.performMove(new MoveDescription(List.of(), new Route(germany, poland)));
+    final List<RecordingMoveDelegate.CapturedMove> snapshot = delegate.captured();
+    // Subsequent calls return new snapshots — snapshot doesn't grow
+    delegate.performMove(new MoveDescription(List.of(), new Route(germany, ukraine)));
+    assertEquals(1, snapshot.size(), "captured() snapshot must not reflect later additions");
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
@@ -178,9 +178,9 @@ class DecisionHandlerTest {
 
   @Test
   void offensiveKinds_return501() throws Exception {
-    // purchase is now wired to PurchaseExecutor (returns 200); only remaining offensive
-    // kinds that are still unimplemented return 501.
-    for (final String kind : new String[] {"combat-move", "noncombat-move", "place"}) {
+    // purchase and combat-move are now wired to real executors (return 200); only the remaining
+    // offensive kinds that are still unimplemented return 501.
+    for (final String kind : new String[] {"noncombat-move", "place"}) {
       final SessionRegistry registry = newRegistry();
       final Session s = newSession(registry);
       final DecisionHandler h =

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerWireFormatTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerWireFormatTest.java
@@ -16,6 +16,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
 import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.dto.CombatMoveOrder;
+import org.triplea.ai.sidecar.dto.CombatMovePlan;
+import org.triplea.ai.sidecar.dto.CombatMoveRequest;
 import org.triplea.ai.sidecar.dto.PurchaseOrder;
 import org.triplea.ai.sidecar.dto.PurchasePlan;
 import org.triplea.ai.sidecar.dto.PurchaseRequest;
@@ -259,8 +262,32 @@ class DecisionHandlerWireFormatTest {
   // ---------------------------------------------------------------------
 
   @Test
-  void combatMove_501_wireShape() throws Exception {
-    assertOffensive501Shape("combat-move");
+  void combatMove_success_wireShape() throws Exception {
+    // combat-move is now wired to CombatMoveExecutor; verify it returns 200 + ready envelope
+    final SessionRegistry registry = newRegistry();
+    final Session s = newSession(registry);
+    final CombatMovePlan fixedPlan = new CombatMovePlan(
+        List.of(new CombatMoveOrder(List.of("unit-1"), "Germany", "Poland")),
+        List.of());
+
+    final DecisionHandler h = new DecisionHandler(
+        registry,
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> fixedPlan);
+
+    final FakeHttpExchange ex = new FakeHttpExchange(
+        "POST", "/session/" + s.sessionId() + "/decision", offensiveBody("combat-move"));
+    h.handle(ex);
+
+    assertEquals(200, ex.responseCode(), "combat-move must return 200");
+    final JsonNode root = responseJson(ex);
+    assertEquals("ready", root.path("status").asText());
+    assertEquals("combat-move", root.path("plan").path("kind").asText());
+    assertTrue(root.path("plan").has("moves"), "plan must have 'moves'");
+    assertTrue(root.path("plan").has("sbrMoves"), "plan must have 'sbrMoves'");
   }
 
   @Test

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -288,6 +288,26 @@ public abstract class AbstractProAi extends AbstractAi {
   }
 
   /**
+   * Public bridge to the {@code protected} {@link #move} entry point for the AI sidecar's
+   * combat-move phase.
+   *
+   * <p>The sidecar's {@code CombatMoveExecutor} lives in a separate package and therefore cannot
+   * invoke {@link #move} directly. This method is a thin delegation with no additional behaviour —
+   * keep it that way. All combat-move logic belongs in {@link #move}.
+   *
+   * <p>When {@code storedCombatMoveMap} has been restored from a {@link
+   * games.strategy.triplea.ai.pro.data.ProSessionSnapshot} before this call, {@link #move} routes
+   * to {@code ProCombatMoveAi#doMove(storedCombatMoveMap, delegate, data, player)} and clears the
+   * stored map — exactly the same path taken in a normal in-process turn.
+   */
+  public void invokeCombatMoveForSidecar(
+      final games.strategy.triplea.delegate.remote.IMoveDelegate delegate,
+      final GameData data,
+      final GamePlayer player) {
+    move(/* nonCombat= */ false, delegate, data, player);
+  }
+
+  /**
    * Projects the three stored ProAi maps into a {@link ProSessionSnapshot} for persistence across
    * HTTP request boundaries.
    *
@@ -412,6 +432,15 @@ public abstract class AbstractProAi extends AbstractAi {
     if (storedPurchaseTerritories == null && !snap.purchaseTerritories().isEmpty()) {
       storedPurchaseTerritories = restorePurchaseMap(snap.purchaseTerritories(), data);
     }
+  }
+
+  /**
+   * Returns {@code true} if {@code storedCombatMoveMap} has not been populated yet (either by a
+   * purchase-phase think or by {@link #restoreCombatMoveMapFromSnapshot}). Used by
+   * {@code CombatMoveExecutor} as a belt-and-suspenders guard before dispatching.
+   */
+  public boolean storedCombatMoveMapIsNull() {
+    return storedCombatMoveMap == null;
   }
 
   private static Map<Territory, ProTerritory> restoreTerritoryMap(


### PR DESCRIPTION
## Summary

Closes map-room/map-room#1764

Implements the combat-move executor for the Java AI sidecar. When the TS side dispatches a `combat-move` decision, the sidecar now drives ProAI instead of returning 501.

### What changed

**Java (triplea fork)**
- `RecordingMoveDelegate` — `IMoveDelegate` stub that captures every `MoveDescription` with a bombing tag sampled via `ProAi.shouldBomberBomb()`. Batch 4 of `doMove()` (the `calculateBombingRoutes` call) sets `isBombing=true`; batches 1–3 are `false`. Package-private `Predicate<Territory>` constructor for unit testing.
- `invokeCombatMoveForSidecar` bridge on `AbstractProAi` — delegates to `move(false, ...)`. When `storedCombatMoveMap != null` (restored from snapshot), routes to `combatMoveAi.doMove(storedCombatMoveMap, ...)` and clears it.
- `storedCombatMoveMapIsNull()` guard accessor.
- `CombatMoveRequest` / `CombatMovePlan` / `CombatMoveOrder` DTOs.
- `CombatMoveExecutor` — enforces ordering contract: `restoreUnitIdMap` → `WireStateApplier.apply` → `restoreCombatMoveMapFromSnapshot` → `invokeCombatMoveForSidecar`. Projects captures to wire shape using UUID→wireId reverse map.
- `DecisionHandler` — routes `combat-move` to `CombatMoveExecutor`; removes it from the 501 catch-all.

**Tests**
- `RecordingMoveDelegateTest` — capture order, SBR partition, snapshot immutability.
- `CombatMoveExecutorIntegrationTest` — purchase then combat-move on same session; asserts non-empty moves for Germans turn 1.
- `staleCombatMoveMapTransportUuidIsDroppedSilently` — stale transport UUID doesn't throw and is dropped cleanly.

**No TS changes** — existing dispatch from #1760 already handles `{moves, sbrMoves}`.

## Test plan

- [x] All 159 sidecar tests pass
- [x] Docker build succeeds
- [x] `CombatMoveExecutorIntegrationTest` — real ProAI round-trip
- [x] `RecordingMoveDelegateTest` — SBR partition verified
- [x] Stale transport resilience
- [ ] 🧑 Manual: play through Germans turn 1 with `:phase3` image — verify combat moves execute in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)