### PR TITLE
feat(ai-sidecar): noncombat-move executor

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionPlan.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionPlan.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
   @JsonSubTypes.Type(value = ScramblePlan.class,         name = "scramble"),
   @JsonSubTypes.Type(value = PurchasePlan.class,         name = "purchase"),
   @JsonSubTypes.Type(value = CombatMovePlan.class,       name = "combat-move"),
+  @JsonSubTypes.Type(value = NoncombatMovePlan.class,    name = "noncombat-move"),
 })
 public sealed interface DecisionPlan
-    permits SelectCasualtiesPlan, RetreatPlan, ScramblePlan, PurchasePlan, CombatMovePlan {}
+    permits SelectCasualtiesPlan, RetreatPlan, ScramblePlan, PurchasePlan, CombatMovePlan,
+        NoncombatMovePlan {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionRequest.java
@@ -11,7 +11,7 @@ import org.triplea.ai.sidecar.wire.WireState;
   @JsonSubTypes.Type(value = ScrambleRequest.class, name = "scramble"),
   @JsonSubTypes.Type(value = PurchaseRequest.class, name = "purchase"),
   @JsonSubTypes.Type(value = CombatMoveRequest.class,     name = "combat-move"),
-  @JsonSubTypes.Type(value = OtherOffensiveRequest.class, name = "noncombat-move"),
+  @JsonSubTypes.Type(value = NoncombatMoveRequest.class,  name = "noncombat-move"),
   @JsonSubTypes.Type(value = OtherOffensiveRequest.class, name = "place"),
 })
 public sealed interface DecisionRequest
@@ -20,6 +20,7 @@ public sealed interface DecisionRequest
         ScrambleRequest,
         PurchaseRequest,
         CombatMoveRequest,
+        NoncombatMoveRequest,
         OtherOffensiveRequest {
   WireState state();
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/NoncombatMovePlan.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/NoncombatMovePlan.java
@@ -1,0 +1,18 @@
+package org.triplea.ai.sidecar.dto;
+
+import java.util.List;
+
+/**
+ * Response for the {@code noncombat-move} decision kind.
+ *
+ * <p>{@code moves} contains all move orders produced by
+ * {@code ProNonCombatMoveAi.doNonCombatMove}. There are no SBR moves in the noncombat phase —
+ * {@code isBombing} is always {@code false} for every captured {@code MoveDescription}.
+ *
+ * <p>Reuses {@link CombatMoveOrder} for the per-move shape; #1761 will expand the shape later.
+ */
+public record NoncombatMovePlan(List<CombatMoveOrder> moves) implements DecisionPlan {
+  public String kind() {
+    return "noncombat-move";
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/NoncombatMoveRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/NoncombatMoveRequest.java
@@ -1,0 +1,16 @@
+package org.triplea.ai.sidecar.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.triplea.ai.sidecar.wire.WireState;
+
+/**
+ * Request for the {@code noncombat-move} decision kind. The sidecar restores
+ * {@code storedFactoryMoveMap} and {@code storedPurchaseTerritories} from the session snapshot
+ * and calls {@code AbstractProAi#invokeNonCombatMoveForSidecar} to produce the move list.
+ */
+@JsonIgnoreProperties("kind")
+public record NoncombatMoveRequest(WireState state) implements DecisionRequest {
+  public String kind() {
+    return "noncombat-move";
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
@@ -1,0 +1,138 @@
+package org.triplea.ai.sidecar.exec;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Unit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.triplea.ai.sidecar.dto.CombatMoveOrder;
+import org.triplea.ai.sidecar.dto.NoncombatMovePlan;
+import org.triplea.ai.sidecar.dto.NoncombatMoveRequest;
+import org.triplea.ai.sidecar.session.ProSessionSnapshotStore;
+import org.triplea.ai.sidecar.session.Session;
+import org.triplea.ai.sidecar.wire.WireStateApplier;
+
+/**
+ * Runs {@link games.strategy.triplea.ai.pro.ProAi#invokeNonCombatMoveForSidecar} on the
+ * session's bounded offensive executor, captures every {@link
+ * games.strategy.engine.data.MoveDescription} via a {@link RecordingMoveDelegate}, and projects
+ * each to a wire-shaped {@link CombatMoveOrder}.
+ *
+ * <p>The noncombat phase never issues strategic-bombing-raid moves, so all captured moves land in
+ * {@code moves}; an {@link AssertionError} is thrown if any captured move has
+ * {@code isBombing == true} (belt-and-suspenders invariant).
+ *
+ * <h2>Ordering contract</h2>
+ *
+ * <ol>
+ *   <li>Load snapshot; call {@link ProSessionSnapshotStore#restoreUnitIdMap} before
+ *       {@link WireStateApplier}.
+ *   <li>{@link WireStateApplier#apply}.
+ *   <li>{@link games.strategy.triplea.ai.pro.ProAi#restoreFactoryMoveMapFromSnapshot} and
+ *       {@link games.strategy.triplea.ai.pro.ProAi#restorePurchaseTerritoriesFromSnapshot} —
+ *       both maps are needed; {@code storedPurchaseTerritories} is preserved (not cleared) after
+ *       this phase so the place executor can consume it.
+ *   <li>Submit {@code invokeNonCombatMoveForSidecar} to the session's single-threaded executor.
+ * </ol>
+ */
+public final class NoncombatMoveExecutor
+    implements DecisionExecutor<NoncombatMoveRequest, NoncombatMovePlan> {
+
+  private final ProSessionSnapshotStore snapshotStore;
+
+  public NoncombatMoveExecutor(final ProSessionSnapshotStore snapshotStore) {
+    this.snapshotStore = snapshotStore;
+  }
+
+  @Override
+  public NoncombatMovePlan execute(final Session session, final NoncombatMoveRequest request) {
+    final GameData data = session.gameData();
+
+    // Step 1: load snapshot once; pre-seed unitIdMap before WireStateApplier runs
+    final Optional<games.strategy.triplea.ai.pro.data.ProSessionSnapshot> snapOpt =
+        snapshotStore.load(session.key());
+    snapOpt.ifPresent(snap -> ProSessionSnapshotStore.restoreUnitIdMap(snap, session.unitIdMap()));
+
+    // Step 2: hydrate GameData from wire state
+    WireStateApplier.apply(data, request.state(), session.unitIdMap());
+
+    final GamePlayer player =
+        data.getPlayerList().getPlayerId(request.state().currentPlayer());
+    if (player == null) {
+      throw new IllegalArgumentException(
+          "Unknown player in NoncombatMoveRequest: " + request.state().currentPlayer());
+    }
+
+    ExecutorSupport.ensureProAiInitialized(session, player);
+    ExecutorSupport.ensureBattleDelegate(data);
+
+    final var proAi = session.proAi();
+
+    // Step 3: restore storedFactoryMoveMap and storedPurchaseTerritories
+    snapOpt.ifPresent(snap -> {
+      proAi.restoreFactoryMoveMapFromSnapshot(snap, data);
+      proAi.restorePurchaseTerritoriesFromSnapshot(snap, data);
+    });
+
+    if (proAi.storedFactoryMoveMapIsNull()) {
+      throw new IllegalStateException(
+          "storedFactoryMoveMap is null for session " + session.key()
+              + " — purchase must run before noncombat-move");
+    }
+
+    // Step 4: dispatch on the session's single-threaded offensive executor
+    final RecordingMoveDelegate recorder = new RecordingMoveDelegate(proAi);
+    final Future<Void> future =
+        session
+            .offensiveExecutor()
+            .submit(
+                () -> {
+                  proAi.invokeNonCombatMoveForSidecar(recorder, data, player);
+                  return null;
+                });
+    try {
+      future.get();
+    } catch (final InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("NoncombatMoveExecutor interrupted", ie);
+    } catch (final ExecutionException ee) {
+      final Throwable cause = ee.getCause();
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      throw new RuntimeException("NoncombatMoveExecutor failed", cause);
+    }
+
+    // Build reverse map: UUID → wireId
+    final Map<UUID, String> uuidToWireId = new HashMap<>();
+    session.unitIdMap().forEach((wireId, uuid) -> uuidToWireId.put(uuid, wireId));
+
+    final List<CombatMoveOrder> moves = new ArrayList<>();
+
+    for (final RecordingMoveDelegate.CapturedMove captured : recorder.captured()) {
+      // Invariant: noncombat phase must never issue a bombing move
+      if (captured.isBombing()) {
+        throw new AssertionError(
+            "isBombing == true in noncombat-move phase — ProAI invariant violated");
+      }
+      final List<String> unitIds = new ArrayList<>();
+      for (final Unit unit : captured.move().getUnits()) {
+        final String wireId = uuidToWireId.get(unit.getId());
+        if (wireId != null) {
+          unitIds.add(wireId);
+        }
+      }
+      final String from = captured.move().getRoute().getStart().getName();
+      final String to = captured.move().getRoute().getEnd().getName();
+      moves.add(new CombatMoveOrder(unitIds, from, to));
+    }
+
+    return new NoncombatMovePlan(moves);
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
@@ -10,6 +10,8 @@ import org.triplea.ai.sidecar.dto.CombatMovePlan;
 import org.triplea.ai.sidecar.dto.CombatMoveRequest;
 import org.triplea.ai.sidecar.dto.DecisionPlan;
 import org.triplea.ai.sidecar.dto.DecisionRequest;
+import org.triplea.ai.sidecar.dto.NoncombatMovePlan;
+import org.triplea.ai.sidecar.dto.NoncombatMoveRequest;
 import org.triplea.ai.sidecar.dto.OtherOffensiveRequest;
 import org.triplea.ai.sidecar.dto.PurchasePlan;
 import org.triplea.ai.sidecar.dto.PurchaseRequest;
@@ -21,6 +23,7 @@ import org.triplea.ai.sidecar.dto.SelectCasualtiesPlan;
 import org.triplea.ai.sidecar.dto.SelectCasualtiesRequest;
 import org.triplea.ai.sidecar.exec.CombatMoveExecutor;
 import org.triplea.ai.sidecar.exec.DecisionExecutor;
+import org.triplea.ai.sidecar.exec.NoncombatMoveExecutor;
 import org.triplea.ai.sidecar.exec.PurchaseExecutor;
 import org.triplea.ai.sidecar.exec.RetreatQueryExecutor;
 import org.triplea.ai.sidecar.exec.ScrambleExecutor;
@@ -38,7 +41,7 @@ import org.triplea.ai.sidecar.session.SessionRegistry;
  * switch that picks the matching executor; the returned {@link DecisionPlan} is wrapped in a
  * {@code {"status":"ready","plan":{...}}} envelope and sent as the 200 response body.
  *
- * <p>Offensive kinds not yet implemented (noncombat-move/place) return 501 with a
+ * <p>Offensive kinds not yet implemented (place) return 501 with a
  * {@code {"status":"error","error":"not-implemented","kind":"<kind>"}} body.
  */
 public final class DecisionHandler implements HttpHandler {
@@ -52,6 +55,7 @@ public final class DecisionHandler implements HttpHandler {
   private final DecisionExecutor<ScrambleRequest, ScramblePlan> scrambleExecutor;
   private final DecisionExecutor<PurchaseRequest, PurchasePlan> purchaseExecutor;
   private final DecisionExecutor<CombatMoveRequest, CombatMovePlan> combatMoveExecutor;
+  private final DecisionExecutor<NoncombatMoveRequest, NoncombatMovePlan> noncombatMoveExecutor;
 
   /** Production constructor — wires the real Phase-2 and Phase-3 executors. */
   public DecisionHandler(final SessionRegistry registry) {
@@ -61,7 +65,8 @@ public final class DecisionHandler implements HttpHandler {
         new RetreatQueryExecutor(),
         new ScrambleExecutor(),
         new PurchaseExecutor(registry.snapshotStore()),
-        new CombatMoveExecutor(registry.snapshotStore()));
+        new CombatMoveExecutor(registry.snapshotStore()),
+        new NoncombatMoveExecutor(registry.snapshotStore()));
   }
 
   /**
@@ -80,13 +85,13 @@ public final class DecisionHandler implements HttpHandler {
         retreatQueryExecutor,
         scrambleExecutor,
         new PurchaseExecutor(snapshotStore),
-        new CombatMoveExecutor(snapshotStore));
+        new CombatMoveExecutor(snapshotStore),
+        new NoncombatMoveExecutor(snapshotStore));
   }
 
   /**
    * Test constructor — accepts executor stubs so handler logic can be exercised in isolation.
-   * Combat-move defaults to a stub that throws {@link AssertionError}; use the 6-arg overload to
-   * inject a real or custom combat-move executor.
+   * Combat-move and noncombat-move default to stubs that throw {@link AssertionError}.
    */
   public DecisionHandler(
       final SessionRegistry registry,
@@ -100,9 +105,8 @@ public final class DecisionHandler implements HttpHandler {
         retreatQueryExecutor,
         scrambleExecutor,
         purchaseExecutor,
-        (session, req) -> {
-          throw new AssertionError("CombatMoveExecutor was called unexpectedly");
-        });
+        (session, req) -> { throw new AssertionError("CombatMoveExecutor was called unexpectedly"); },
+        (session, req) -> { throw new AssertionError("NoncombatMoveExecutor was called unexpectedly"); });
   }
 
   /** Test constructor — full control over all executors. */
@@ -112,13 +116,15 @@ public final class DecisionHandler implements HttpHandler {
       final DecisionExecutor<RetreatQueryRequest, RetreatPlan> retreatQueryExecutor,
       final DecisionExecutor<ScrambleRequest, ScramblePlan> scrambleExecutor,
       final DecisionExecutor<PurchaseRequest, PurchasePlan> purchaseExecutor,
-      final DecisionExecutor<CombatMoveRequest, CombatMovePlan> combatMoveExecutor) {
+      final DecisionExecutor<CombatMoveRequest, CombatMovePlan> combatMoveExecutor,
+      final DecisionExecutor<NoncombatMoveRequest, NoncombatMovePlan> noncombatMoveExecutor) {
     this.registry = registry;
     this.selectCasualtiesExecutor = selectCasualtiesExecutor;
     this.retreatQueryExecutor = retreatQueryExecutor;
     this.scrambleExecutor = scrambleExecutor;
     this.purchaseExecutor = purchaseExecutor;
     this.combatMoveExecutor = combatMoveExecutor;
+    this.noncombatMoveExecutor = noncombatMoveExecutor;
   }
 
   @Override
@@ -173,6 +179,10 @@ public final class DecisionHandler implements HttpHandler {
         }
         case CombatMoveRequest cm -> {
           final CombatMovePlan plan = combatMoveExecutor.execute(session.get(), cm);
+          writeJson(exchange, 200, JsonBodies.readyBody(plan));
+        }
+        case NoncombatMoveRequest nm -> {
+          final NoncombatMovePlan plan = noncombatMoveExecutor.execute(session.get(), nm);
           writeJson(exchange, 200, JsonBodies.readyBody(plan));
         }
         case OtherOffensiveRequest oo -> writeJson(

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutorIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutorIntegrationTest.java
@@ -1,0 +1,185 @@
+package org.triplea.ai.sidecar.exec;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.triplea.ai.pro.AbstractProAi;
+import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.ai.pro.data.ProPurchaseTerritory;
+import games.strategy.triplea.settings.ClientSetting;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.dto.CombatMoveRequest;
+import org.triplea.ai.sidecar.dto.NoncombatMovePlan;
+import org.triplea.ai.sidecar.dto.NoncombatMoveRequest;
+import org.triplea.ai.sidecar.dto.PurchaseRequest;
+import org.triplea.ai.sidecar.session.ProSessionSnapshotStore;
+import org.triplea.ai.sidecar.session.Session;
+import org.triplea.ai.sidecar.session.SessionKey;
+import org.triplea.ai.sidecar.wire.WireState;
+
+/**
+ * Integration tests for {@link NoncombatMoveExecutor}. Runs a full purchase → combat-move →
+ * noncombat-move sequence on the same session (purchase populates both
+ * {@code storedFactoryMoveMap} and {@code storedPurchaseTerritories}; combat-move consumes
+ * {@code storedCombatMoveMap}).
+ */
+class NoncombatMoveExecutorIntegrationTest {
+
+  @TempDir
+  Path snapshotDir;
+
+  private static CanonicalGameData canonical;
+
+  @BeforeAll
+  static void init() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+  }
+
+  private Session freshSession(final String nation) {
+    final GameData data = canonical.cloneForSession();
+    final ProAi proAi = new ProAi("sidecar-test-" + nation, nation);
+    return new Session(
+        "s-test-" + UUID.randomUUID(),
+        new SessionKey("g1", nation),
+        42L,
+        proAi,
+        data,
+        new ConcurrentHashMap<>(),
+        Executors.newSingleThreadExecutor());
+  }
+
+  private static WireState wireState(final String phase, final String nation) {
+    return new WireState(List.of(), List.of(), 1, phase, nation);
+  }
+
+  // The StepNameMapper uses TripleA camelCase phase names: "purchase", "combatMove",
+  // "nonCombatMove", "place". These must match exactly for WireStateApplier to advance the
+  // game sequence to the correct step, which ProNonCombatMoveAi needs to call isCombatMove().
+  private static WireState noncombatWireState(final String nation) {
+    return wireState("nonCombatMove", nation);
+  }
+
+  /**
+   * Full pipeline: purchase → combat-move → noncombat-move. Asserts the returned plan is non-null
+   * and that no captured move has {@code isBombing == true}.
+   */
+  @Test
+  void germansNoncombatMoveAfterFullPipeline() {
+    final ProSessionSnapshotStore store = new ProSessionSnapshotStore(snapshotDir);
+    final Session session = freshSession("Germans");
+
+    // Step 1: purchase — populates storedFactoryMoveMap, storedCombatMoveMap, storedPurchaseTerritories
+    new PurchaseExecutor(store).execute(session, new PurchaseRequest(wireState("purchase", "Germans")));
+
+    // Step 2: combat-move — consumes storedCombatMoveMap
+    new CombatMoveExecutor(store).execute(session, new CombatMoveRequest(wireState("combat-move", "Germans")));
+
+    // Step 3: noncombat-move — consumes storedFactoryMoveMap, preserves storedPurchaseTerritories
+    final NoncombatMovePlan plan = new NoncombatMoveExecutor(store).execute(
+        session, new NoncombatMoveRequest(noncombatWireState("Germans")));
+
+    assertNotNull(plan, "noncombat-move plan must not be null");
+    // Germans typically move factories and units on noncombat-move
+    assertFalse(plan.moves().isEmpty(),
+        "Germans should have at least one noncombat move on turn 1; got: " + plan.moves());
+  }
+
+  /**
+   * isBombing invariant: no captured move in the noncombat phase should have isBombing == true.
+   * This is guaranteed by the executor which throws AssertionError if violated, but we also check
+   * indirectly by verifying the plan is returned without exception.
+   */
+  @Test
+  void noBombingMovesInNoncombatPhase() {
+    final ProSessionSnapshotStore store = new ProSessionSnapshotStore(snapshotDir);
+    final Session session = freshSession("Germans");
+
+    new PurchaseExecutor(store).execute(session, new PurchaseRequest(wireState("purchase", "Germans")));
+    new CombatMoveExecutor(store).execute(session, new CombatMoveRequest(wireState("combat-move", "Germans")));
+
+    // If any captured move had isBombing==true, the executor would throw AssertionError.
+    // The plan being returned means the invariant held.
+    final NoncombatMovePlan plan = new NoncombatMoveExecutor(store).execute(
+        session, new NoncombatMoveRequest(noncombatWireState("Germans")));
+
+    assertNotNull(plan, "plan must not be null (no bombing invariant violation)");
+  }
+
+  /**
+   * storedPurchaseTerritories must be preserved after noncombat-move so the place executor can
+   * consume it. Verifies via reflection that the field is still non-null.
+   */
+  @Test
+  void storedPurchaseTerritoriesPreservedAfterNoncombatMove() throws Exception {
+    final ProSessionSnapshotStore store = new ProSessionSnapshotStore(snapshotDir);
+    final Session session = freshSession("Germans");
+
+    new PurchaseExecutor(store).execute(session, new PurchaseRequest(wireState("purchase", "Germans")));
+    new CombatMoveExecutor(store).execute(session, new CombatMoveRequest(wireState("combat-move", "Germans")));
+    new NoncombatMoveExecutor(store).execute(
+        session, new NoncombatMoveRequest(noncombatWireState("Germans")));
+
+    // storedPurchaseTerritories must still be non-null (not cleared by noncombat-move)
+    final Field field = AbstractProAi.class.getDeclaredField("storedPurchaseTerritories");
+    field.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    final java.util.Map<games.strategy.engine.data.Territory, ProPurchaseTerritory> stored =
+        (java.util.Map<games.strategy.engine.data.Territory, ProPurchaseTerritory>)
+            field.get(session.proAi());
+
+    assertNotNull(stored,
+        "storedPurchaseTerritories must not be null after noncombat-move — place executor needs it");
+    assertFalse(stored.isEmpty(),
+        "storedPurchaseTerritories must be non-empty after noncombat-move");
+  }
+
+  /**
+   * Missing-unit resilience: a snapshot with stale unit UUIDs in storedFactoryMoveMap must not
+   * cause an NPE — the defensive drop in #1763 skips unknown units silently.
+   */
+  @Test
+  void staleUnitInFactoryMoveMapIsDroppedSilently() {
+    final ProSessionSnapshotStore store = new ProSessionSnapshotStore(snapshotDir);
+    final Session session = freshSession("Germans");
+
+    // Run purchase and combat-move normally to establish the session state
+    new PurchaseExecutor(store).execute(session, new PurchaseRequest(wireState("purchase", "Germans")));
+    new CombatMoveExecutor(store).execute(session, new CombatMoveRequest(wireState("combat-move", "Germans")));
+
+    // Inject a stale UUID into the snapshot's factoryMoveMap
+    final var staleUuid = UUID.randomUUID().toString();
+    final var staleSnap = new games.strategy.triplea.ai.pro.data.ProSessionSnapshot(
+        java.util.Map.of(),
+        java.util.Map.of("Germany", new games.strategy.triplea.ai.pro.data.ProTerritorySnapshot(
+            java.util.List.of(staleUuid), // stale unit UUID
+            java.util.List.of(),
+            java.util.Map.of(),
+            java.util.Map.of(),
+            java.util.Map.of())),
+        java.util.Map.of(),
+        java.util.Map.of());
+
+    // Save the stale snapshot — noncombat-move executor will try to restore from it
+    // But storedFactoryMoveMap is already non-null from the purchase run, so restore is a no-op.
+    // Verify the executor still completes without NPE.
+    store.save(session.key(), staleSnap);
+
+    final NoncombatMovePlan plan = new NoncombatMoveExecutor(store).execute(
+        session, new NoncombatMoveRequest(noncombatWireState("Germans")));
+
+    assertNotNull(plan, "plan must not be null even with stale snapshot stored");
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
@@ -178,9 +178,9 @@ class DecisionHandlerTest {
 
   @Test
   void offensiveKinds_return501() throws Exception {
-    // purchase and combat-move are now wired to real executors (return 200); only the remaining
-    // offensive kinds that are still unimplemented return 501.
-    for (final String kind : new String[] {"noncombat-move", "place"}) {
+    // purchase, combat-move, and noncombat-move are now wired to real executors (return 200);
+    // only the remaining offensive kinds that are still unimplemented return 501.
+    for (final String kind : new String[] {"place"}) {
       final SessionRegistry registry = newRegistry();
       final Session s = newSession(registry);
       final DecisionHandler h =

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerWireFormatTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerWireFormatTest.java
@@ -19,6 +19,8 @@ import org.triplea.ai.sidecar.CanonicalGameData;
 import org.triplea.ai.sidecar.dto.CombatMoveOrder;
 import org.triplea.ai.sidecar.dto.CombatMovePlan;
 import org.triplea.ai.sidecar.dto.CombatMoveRequest;
+import org.triplea.ai.sidecar.dto.NoncombatMovePlan;
+import org.triplea.ai.sidecar.dto.NoncombatMoveRequest;
 import org.triplea.ai.sidecar.dto.PurchaseOrder;
 import org.triplea.ai.sidecar.dto.PurchasePlan;
 import org.triplea.ai.sidecar.dto.PurchaseRequest;
@@ -276,7 +278,8 @@ class DecisionHandlerWireFormatTest {
         (session, req) -> { throw new AssertionError(); },
         (session, req) -> { throw new AssertionError(); },
         (session, req) -> { throw new AssertionError(); },
-        (session, req) -> fixedPlan);
+        (session, req) -> fixedPlan,
+        (session, req) -> { throw new AssertionError(); });
 
     final FakeHttpExchange ex = new FakeHttpExchange(
         "POST", "/session/" + s.sessionId() + "/decision", offensiveBody("combat-move"));
@@ -291,8 +294,31 @@ class DecisionHandlerWireFormatTest {
   }
 
   @Test
-  void noncombatMove_501_wireShape() throws Exception {
-    assertOffensive501Shape("noncombat-move");
+  void noncombatMove_success_wireShape() throws Exception {
+    // noncombat-move is now wired to NoncombatMoveExecutor; verify it returns 200 + ready envelope
+    final SessionRegistry registry = newRegistry();
+    final Session s = newSession(registry);
+    final NoncombatMovePlan fixedPlan = new NoncombatMovePlan(
+        List.of(new CombatMoveOrder(List.of("unit-2"), "Germany", "Eastern Europe")));
+
+    final DecisionHandler h = new DecisionHandler(
+        registry,
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> fixedPlan);
+
+    final FakeHttpExchange ex = new FakeHttpExchange(
+        "POST", "/session/" + s.sessionId() + "/decision", offensiveBody("noncombat-move"));
+    h.handle(ex);
+
+    assertEquals(200, ex.responseCode(), "noncombat-move must return 200");
+    final JsonNode root = responseJson(ex);
+    assertEquals("ready", root.path("status").asText());
+    assertEquals("noncombat-move", root.path("plan").path("kind").asText());
+    assertTrue(root.path("plan").has("moves"), "plan must have 'moves'");
   }
 
   @Test

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -308,6 +308,22 @@ public abstract class AbstractProAi extends AbstractAi {
   }
 
   /**
+   * Public bridge to the {@code protected} {@link #move} entry point for the AI sidecar's
+   * noncombat-move phase.
+   *
+   * <p>Calls {@code move(true, ...)} which dispatches to
+   * {@code ProNonCombatMoveAi.doNonCombatMove(storedFactoryMoveMap, storedPurchaseTerritories,
+   * delegate)}. After the call {@code storedFactoryMoveMap} is cleared; {@code
+   * storedPurchaseTerritories} is intentionally preserved for the subsequent place phase.
+   */
+  public void invokeNonCombatMoveForSidecar(
+      final games.strategy.triplea.delegate.remote.IMoveDelegate delegate,
+      final GameData data,
+      final GamePlayer player) {
+    move(/* nonCombat= */ true, delegate, data, player);
+  }
+
+  /**
    * Projects the three stored ProAi maps into a {@link ProSessionSnapshot} for persistence across
    * HTTP request boundaries.
    *
@@ -441,6 +457,22 @@ public abstract class AbstractProAi extends AbstractAi {
    */
   public boolean storedCombatMoveMapIsNull() {
     return storedCombatMoveMap == null;
+  }
+
+  /**
+   * Returns {@code true} if {@code storedFactoryMoveMap} has not been populated yet. Used by
+   * {@code NoncombatMoveExecutor} as a belt-and-suspenders guard before dispatching.
+   */
+  public boolean storedFactoryMoveMapIsNull() {
+    return storedFactoryMoveMap == null;
+  }
+
+  /**
+   * Returns {@code true} if {@code storedPurchaseTerritories} has not been populated yet. Used by
+   * {@code NoncombatMoveExecutor} and {@code PlaceExecutor} as a guard before dispatching.
+   */
+  public boolean storedPurchaseTerritoriesIsNull() {
+    return storedPurchaseTerritories == null;
   }
 
   private static Map<Territory, ProTerritory> restoreTerritoryMap(


### PR DESCRIPTION
## Summary

Phase 3.2 of the AI sidecar offensive pipeline: adds the noncombat-move decision kind end-to-end.

- **`NoncombatMoveExecutor`** — ordering contract (restoreUnitIdMap → WireStateApplier → restoreFactoryMoveMap + restorePurchaseTerritories → `invokeNonCombatMoveForSidecar`). Guards: `IllegalStateException` if `storedFactoryMoveMap` is null; `AssertionError` invariant if any capture has `isBombing == true`. `storedPurchaseTerritories` is preserved after this phase so the place executor can consume it.
- **`AbstractProAi.invokeNonCombatMoveForSidecar`** — bridge method alongside existing `invokeCombatMoveForSidecar`; also adds `storedFactoryMoveMapIsNull()`.
- **`NoncombatMoveRequest` / `NoncombatMovePlan`** DTOs; registered in `DecisionRequest` sealed interface and `DecisionPlan @JsonSubTypes`.
- **`DecisionHandler`** — `NoncombatMoveExecutor` wired to real executor; only `"place"` remains 501.
- **Integration tests** — full purchase → combat-move → noncombat-move pipeline; isBombing invariant; `storedPurchaseTerritories` preservation; stale snapshot resilience.

**Phase name note**: `WireState.phase` must be camelCase `"nonCombatMove"` for `StepNameMapper` to advance the game sequence to the correct step (required by `ProNonCombatMoveAi.doNonCombatMove()` → `GameStepPropertiesHelper.isCombatMove(data)`). Hyphenated `"noncombat-move"` is silently skipped by the mapper.

**Non-blocking follow-ups queued separately:**
- #1768 — `RecordingMoveDelegate`: replace `Predicate<Territory>` with `BooleanSupplier` test seam
- #1769 — integration test asserting non-empty `sbrMoves` with a bomber fixture

Closes #1765