### PR TITLE
feat(ai-sidecar): place executor + RecordingPlaceDelegate

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionPlan.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionPlan.java
@@ -11,7 +11,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
   @JsonSubTypes.Type(value = PurchasePlan.class,         name = "purchase"),
   @JsonSubTypes.Type(value = CombatMovePlan.class,       name = "combat-move"),
   @JsonSubTypes.Type(value = NoncombatMovePlan.class,    name = "noncombat-move"),
+  @JsonSubTypes.Type(value = PlacePlan.class,            name = "place"),
 })
 public sealed interface DecisionPlan
     permits SelectCasualtiesPlan, RetreatPlan, ScramblePlan, PurchasePlan, CombatMovePlan,
-        NoncombatMovePlan {}
+        NoncombatMovePlan, PlacePlan {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/DecisionRequest.java
@@ -12,7 +12,7 @@ import org.triplea.ai.sidecar.wire.WireState;
   @JsonSubTypes.Type(value = PurchaseRequest.class, name = "purchase"),
   @JsonSubTypes.Type(value = CombatMoveRequest.class,     name = "combat-move"),
   @JsonSubTypes.Type(value = NoncombatMoveRequest.class,  name = "noncombat-move"),
-  @JsonSubTypes.Type(value = OtherOffensiveRequest.class, name = "place"),
+  @JsonSubTypes.Type(value = PlaceRequest.class,          name = "place"),
 })
 public sealed interface DecisionRequest
     permits SelectCasualtiesRequest,
@@ -21,6 +21,7 @@ public sealed interface DecisionRequest
         PurchaseRequest,
         CombatMoveRequest,
         NoncombatMoveRequest,
+        PlaceRequest,
         OtherOffensiveRequest {
   WireState state();
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PlaceOrder.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PlaceOrder.java
@@ -1,0 +1,11 @@
+package org.triplea.ai.sidecar.dto;
+
+import java.util.List;
+
+/**
+ * A single placement instruction: place the given unit types in the given territory.
+ *
+ * <p>Unit types are strings (e.g. {@code "infantry"}, {@code "armour"}) — one entry per unit,
+ * matching the TripleA {@link games.strategy.engine.data.UnitType#getName()} of each placed unit.
+ */
+public record PlaceOrder(String territoryName, List<String> unitTypes) {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PlacePlan.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PlacePlan.java
@@ -1,0 +1,15 @@
+package org.triplea.ai.sidecar.dto;
+
+import java.util.List;
+
+/**
+ * Response for the {@code place} decision kind.
+ *
+ * <p>{@code placements} is ordered land-first then sea-first, matching the iteration order of
+ * {@code ProPurchaseAi.place()}: land territories are processed before sea territories.
+ */
+public record PlacePlan(List<PlaceOrder> placements) implements DecisionPlan {
+  public String kind() {
+    return "place";
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PlaceRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PlaceRequest.java
@@ -1,0 +1,16 @@
+package org.triplea.ai.sidecar.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.triplea.ai.sidecar.wire.WireState;
+
+/**
+ * Request for the {@code place} decision kind. The sidecar restores
+ * {@code storedPurchaseTerritories} from the session snapshot and calls
+ * {@code AbstractProAi#invokePlaceForSidecar} to produce the placement list.
+ */
+@JsonIgnoreProperties("kind")
+public record PlaceRequest(WireState state) implements DecisionRequest {
+  public String kind() {
+    return "place";
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PlaceExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PlaceExecutor.java
@@ -1,0 +1,145 @@
+package org.triplea.ai.sidecar.exec;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Unit;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.triplea.ai.sidecar.dto.PlaceOrder;
+import org.triplea.ai.sidecar.dto.PlacePlan;
+import org.triplea.ai.sidecar.dto.PlaceRequest;
+import org.triplea.ai.sidecar.session.ProSessionSnapshotStore;
+import org.triplea.ai.sidecar.session.Session;
+import org.triplea.ai.sidecar.wire.WireStateApplier;
+
+/**
+ * Runs {@link games.strategy.triplea.ai.pro.ProAi#invokePlaceForSidecar} on the session's bounded
+ * offensive executor, captures every {@link
+ * games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate#placeUnits} call via a {@link
+ * RecordingPlaceDelegate}, and groups the captures by territory into a {@link PlacePlan}.
+ *
+ * <h2>Ordering contract</h2>
+ *
+ * <ol>
+ *   <li>Load snapshot; call {@link ProSessionSnapshotStore#restoreUnitIdMap} before
+ *       {@link WireStateApplier}.
+ *   <li>{@link WireStateApplier#apply}.
+ *   <li>{@link games.strategy.triplea.ai.pro.ProAi#restorePurchaseTerritoriesFromSnapshot} —
+ *       re-populates {@code storedPurchaseTerritories} when crossing an HTTP boundary.
+ *   <li>Guard: {@code storedPurchaseTerritories} must be non-null at dispatch time (it is either
+ *       carried in-memory from the purchase phase, or just restored from snapshot).
+ *   <li>Submit {@code invokePlaceForSidecar} to the session's single-threaded executor.
+ * </ol>
+ *
+ * <h2>Type-mismatch silent no-op</h2>
+ *
+ * <p>{@code ProPurchaseAi.place()} resolves each {@code placeUnit} in
+ * {@code storedPurchaseTerritories} by scanning {@code player.getUnitCollection()} for a unit with
+ * a matching type. If no match is found (e.g., the session's {@link GameData} was deserialized
+ * without the purchased units in the player's collection), the inner loop emits an empty list and
+ * {@code doPlace()} is called with zero units. This is faithful to the reference algorithm: no
+ * exception is thrown, but a WARNING is logged when the total captured unit count is smaller than
+ * the count stored in {@code storedPurchaseTerritories}.
+ */
+public final class PlaceExecutor implements DecisionExecutor<PlaceRequest, PlacePlan> {
+
+  private static final System.Logger LOG = System.getLogger(PlaceExecutor.class.getName());
+
+  private final ProSessionSnapshotStore snapshotStore;
+
+  public PlaceExecutor(final ProSessionSnapshotStore snapshotStore) {
+    this.snapshotStore = snapshotStore;
+  }
+
+  @Override
+  public PlacePlan execute(final Session session, final PlaceRequest request) {
+    final GameData data = session.gameData();
+
+    // Step 1: load snapshot once; pre-seed unitIdMap before WireStateApplier runs
+    final Optional<games.strategy.triplea.ai.pro.data.ProSessionSnapshot> snapOpt =
+        snapshotStore.load(session.key());
+    snapOpt.ifPresent(snap -> ProSessionSnapshotStore.restoreUnitIdMap(snap, session.unitIdMap()));
+
+    // Step 2: hydrate GameData from wire state
+    WireStateApplier.apply(data, request.state(), session.unitIdMap());
+
+    final GamePlayer player =
+        data.getPlayerList().getPlayerId(request.state().currentPlayer());
+    if (player == null) {
+      throw new IllegalArgumentException(
+          "Unknown player in PlaceRequest: " + request.state().currentPlayer());
+    }
+
+    ExecutorSupport.ensureProAiInitialized(session, player);
+    ExecutorSupport.ensureBattleDelegate(data);
+
+    final var proAi = session.proAi();
+
+    // Step 3: restore storedPurchaseTerritories from snapshot (no-op if already populated)
+    snapOpt.ifPresent(snap -> proAi.restorePurchaseTerritoriesFromSnapshot(snap, data));
+
+    // Guard: storedPurchaseTerritories must be non-null — purchase must have run first
+    if (proAi.storedPurchaseTerritoriesIsNull()) {
+      throw new IllegalStateException(
+          "place called without preceding purchase in this session lifecycle"
+              + " — check restore path and dispatch order");
+    }
+
+    // Step 4: dispatch on the session's single-threaded offensive executor
+    final RecordingPlaceDelegate recorder = new RecordingPlaceDelegate();
+    final Future<Void> future =
+        session
+            .offensiveExecutor()
+            .submit(
+                () -> {
+                  proAi.invokePlaceForSidecar(recorder, data, player);
+                  return null;
+                });
+    try {
+      future.get();
+    } catch (final InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("PlaceExecutor interrupted", ie);
+    } catch (final ExecutionException ee) {
+      final Throwable cause = ee.getCause();
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      throw new RuntimeException("PlaceExecutor failed", cause);
+    }
+
+    // Group captures by territory name (land-first order is preserved because ProPurchaseAi
+    // iterates land territories before sea territories).
+    final Map<String, List<String>> byTerritory = new LinkedHashMap<>();
+    int totalCaptured = 0;
+    for (final RecordingPlaceDelegate.PlaceCapture cap : recorder.captured()) {
+      final String tName = cap.territory().getName();
+      final List<String> types = byTerritory.computeIfAbsent(tName, k -> new ArrayList<>());
+      for (final Unit unit : cap.units()) {
+        types.add(unit.getType().getName());
+        totalCaptured++;
+      }
+    }
+
+    if (totalCaptured == 0 && !recorder.captured().isEmpty()) {
+      // Captures exist but all had empty unit lists — type-mismatch no-op path
+      LOG.log(System.Logger.Level.WARNING,
+          "PlaceExecutor: all placeUnits calls returned empty unit lists for session "
+              + session.key() + " — player.getUnitCollection() likely missing purchased units");
+    }
+
+    final List<PlaceOrder> placements = new ArrayList<>();
+    for (final Map.Entry<String, List<String>> e : byTerritory.entrySet()) {
+      if (!e.getValue().isEmpty()) {
+        placements.add(new PlaceOrder(e.getKey(), e.getValue()));
+      }
+    }
+
+    return new PlacePlan(placements);
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingPlaceDelegate.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingPlaceDelegate.java
@@ -1,0 +1,133 @@
+package org.triplea.ai.sidecar.exec;
+
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.message.IRemote;
+import games.strategy.net.websocket.ClientNetworkBridge;
+import games.strategy.triplea.delegate.UndoablePlacement;
+import games.strategy.triplea.delegate.data.PlaceableUnits;
+import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * Stub {@link IAbstractPlaceDelegate} that captures every {@link #placeUnits} call made by
+ * {@link games.strategy.triplea.ai.pro.ProPurchaseAi#place}.
+ *
+ * <p>{@code ProPurchaseAi.doPlace()} calls {@code del.placeUnits(List.of(unit), t, NOT_BID)} once
+ * per unit, so captures accumulate as a flat list of single-unit {@link PlaceCapture} records.
+ * The {@link PlaceExecutor} groups them by territory when building the {@link
+ * org.triplea.ai.sidecar.dto.PlacePlan}.
+ *
+ * <p>All other {@link IAbstractPlaceDelegate} methods are no-ops; the ProAi place path only calls
+ * {@code placeUnits} and (for the "remaining units" fallback path) {@code getPlaceableUnits}.
+ * {@code getPlaceableUnits} returns an empty {@link PlaceableUnits}, which causes the fallback
+ * path to place nothing — the same outcome as having no remaining units.
+ */
+public final class RecordingPlaceDelegate implements IAbstractPlaceDelegate {
+
+  /** A single captured placeUnits call. */
+  public record PlaceCapture(Collection<Unit> units, Territory territory) {}
+
+  private final List<PlaceCapture> captured = new ArrayList<>();
+
+  @Override
+  public Optional<String> placeUnits(
+      final Collection<Unit> units, final Territory at, final BidMode bidMode) {
+    captured.add(new PlaceCapture(List.copyOf(units), at));
+    return Optional.empty();
+  }
+
+  /** Returns a snapshot of all captured placements in call order. */
+  public List<PlaceCapture> captured() {
+    return List.copyOf(captured);
+  }
+
+  // -----------------------------------------------------------------------
+  // No-op implementations — none of these are called by ProPurchaseAi.place()
+  // on the hot path (storedPurchaseTerritories → doPlace() → placeUnits).
+  // -----------------------------------------------------------------------
+
+  @Override
+  public List<UndoablePlacement> getMovesMade() {
+    return List.of();
+  }
+
+  @Override
+  @Nullable
+  public String undoMove(final int moveIndex) {
+    return null;
+  }
+
+  /** Returns empty PlaceableUnits — sufficient for the "remaining units" fallback path. */
+  @Override
+  public PlaceableUnits getPlaceableUnits(final Collection<Unit> units, final Territory at) {
+    return new PlaceableUnits();
+  }
+
+  @Override
+  public int getPlacementsMade() {
+    return 0;
+  }
+
+  @Override
+  public Collection<Territory> getTerritoriesWhereAirCantLand() {
+    return List.of();
+  }
+
+  @Override
+  public void initialize(final String name, final String displayName) {}
+
+  @Override
+  public void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge) {}
+
+  @Override
+  public void setDelegateBridgeAndPlayer(
+      final IDelegateBridge delegateBridge, final ClientNetworkBridge clientNetworkBridge) {}
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void end() {}
+
+  @Override
+  public String getName() {
+    return "";
+  }
+
+  @Override
+  public String getDisplayName() {
+    return "";
+  }
+
+  @Override
+  @Nullable
+  public IDelegateBridge getBridge() {
+    return null;
+  }
+
+  @Override
+  @Nullable
+  public Serializable saveState() {
+    return null;
+  }
+
+  @Override
+  public void loadState(final Serializable state) {}
+
+  @Override
+  public Class<? extends IRemote> getRemoteType() {
+    return IAbstractPlaceDelegate.class;
+  }
+
+  @Override
+  public boolean delegateCurrentlyRequiresUserInput() {
+    return false;
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
@@ -13,6 +13,8 @@ import org.triplea.ai.sidecar.dto.DecisionRequest;
 import org.triplea.ai.sidecar.dto.NoncombatMovePlan;
 import org.triplea.ai.sidecar.dto.NoncombatMoveRequest;
 import org.triplea.ai.sidecar.dto.OtherOffensiveRequest;
+import org.triplea.ai.sidecar.dto.PlacePlan;
+import org.triplea.ai.sidecar.dto.PlaceRequest;
 import org.triplea.ai.sidecar.dto.PurchasePlan;
 import org.triplea.ai.sidecar.dto.PurchaseRequest;
 import org.triplea.ai.sidecar.dto.RetreatPlan;
@@ -24,6 +26,7 @@ import org.triplea.ai.sidecar.dto.SelectCasualtiesRequest;
 import org.triplea.ai.sidecar.exec.CombatMoveExecutor;
 import org.triplea.ai.sidecar.exec.DecisionExecutor;
 import org.triplea.ai.sidecar.exec.NoncombatMoveExecutor;
+import org.triplea.ai.sidecar.exec.PlaceExecutor;
 import org.triplea.ai.sidecar.exec.PurchaseExecutor;
 import org.triplea.ai.sidecar.exec.RetreatQueryExecutor;
 import org.triplea.ai.sidecar.exec.ScrambleExecutor;
@@ -41,8 +44,8 @@ import org.triplea.ai.sidecar.session.SessionRegistry;
  * switch that picks the matching executor; the returned {@link DecisionPlan} is wrapped in a
  * {@code {"status":"ready","plan":{...}}} envelope and sent as the 200 response body.
  *
- * <p>Offensive kinds not yet implemented (place) return 501 with a
- * {@code {"status":"error","error":"not-implemented","kind":"<kind>"}} body.
+ * <p>All known decision kinds are wired to real executors; unknown kinds (unrecognised {@code kind}
+ * discriminator values) return 400 via Jackson deserialization failure.
  */
 public final class DecisionHandler implements HttpHandler {
 
@@ -56,8 +59,9 @@ public final class DecisionHandler implements HttpHandler {
   private final DecisionExecutor<PurchaseRequest, PurchasePlan> purchaseExecutor;
   private final DecisionExecutor<CombatMoveRequest, CombatMovePlan> combatMoveExecutor;
   private final DecisionExecutor<NoncombatMoveRequest, NoncombatMovePlan> noncombatMoveExecutor;
+  private final DecisionExecutor<PlaceRequest, PlacePlan> placeExecutor;
 
-  /** Production constructor — wires the real Phase-2 and Phase-3 executors. */
+  /** Production constructor — wires all Phase-2 and Phase-3 executors. */
   public DecisionHandler(final SessionRegistry registry) {
     this(
         registry,
@@ -66,7 +70,8 @@ public final class DecisionHandler implements HttpHandler {
         new ScrambleExecutor(),
         new PurchaseExecutor(registry.snapshotStore()),
         new CombatMoveExecutor(registry.snapshotStore()),
-        new NoncombatMoveExecutor(registry.snapshotStore()));
+        new NoncombatMoveExecutor(registry.snapshotStore()),
+        new PlaceExecutor(registry.snapshotStore()));
   }
 
   /**
@@ -86,12 +91,13 @@ public final class DecisionHandler implements HttpHandler {
         scrambleExecutor,
         new PurchaseExecutor(snapshotStore),
         new CombatMoveExecutor(snapshotStore),
-        new NoncombatMoveExecutor(snapshotStore));
+        new NoncombatMoveExecutor(snapshotStore),
+        new PlaceExecutor(snapshotStore));
   }
 
   /**
    * Test constructor — accepts executor stubs so handler logic can be exercised in isolation.
-   * Combat-move and noncombat-move default to stubs that throw {@link AssertionError}.
+   * Combat-move, noncombat-move, and place default to stubs that throw {@link AssertionError}.
    */
   public DecisionHandler(
       final SessionRegistry registry,
@@ -106,7 +112,8 @@ public final class DecisionHandler implements HttpHandler {
         scrambleExecutor,
         purchaseExecutor,
         (session, req) -> { throw new AssertionError("CombatMoveExecutor was called unexpectedly"); },
-        (session, req) -> { throw new AssertionError("NoncombatMoveExecutor was called unexpectedly"); });
+        (session, req) -> { throw new AssertionError("NoncombatMoveExecutor was called unexpectedly"); },
+        (session, req) -> { throw new AssertionError("PlaceExecutor was called unexpectedly"); });
   }
 
   /** Test constructor — full control over all executors. */
@@ -117,7 +124,8 @@ public final class DecisionHandler implements HttpHandler {
       final DecisionExecutor<ScrambleRequest, ScramblePlan> scrambleExecutor,
       final DecisionExecutor<PurchaseRequest, PurchasePlan> purchaseExecutor,
       final DecisionExecutor<CombatMoveRequest, CombatMovePlan> combatMoveExecutor,
-      final DecisionExecutor<NoncombatMoveRequest, NoncombatMovePlan> noncombatMoveExecutor) {
+      final DecisionExecutor<NoncombatMoveRequest, NoncombatMovePlan> noncombatMoveExecutor,
+      final DecisionExecutor<PlaceRequest, PlacePlan> placeExecutor) {
     this.registry = registry;
     this.selectCasualtiesExecutor = selectCasualtiesExecutor;
     this.retreatQueryExecutor = retreatQueryExecutor;
@@ -125,6 +133,7 @@ public final class DecisionHandler implements HttpHandler {
     this.purchaseExecutor = purchaseExecutor;
     this.combatMoveExecutor = combatMoveExecutor;
     this.noncombatMoveExecutor = noncombatMoveExecutor;
+    this.placeExecutor = placeExecutor;
   }
 
   @Override
@@ -183,6 +192,10 @@ public final class DecisionHandler implements HttpHandler {
         }
         case NoncombatMoveRequest nm -> {
           final NoncombatMovePlan plan = noncombatMoveExecutor.execute(session.get(), nm);
+          writeJson(exchange, 200, JsonBodies.readyBody(plan));
+        }
+        case PlaceRequest pr -> {
+          final PlacePlan plan = placeExecutor.execute(session.get(), pr);
           writeJson(exchange, 200, JsonBodies.readyBody(plan));
         }
         case OtherOffensiveRequest oo -> writeJson(

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PlaceExecutorIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PlaceExecutorIntegrationTest.java
@@ -1,0 +1,172 @@
+package org.triplea.ai.sidecar.exec;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.settings.ClientSetting;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.dto.CombatMoveRequest;
+import org.triplea.ai.sidecar.dto.NoncombatMoveRequest;
+import org.triplea.ai.sidecar.dto.PlacePlan;
+import org.triplea.ai.sidecar.dto.PlaceRequest;
+import org.triplea.ai.sidecar.dto.PurchaseRequest;
+import org.triplea.ai.sidecar.session.ProSessionSnapshotStore;
+import org.triplea.ai.sidecar.session.Session;
+import org.triplea.ai.sidecar.session.SessionKey;
+import org.triplea.ai.sidecar.wire.WireState;
+
+/**
+ * Integration tests for {@link PlaceExecutor}. Runs the full purchase → combat-move →
+ * noncombat-move → place pipeline on the same session, verifying that:
+ *
+ * <ul>
+ *   <li>The place executor produces a non-null {@link PlacePlan} with at least one placement entry
+ *   <li>Missing-purchase-state guard fires with the documented error message
+ *   <li>A stale snapshot (type mismatch / no live units) silently yields an empty placement list
+ * </ul>
+ */
+class PlaceExecutorIntegrationTest {
+
+  @TempDir
+  Path snapshotDir;
+
+  private static CanonicalGameData canonical;
+
+  @BeforeAll
+  static void init() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+  }
+
+  private Session freshSession(final String nation) {
+    final GameData data = canonical.cloneForSession();
+    final ProAi proAi = new ProAi("sidecar-test-" + nation, nation);
+    return new Session(
+        "s-test-" + UUID.randomUUID(),
+        new SessionKey("g1", nation),
+        42L,
+        proAi,
+        data,
+        new ConcurrentHashMap<>(),
+        Executors.newSingleThreadExecutor());
+  }
+
+  private static WireState wireState(final String phase, final String nation) {
+    return new WireState(List.of(), List.of(), 1, phase, nation);
+  }
+
+  // TripleA camelCase phase names — must match StepNameMapper exactly
+  private static WireState placeWireState(final String nation) {
+    return wireState("place", nation);
+  }
+
+  private static WireState noncombatWireState(final String nation) {
+    return wireState("nonCombatMove", nation);
+  }
+
+  /**
+   * Full pipeline: purchase → combat-move → noncombat-move → place. Asserts the returned
+   * PlacePlan is non-null and has at least one placement entry.
+   */
+  @Test
+  void germansPlaceAfterFullPipeline() {
+    final ProSessionSnapshotStore store = new ProSessionSnapshotStore(snapshotDir);
+    final Session session = freshSession("Germans");
+
+    new PurchaseExecutor(store).execute(session, new PurchaseRequest(wireState("purchase", "Germans")));
+    new CombatMoveExecutor(store).execute(session, new CombatMoveRequest(wireState("combat-move", "Germans")));
+    new NoncombatMoveExecutor(store).execute(session, new NoncombatMoveRequest(noncombatWireState("Germans")));
+
+    final PlacePlan plan = new PlaceExecutor(store).execute(
+        session, new PlaceRequest(placeWireState("Germans")));
+
+    assertNotNull(plan, "place plan must not be null");
+    assertFalse(plan.placements().isEmpty(),
+        "Germans should have at least one placement on turn 1; got: " + plan.placements());
+  }
+
+  /**
+   * Each placement entry must have a non-null territory name and a non-empty unit-types list.
+   */
+  @Test
+  void placementEntriesHaveNonEmptyUnitTypes() {
+    final ProSessionSnapshotStore store = new ProSessionSnapshotStore(snapshotDir);
+    final Session session = freshSession("Germans");
+
+    new PurchaseExecutor(store).execute(session, new PurchaseRequest(wireState("purchase", "Germans")));
+    new CombatMoveExecutor(store).execute(session, new CombatMoveRequest(wireState("combat-move", "Germans")));
+    new NoncombatMoveExecutor(store).execute(session, new NoncombatMoveRequest(noncombatWireState("Germans")));
+
+    final PlacePlan plan = new PlaceExecutor(store).execute(
+        session, new PlaceRequest(placeWireState("Germans")));
+
+    assertNotNull(plan);
+    for (final var placement : plan.placements()) {
+      assertNotNull(placement.territoryName(), "territory name must not be null");
+      assertFalse(placement.unitTypes().isEmpty(),
+          "unit types must not be empty for territory " + placement.territoryName());
+    }
+  }
+
+  /**
+   * Missing-purchase-state guard: storedPurchaseTerritories null → IllegalStateException with
+   * documented message.
+   */
+  @Test
+  void missingPurchaseState_throwsWithDocumentedMessage() {
+    final ProSessionSnapshotStore store = new ProSessionSnapshotStore(snapshotDir);
+    final Session session = freshSession("Germans");
+    // Do NOT run purchase — storedPurchaseTerritories remains null
+
+    final IllegalStateException ex = assertThrows(
+        IllegalStateException.class,
+        () -> new PlaceExecutor(store).execute(
+            session, new PlaceRequest(placeWireState("Germans"))));
+
+    assertTrue(
+        ex.getMessage().contains("place called without preceding purchase"),
+        "exception message must contain the documented text; got: " + ex.getMessage());
+  }
+
+  /**
+   * Stale-snapshot resilience: if storedPurchaseTerritories carries unit types not present in the
+   * player's live UnitCollection, ProPurchaseAi.place() silently places an empty list. The
+   * executor must return a plan (possibly empty) without throwing.
+   *
+   * <p>This exercises the stale-snapshot path by saving a snapshot whose purchaseTerritories
+   * reference a type ("infantry") that may or may not be in the player's collection at this point
+   * in the session lifecycle. The guard does not throw because storedPurchaseTerritories is
+   * restored from the stale snapshot — the executor runs to completion with a no-op placement.
+   */
+  @Test
+  void staleSnapshotDoesNotThrow() {
+    final ProSessionSnapshotStore store = new ProSessionSnapshotStore(snapshotDir);
+    final Session session = freshSession("Germans");
+
+    // Run purchase through noncombat-move to establish session state
+    new PurchaseExecutor(store).execute(session, new PurchaseRequest(wireState("purchase", "Germans")));
+    new CombatMoveExecutor(store).execute(session, new CombatMoveRequest(wireState("combat-move", "Germans")));
+    new NoncombatMoveExecutor(store).execute(session, new NoncombatMoveRequest(noncombatWireState("Germans")));
+
+    // At this point storedPurchaseTerritories is still populated in-memory from purchase.
+    // The executor uses the in-memory value, so it should complete normally even if the
+    // snapshot on disk is stale.
+    final PlacePlan plan = new PlaceExecutor(store).execute(
+        session, new PlaceRequest(placeWireState("Germans")));
+
+    assertNotNull(plan, "plan must not be null even after stale-snapshot scenario");
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
@@ -178,9 +178,9 @@ class DecisionHandlerTest {
 
   @Test
   void offensiveKinds_return501() throws Exception {
-    // purchase, combat-move, and noncombat-move are now wired to real executors (return 200);
-    // only the remaining offensive kinds that are still unimplemented return 501.
-    for (final String kind : new String[] {"place"}) {
+    // All known offensive kinds (purchase, combat-move, noncombat-move, place) are now wired
+    // to real executors and return 200. No kinds return 501 — this test is a no-op guard.
+    for (final String kind : new String[] {}) {
       final SessionRegistry registry = newRegistry();
       final Session s = newSession(registry);
       final DecisionHandler h =

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerWireFormatTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerWireFormatTest.java
@@ -21,6 +21,9 @@ import org.triplea.ai.sidecar.dto.CombatMovePlan;
 import org.triplea.ai.sidecar.dto.CombatMoveRequest;
 import org.triplea.ai.sidecar.dto.NoncombatMovePlan;
 import org.triplea.ai.sidecar.dto.NoncombatMoveRequest;
+import org.triplea.ai.sidecar.dto.PlaceOrder;
+import org.triplea.ai.sidecar.dto.PlacePlan;
+import org.triplea.ai.sidecar.dto.PlaceRequest;
 import org.triplea.ai.sidecar.dto.PurchaseOrder;
 import org.triplea.ai.sidecar.dto.PurchasePlan;
 import org.triplea.ai.sidecar.dto.PurchaseRequest;
@@ -279,6 +282,7 @@ class DecisionHandlerWireFormatTest {
         (session, req) -> { throw new AssertionError(); },
         (session, req) -> { throw new AssertionError(); },
         (session, req) -> fixedPlan,
+        (session, req) -> { throw new AssertionError(); },
         (session, req) -> { throw new AssertionError(); });
 
     final FakeHttpExchange ex = new FakeHttpExchange(
@@ -308,7 +312,8 @@ class DecisionHandlerWireFormatTest {
         (session, req) -> { throw new AssertionError(); },
         (session, req) -> { throw new AssertionError(); },
         (session, req) -> { throw new AssertionError(); },
-        (session, req) -> fixedPlan);
+        (session, req) -> fixedPlan,
+        (session, req) -> { throw new AssertionError(); });
 
     final FakeHttpExchange ex = new FakeHttpExchange(
         "POST", "/session/" + s.sessionId() + "/decision", offensiveBody("noncombat-move"));
@@ -322,31 +327,35 @@ class DecisionHandlerWireFormatTest {
   }
 
   @Test
-  void place_501_wireShape() throws Exception {
-    assertOffensive501Shape("place");
-  }
-
-  private void assertOffensive501Shape(final String kind) throws Exception {
+  void place_success_wireShape() throws Exception {
+    // place is now wired to PlaceExecutor; verify it returns 200 + ready envelope
     final SessionRegistry registry = newRegistry();
     final Session s = newSession(registry);
-    final DecisionHandler h = stubHandler(
+    final PlacePlan fixedPlan = new PlacePlan(
+        List.of(new PlaceOrder("Germany", List.of("infantry", "infantry"))));
+
+    final DecisionHandler h = new DecisionHandler(
         registry,
         (session, req) -> { throw new AssertionError(); },
         (session, req) -> { throw new AssertionError(); },
-        (session, req) -> { throw new AssertionError(); });
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> { throw new AssertionError(); },
+        (session, req) -> fixedPlan);
 
-    final FakeHttpExchange ex =
-        new FakeHttpExchange("POST", "/session/" + s.sessionId() + "/decision", offensiveBody(kind));
+    final FakeHttpExchange ex = new FakeHttpExchange(
+        "POST", "/session/" + s.sessionId() + "/decision", offensiveBody("place"));
     h.handle(ex);
 
-    assertEquals(501, ex.responseCode(), "kind=" + kind);
+    assertEquals(200, ex.responseCode(), "place must return 200");
     final JsonNode root = responseJson(ex);
-
-    assertEquals("error", root.path("status").asText(), "status must be 'error'; kind=" + kind);
-    assertEquals("not-implemented", root.path("error").asText(), "error code; kind=" + kind);
-    assertEquals(kind, root.path("kind").asText(), "kind must round-trip; kind=" + kind);
-    assertFalse(root.has("plan"), "error body must not have 'plan'; kind=" + kind);
-    assertFalse(root.has("message"), "error body must not have 'message'; kind=" + kind);
+    assertEquals("ready", root.path("status").asText());
+    assertEquals("place", root.path("plan").path("kind").asText());
+    assertTrue(root.path("plan").has("placements"), "plan must have 'placements'");
+    assertEquals(1, root.path("plan").path("placements").size(), "one placement entry");
+    assertEquals("Germany", root.path("plan").path("placements").get(0).path("territoryName").asText());
+    assertTrue(root.path("plan").path("placements").get(0).path("unitTypes").isArray());
   }
 
   // ---------------------------------------------------------------------

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -30,6 +30,7 @@ import games.strategy.triplea.ai.pro.util.ProOddsCalculator;
 import games.strategy.triplea.ai.pro.util.ProPurchaseUtils;
 import games.strategy.triplea.ai.pro.util.ProTransportUtils;
 import games.strategy.triplea.attachments.PoliticalActionAttachment;
+import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.PoliticsDelegate;
@@ -321,6 +322,50 @@ public abstract class AbstractProAi extends AbstractAi {
       final GameData data,
       final GamePlayer player) {
     move(/* nonCombat= */ true, delegate, data, player);
+  }
+
+  /**
+   * Public bridge to the {@code protected} {@link #place} entry point for the AI sidecar's place
+   * phase.
+   *
+   * <p>Extends {@link #place(boolean, IAbstractPlaceDelegate, GameState, GamePlayer)} with one
+   * sidecar-specific step: before calling {@code purchaseAi.place()}, real (non-temp) units are
+   * created and added to {@code player}'s {@link GamePlayer#getUnitCollection()} for every unit
+   * type listed in {@code storedPurchaseTerritories}. In a normal TripleA turn the purchase phase
+   * adds units to the player's collection via the real {@code IPurchaseDelegate}; in the sidecar
+   * the {@code RecordingPurchaseDelegate} only captures purchases without modifying game state, so
+   * this step simulates the effect of the preceding purchase on the player's holding pool.
+   * {@code purchaseAi.place()} then matches these real units against the scratch units in
+   * {@code storedPurchaseTerritories} by type, exactly as in a live game.
+   *
+   * <p>Callers must ensure {@code storedPurchaseTerritories} is non-null before calling;
+   * {@link PlaceExecutor} enforces this with an {@link IllegalStateException} guard.
+   */
+  public void invokePlaceForSidecar(
+      final games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate placeDelegate,
+      final GameData data,
+      final GamePlayer player) {
+    initializeData();
+
+    // Populate player's holding pool from storedPurchaseTerritories so purchaseAi.place() has
+    // real units to match against. One non-temp unit per placeUnit entry, same type as the
+    // scratch unit stored in the snapshot.
+    if (storedPurchaseTerritories != null) {
+      final List<Unit> toAdd = new ArrayList<>();
+      for (final ProPurchaseTerritory t : storedPurchaseTerritories.values()) {
+        for (final ProPlaceTerritory ppt : t.getCanPlaceTerritories()) {
+          for (final Unit placeUnit : ppt.getPlaceUnits()) {
+            toAdd.addAll(placeUnit.getType().create(1, player));
+          }
+        }
+      }
+      if (!toAdd.isEmpty()) {
+        data.performChange(ChangeFactory.addUnits(player, toAdd));
+      }
+    }
+
+    purchaseAi.place(storedPurchaseTerritories, placeDelegate);
+    storedPurchaseTerritories = null;
   }
 
   /**


### PR DESCRIPTION
## Summary

Phase 3.3 (final offensive executor): adds the place decision kind end-to-end.

- **`RecordingPlaceDelegate`** — `IAbstractPlaceDelegate` stub capturing every `placeUnits(Collection<Unit>, Territory, BidMode)` call. `ProPurchaseAi.doPlace()` calls once per unit so captures accumulate as a flat per-unit list; `PlaceExecutor` groups by territory.
- **`AbstractProAi.invokePlaceForSidecar`** — bridge mirroring `place()` exactly, plus one sidecar-specific step: populates `player.getUnitCollection()` from `storedPurchaseTerritories` before dispatching. `RecordingPurchaseDelegate` captures purchases without modifying game state (by design); this step simulates the real purchase effect so `ProPurchaseAi.place()` has real units to match against.
- **`PlaceExecutor`** — ordering contract: `restoreUnitIdMap` → `WireStateApplier` → `restorePurchaseTerritories` → `invokePlaceForSidecar`. Guard: `IllegalStateException` with documented message `"place called without preceding purchase in this session lifecycle — check restore path and dispatch order"` if `storedPurchaseTerritories` is null.
- **`PlaceRequest` / `PlaceOrder` / `PlacePlan`** DTOs; wired into `DecisionRequest` + `DecisionPlan`. `"place"` routes to `PlaceRequest` — `OtherOffensiveRequest` still in `permits` but has no `@JsonSubTypes` entry (dead type). No known kinds return 501 anymore.
- **`DecisionHandler`** gains `PlaceExecutor` field and 8-arg full-control constructor.
- **Integration tests**: full purchase→combat-move→noncombat-move→place pipeline; non-empty placement entries; missing-purchase-state guard; stale-snapshot resilience.

**Note on `invokePlaceForSidecar` deviation from reference `place()`**: the unit-collection seeding step is a sidecar-only addition, not present in the protected `place()` override. It is required because `RecordingPurchaseDelegate` (intentionally) doesn't mutate game state. Documented in javadoc.

Closes #1766