### PR TITLE
fix(wire): add per-unit owner field to WireUnit

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -261,6 +261,15 @@ public final class WireStateApplier {
         throw new IllegalArgumentException(
             "Unknown unit type in WireState: " + wu.unitType());
       }
+      // Per-unit owner: use the explicit owner from the wire when present, otherwise fall back
+      // to the territory owner. The fallback preserves backward compatibility with clients that
+      // do not send an owner field. The per-unit owner is critical for sea zones (territory
+      // owner = Neutral) where multiple nations may have ships — without it the ProAI sees all
+      // naval units as belonging to Neutral and misidentifies allies as enemies (#1776).
+      final GamePlayer unitOwner =
+          (wu.owner() != null && !wu.owner().isEmpty())
+              ? resolvePlayer(gameData, wu.owner())
+              : wireOwner;
       final Unit existing = findUnitById(territory.getUnits(), uuid);
       final Unit unit;
       if (existing != null) {
@@ -271,7 +280,7 @@ public final class WireStateApplier {
           existingUnitHitDeltas.put(unit, wu.hitsTaken());
         }
       } else {
-        unit = new Unit(uuid, type, wireOwner, gameData);
+        unit = new Unit(uuid, type, unitOwner, gameData);
         // Register with the central UnitsList so {@code GameData.getUnits().get(uuid)}
         // resolves to this unit. The raw {@link Unit#Unit(UUID, UnitType, GamePlayer,
         // GameData)} constructor does not do this registration — only {@link

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireUnit.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireUnit.java
@@ -2,26 +2,38 @@ package org.triplea.ai.sidecar.wire;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
 
 public record WireUnit(
-    String unitId, String unitType, int hitsTaken, int movesUsed, int bombingDamage) {
+    String unitId, String unitType, int hitsTaken, int movesUsed, int bombingDamage,
+    @Nullable String owner) {
   @JsonCreator
   public static WireUnit of(
       @JsonProperty("unitId") final String unitId,
       @JsonProperty("unitType") final String unitType,
       @JsonProperty("hitsTaken") final Integer hitsTaken,
       @JsonProperty("movesUsed") final Integer movesUsed,
-      @JsonProperty("bombingDamage") final Integer bombingDamage) {
+      @JsonProperty("bombingDamage") final Integer bombingDamage,
+      @JsonProperty("owner") final String owner) {
     return new WireUnit(
         unitId,
         unitType,
         hitsTaken == null ? 0 : hitsTaken,
         movesUsed == null ? 0 : movesUsed,
-        bombingDamage == null ? 0 : bombingDamage);
+        bombingDamage == null ? 0 : bombingDamage,
+        owner);
   }
 
+  /** Backward-compat constructor used by existing tests that don't specify an owner. */
   public WireUnit(
       final String unitId, final String unitType, final int hitsTaken, final int movesUsed) {
-    this(unitId, unitType, hitsTaken, movesUsed, 0);
+    this(unitId, unitType, hitsTaken, movesUsed, 0, null);
+  }
+
+  /** Backward-compat constructor for tests that specify bombingDamage but not owner. */
+  public WireUnit(
+      final String unitId, final String unitType,
+      final int hitsTaken, final int movesUsed, final int bombingDamage) {
+    this(unitId, unitType, hitsTaken, movesUsed, bombingDamage, null);
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
@@ -308,6 +308,70 @@ class WireStateApplierTest {
         .hasMessageContaining("deathstar");
   }
 
+  // ---------- per-unit owner (#1776 regression fence) ----------
+
+  /**
+   * Sea zone with ships from two different nations: the unit's owner must come from the
+   * per-unit {@code owner} field, not the territory owner (Neutral). This is the regression
+   * fence for the bug where ProAI saw Italian ally ships as enemies because they were all
+   * attributed to Neutral.
+   */
+  @Test
+  void perUnitOwner_seaZoneMultiNation_assignsCorrectOwners() {
+    final GameData gd = fresh();
+    // 112 Sea Zone: territory owner is Germans but the cruiser belongs to Italians.
+    // This mirrors the bug scenario where sea zones hold ships from allied nations.
+    final WireUnit germanSub =
+        WireUnit.of("u-sub-1", "submarine", 0, 0, 0, "Germans");
+    final WireUnit italianCruiser =
+        WireUnit.of("u-cru-1", "cruiser", 0, 0, 0, "Italians");
+    final WireState wire =
+        new WireState(
+            List.of(new WireTerritory("112 Sea Zone", "Germans", List.of(germanSub, italianCruiser))),
+            List.of(),
+            1,
+            "combat",
+            "Germans");
+
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    WireStateApplier.apply(gd, wire, idMap);
+
+    final Territory seaZone = gd.getMap().getTerritoryOrNull("112 Sea Zone");
+    assertThat(seaZone).isNotNull();
+    final Map<String, String> unitOwners =
+        seaZone.getUnits().stream()
+            .collect(Collectors.toMap(
+                u -> u.getType().getName(),
+                u -> u.getOwner().getName()));
+    assertThat(unitOwners).containsEntry("submarine", "Germans");
+    assertThat(unitOwners).containsEntry("cruiser", "Italians");
+  }
+
+  /**
+   * Backward compat: units without an owner field ({@code owner} null) fall back to territory
+   * owner. No crash, correct assignment.
+   */
+  @Test
+  void perUnitOwner_nullOwner_fallsBackToTerritoryOwner() {
+    final GameData gd = fresh();
+    // Germany is a land territory owned by Germans.
+    final WireUnit infantry = new WireUnit("u-inf-1", "infantry", 0, 0); // no owner field
+    final WireState wire =
+        new WireState(
+            List.of(new WireTerritory("Germany", "Germans", List.of(infantry))),
+            List.of(),
+            1,
+            "combat",
+            "Germans");
+
+    WireStateApplier.apply(gd, wire, freshIdMap());
+
+    final Territory germany = gd.getMap().getTerritoryOrNull("Germany");
+    assertThat(germany).isNotNull();
+    assertThat(germany.getUnits()).hasSize(1);
+    assertThat(germany.getUnits().iterator().next().getOwner().getName()).isEqualTo("Germans");
+  }
+
   @Test
   void techFlag_setsAttachmentProperty() {
     final GameData gd = fresh();


### PR DESCRIPTION
Closes map-room/map-room#1776

## Problem

Sea zones can hold ships from multiple allied nations. When the TypeScript side serialises `WireUnit`, it did not include the unit's owner — only the territory owner was sent. `WireStateApplier` therefore attributed all units in that territory to the territory's owner, causing ProAI to treat Italian ally ships as enemies.

## Fix

* **`WireUnit`** — added nullable `owner` field as a 6th record component.  
  * New `WireUnit.of()` `@JsonCreator` factory with `@JsonProperty("owner")`.  
  * Two backward-compat constructors (4-arg and 5-arg) for existing tests that don't send an owner.

* **`WireStateApplier`** — in `applyTerritory()`, resolve `unitOwner` from `wu.owner()` when non-null/non-empty; otherwise fall back to the territory owner (backward compat).

## Tests

Two new cases in `WireStateApplierTest`:

| Test | Verifies |
|------|----------|
| `perUnitOwner_seaZoneMultiNation_assignsCorrectOwners` | German submarine + Italian cruiser in same sea zone each get the correct owner |
| `perUnitOwner_nullOwner_fallsBackToTerritoryOwner` | Unit without owner field gets territory owner (backward compat) |

All existing tests pass — BUILD SUCCESSFUL.