### PR TITLE
feat(ai-sidecar): Phase 2 Task 2.3 — deterministic sessionId, disk persistence, session reaper

### DIFF
--- a/game-app/ai-sidecar/.gitignore
+++ b/game-app/ai-sidecar/.gitignore
@@ -1,0 +1,2 @@
+# Runtime session data written by the sidecar — not part of source
+data/

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/SidecarConfig.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/SidecarConfig.java
@@ -2,12 +2,31 @@ package org.triplea.ai.sidecar;
 
 import java.util.Map;
 
-public record SidecarConfig(String bindHost, int port, int workerCount, String authToken) {
+/**
+ * Configuration loaded entirely from environment variables.
+ *
+ * <p>New in v2:
+ * <ul>
+ *   <li>{@code SIDECAR_DATA_DIR} — directory for session manifests (default: {@code data/sessions}).
+ *   <li>{@code SIDECAR_SERVER_URL} — base URL of the Map Room server, used by the reaper to check
+ *       gameover status (optional; gameover reaping is skipped when unset).
+ * </ul>
+ */
+public record SidecarConfig(
+    String bindHost,
+    int port,
+    int workerCount,
+    String authToken,
+    String dataDir,
+    String serverUrl) {
+
   public static SidecarConfig fromEnv(final Map<String, String> env) {
     return new SidecarConfig(
         env.getOrDefault("SIDECAR_BIND_HOST", "0.0.0.0"),
         Integer.parseInt(env.getOrDefault("SIDECAR_PORT", "8099")),
         Integer.parseInt(env.getOrDefault("SIDECAR_WORKERS", "4")),
-        env.getOrDefault("SIDECAR_AUTH_TOKEN", "dev-token"));
+        env.getOrDefault("SIDECAR_AUTH_TOKEN", "dev-token"),
+        env.getOrDefault("SIDECAR_DATA_DIR", "data/sessions"),
+        env.getOrDefault("SIDECAR_SERVER_URL", null));
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/SidecarMain.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/SidecarMain.java
@@ -2,9 +2,12 @@ package org.triplea.ai.sidecar;
 
 import games.strategy.triplea.settings.ClientSetting;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Clock;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import org.triplea.ai.sidecar.http.HttpService;
+import org.triplea.ai.sidecar.session.SessionReaper;
 import org.triplea.ai.sidecar.session.SessionRegistry;
 
 public final class SidecarMain {
@@ -15,28 +18,43 @@ public final class SidecarMain {
 
     final SidecarConfig cfg = SidecarConfig.fromEnv(System.getenv());
     final CanonicalGameData canonical = CanonicalGameData.load();
-    final SessionRegistry registry = new SessionRegistry(canonical);
+    final Path dataDir = Path.of(cfg.dataDir());
+    final SessionRegistry registry = new SessionRegistry(canonical, dataDir);
+
+    // Restore sessions persisted in a previous run.
+    registry.rehydrate();
 
     final HttpService svc = HttpService.start(cfg, registry);
     System.out.printf(
         "[ai-sidecar] listening on %s:%d%n", cfg.bindHost(), svc.boundPort());
+
+    // Start reaper — runs every 5 minutes, cleans stale sessions (>30 days).
+    final SessionReaper reaper = new SessionReaper(registry, Clock.systemUTC(), cfg.serverUrl());
+    reaper.start();
 
     final CountDownLatch latch = new CountDownLatch(1);
     Runtime.getRuntime()
         .addShutdownHook(
             new Thread(
                 () -> {
+                  reaper.stop();
                   svc.stop();
                   latch.countDown();
                 }));
     latch.await();
   }
 
-  // Test hook — lets the integration test call the same wiring as main() without blocking.
+  /**
+   * Test hook — starts the sidecar with the given env overrides.
+   * Uses SIDECAR_DATA_DIR from env to point to a temp dir so tests are isolated.
+   */
   static HttpService startForTest(final Map<String, String> env) throws IOException {
     ClientSetting.initialize();
     final SidecarConfig cfg = SidecarConfig.fromEnv(env);
     final CanonicalGameData canonical = CanonicalGameData.load();
-    return HttpService.start(cfg, new SessionRegistry(canonical));
+    final Path dataDir = Path.of(cfg.dataDir());
+    final SessionRegistry registry = new SessionRegistry(canonical, dataDir);
+    registry.rehydrate();
+    return HttpService.start(cfg, registry);
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/HttpService.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/HttpService.java
@@ -17,11 +17,16 @@ public final class HttpService {
 
   public static HttpService start(final SidecarConfig cfg, final SessionRegistry registry)
       throws IOException {
-    final HttpServer server = HttpServer.create(new InetSocketAddress(cfg.bindHost(), cfg.port()), 0);
+    final HttpServer server =
+        HttpServer.create(new InetSocketAddress(cfg.bindHost(), cfg.port()), 0);
     final AuthFilter auth = new AuthFilter(cfg.authToken());
 
     server.createContext("/health", new HealthHandler());
-    registerAuthed(server, "/session", new SessionCreateHandler(registry), auth);
+
+    // v2 contract: POST /sessions (plural, deterministic sessionId)
+    registerAuthed(server, "/sessions", new SessionCreateHandler(registry), auth);
+
+    // Per-session sub-paths: /session/{id}/update, /session/{id}/decision, DELETE /session/{id}
     registerAuthed(server, "/session/", new CompositeSessionHandler(registry), auth);
 
     server.setExecutor(null);
@@ -38,7 +43,10 @@ public final class HttpService {
   }
 
   private static void registerAuthed(
-      final HttpServer server, final String path, final HttpHandler handler, final AuthFilter auth) {
+      final HttpServer server,
+      final String path,
+      final HttpHandler handler,
+      final AuthFilter auth) {
     server.createContext(
         path,
         exchange -> {

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/SessionCreateHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/SessionCreateHandler.java
@@ -5,12 +5,18 @@ import com.sun.net.httpserver.HttpHandler;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import org.triplea.ai.sidecar.session.Session;
-import org.triplea.ai.sidecar.session.SessionKey;
 import org.triplea.ai.sidecar.session.SessionRegistry;
 import org.triplea.ai.sidecar.wire.SessionCreateRequest;
 import org.triplea.ai.sidecar.wire.SessionCreateResponse;
 
+/**
+ * Handles {@code POST /sessions} (v2 contract).
+ *
+ * <p>The caller supplies a deterministic {@code sessionId = matchID:nation}. The handler
+ * validates that {@code sessionId == gameId + ":" + nation} and then delegates to
+ * {@link SessionRegistry#createOrGet} which is idempotent — reopening an existing session
+ * returns {@code created=false} without reinitialising ProData.
+ */
 public final class SessionCreateHandler implements HttpHandler {
   private final SessionRegistry registry;
 
@@ -33,12 +39,30 @@ public final class SessionCreateHandler implements HttpHandler {
       writeJson(exchange, 400, JsonBodies.errorBody("bad-request", "invalid JSON body"));
       return;
     }
-    if (req.gameId() == null || req.nation() == null) {
-      writeJson(exchange, 400, JsonBodies.errorBody("bad-request", "gameId and nation required"));
+    // Validate required fields
+    if (req.sessionId() == null || req.gameId() == null || req.nation() == null) {
+      writeJson(exchange, 400, JsonBodies.errorBody("bad-request",
+          "sessionId, gameId and nation are required"));
       return;
     }
-    final Session session = registry.createOrGet(new SessionKey(req.gameId(), req.nation()), req.seed());
-    writeJson(exchange, 200, JsonBodies.writeValue(new SessionCreateResponse(session.sessionId())));
+    // Validate deterministic sessionId contract
+    final String expectedId = req.gameId() + ":" + req.nation();
+    if (!expectedId.equals(req.sessionId())) {
+      writeJson(exchange, 400, JsonBodies.errorBody("bad-request",
+          "sessionId must equal gameId + \":\" + nation (expected \"" + expectedId + "\")"));
+      return;
+    }
+
+    final SessionRegistry.CreateResult result =
+        registry.createOrGet(
+            new org.triplea.ai.sidecar.session.SessionKey(req.gameId(), req.nation()),
+            req.sessionId(),
+            req.seed());
+
+    writeJson(
+        exchange,
+        200,
+        JsonBodies.writeValue(new SessionCreateResponse(result.session().sessionId(), result.created())));
   }
 
   private static void writeJson(final HttpExchange ex, final int status, final String body)

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/SessionLifecycleHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/SessionLifecycleHandler.java
@@ -64,6 +64,8 @@ public final class SessionLifecycleHandler implements HttpHandler {
       return;
     }
     // Phase 1: accept and record the delta request; actual GameData mutation is Phase 2.
+    // Touch updatedAt so the reaper doesn't mark this session as stale.
+    registry.touchUpdatedAt(session.get().key());
     exchange.sendResponseHeaders(204, -1);
     exchange.close();
   }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionManifest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionManifest.java
@@ -1,0 +1,45 @@
+package org.triplea.ai.sidecar.session;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Disk record for a sidecar session. Written atomically to
+ * {@code data/sessions/{gameId}/{nation}.json} on creation and update.
+ * Re-read on startup to rehydrate the in-memory session registry.
+ */
+public final class SessionManifest {
+  private final String sessionId;
+  private final String gameId;
+  private final String nation;
+  private final long seed;
+  private final long createdAt;
+  private final long updatedAt;
+
+  @JsonCreator
+  public SessionManifest(
+      @JsonProperty("sessionId") final String sessionId,
+      @JsonProperty("gameId") final String gameId,
+      @JsonProperty("nation") final String nation,
+      @JsonProperty("seed") final long seed,
+      @JsonProperty("createdAt") final long createdAt,
+      @JsonProperty("updatedAt") final long updatedAt) {
+    this.sessionId = sessionId;
+    this.gameId = gameId;
+    this.nation = nation;
+    this.seed = seed;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  @JsonProperty("sessionId") public String sessionId() { return sessionId; }
+  @JsonProperty("gameId") public String gameId() { return gameId; }
+  @JsonProperty("nation") public String nation() { return nation; }
+  @JsonProperty("seed") public long seed() { return seed; }
+  @JsonProperty("createdAt") public long createdAt() { return createdAt; }
+  @JsonProperty("updatedAt") public long updatedAt() { return updatedAt; }
+
+  public SessionManifest withUpdatedAt(final long newUpdatedAt) {
+    return new SessionManifest(sessionId, gameId, nation, seed, createdAt, newUpdatedAt);
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionReaper.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionReaper.java
@@ -1,0 +1,95 @@
+package org.triplea.ai.sidecar.session;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Background task that removes stale sessions every 5 minutes.
+ *
+ * <p>A session is stale if its {@code updatedAt} timestamp is older than 30 days.
+ * If {@code serverUrl} is provided (non-null), gameover sessions are also reaped
+ * by querying {@code GET {serverUrl}/api/matches/{matchID}} — this is an optional
+ * enhancement: gameover reaping is skipped when the server URL is not configured.
+ *
+ * <p>The reaper is started via {@link #start()} and shut down via {@link #stop()}.
+ * For testing, {@link #runOnce()} executes one reap cycle synchronously.
+ */
+public final class SessionReaper {
+
+  private static final System.Logger LOG =
+      System.getLogger(SessionReaper.class.getName());
+
+  static final long STALE_THRESHOLD_DAYS = 30;
+  static final long INTERVAL_MINUTES = 5;
+
+  private final SessionRegistry registry;
+  private final Clock clock;
+  private final String serverUrl; // nullable
+
+  private ScheduledExecutorService scheduler;
+
+  public SessionReaper(
+      final SessionRegistry registry,
+      final Clock clock,
+      final String serverUrl) {
+    this.registry = registry;
+    this.clock = clock;
+    this.serverUrl = serverUrl;
+  }
+
+  /** Starts the background reaper. Idempotent. */
+  public synchronized void start() {
+    if (scheduler != null) {
+      return;
+    }
+    scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+      final Thread t = new Thread(r, "sidecar-reaper");
+      t.setDaemon(true);
+      return t;
+    });
+    scheduler.scheduleAtFixedRate(
+        this::runOnceSafe, INTERVAL_MINUTES, INTERVAL_MINUTES, TimeUnit.MINUTES);
+    LOG.log(System.Logger.Level.INFO,
+        "Session reaper started (interval={0}m, stale_threshold={1}d)",
+        new Object[]{INTERVAL_MINUTES, STALE_THRESHOLD_DAYS});
+  }
+
+  /** Stops the background reaper. */
+  public synchronized void stop() {
+    if (scheduler != null) {
+      scheduler.shutdownNow();
+      scheduler = null;
+    }
+  }
+
+  /** Runs one reap cycle. Used directly by tests and by the scheduler. */
+  public void runOnce() {
+    final long now = clock.millis();
+    final long staleBeforeMs = now - TimeUnit.DAYS.toMillis(STALE_THRESHOLD_DAYS);
+
+    final List<SessionKey> toDelete = registry.findStale(staleBeforeMs);
+
+    if (!toDelete.isEmpty()) {
+      LOG.log(System.Logger.Level.INFO, "Reaper: deleting {0} stale sessions", toDelete.size());
+    }
+
+    for (final SessionKey key : toDelete) {
+      registry.deleteByKey(key);
+    }
+
+    // TODO(Phase 3): gameover check via GET {serverUrl}/api/matches/{matchID}
+    // when serverUrl != null. Deferred: requires the sidecar to call the game server,
+    // which is otherwise a leaf service. See docs/ai-sidecar-contract-v2.md.
+  }
+
+  private void runOnceSafe() {
+    try {
+      runOnce();
+    } catch (final Exception e) {
+      LOG.log(System.Logger.Level.WARNING, "Reaper cycle failed", e);
+    }
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionRegistry.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionRegistry.java
@@ -3,54 +3,108 @@ package org.triplea.ai.sidecar.session;
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.ai.pro.ProAi;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.triplea.ai.sidecar.CanonicalGameData;
 
+/**
+ * In-memory registry of active sidecar sessions, backed by disk persistence.
+ *
+ * <p>Sessions are keyed by their deterministic {@code sessionId} ({@code matchID:nation}).
+ * On startup, call {@link #rehydrate()} to restore sessions from disk. On session create,
+ * the manifest is written atomically via {@link SessionStore}.
+ *
+ * <p>Thread safety: {@code createOrGet}, {@code delete}, {@code deleteByKey}, and
+ * {@code rehydrate} are {@code synchronized} to prevent concurrent create/delete races.
+ * Read operations ({@code get}) use the underlying {@code ConcurrentHashMap} directly.
+ */
 public final class SessionRegistry {
   private final CanonicalGameData canonical;
   private final ProSessionSnapshotStore snapshotStore;
+  private final SessionStore sessionStore;
   private final ConcurrentHashMap<SessionKey, Session> byKey = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, Session> byId = new ConcurrentHashMap<>();
+  // Tracks updatedAt per key (used by reaper). Updated by setUpdatedAt.
+  private final ConcurrentHashMap<SessionKey, Long> updatedAtMap = new ConcurrentHashMap<>();
 
+  /** Production constructor: data dir defaults to ./data/sessions; snapshot dir to tmpdir. */
   public SessionRegistry(final CanonicalGameData canonical) {
-    this(canonical, new ProSessionSnapshotStore(Path.of(
-        System.getProperty("java.io.tmpdir"), "sidecar-snapshots")));
+    this(
+        canonical,
+        Path.of("data", "sessions"),
+        new ProSessionSnapshotStore(Path.of(
+            System.getProperty("java.io.tmpdir"), "sidecar-snapshots")));
   }
 
-  public SessionRegistry(
-      final CanonicalGameData canonical, final ProSessionSnapshotStore snapshotStore) {
+  /** Constructor accepting a custom data dir (used in tests and via SidecarConfig). */
+  public SessionRegistry(final CanonicalGameData canonical, final Path dataDir) {
+    this(
+        canonical,
+        dataDir,
+        new ProSessionSnapshotStore(dataDir.resolve("snapshots")));
+  }
+
+  private SessionRegistry(
+      final CanonicalGameData canonical,
+      final Path dataDir,
+      final ProSessionSnapshotStore snapshotStore) {
     this.canonical = canonical;
     this.snapshotStore = snapshotStore;
+    this.sessionStore = new SessionStore(dataDir);
   }
 
-  public synchronized Session createOrGet(final SessionKey key, final long seed) {
-    final Session existing = byKey.get(key);
-    if (existing != null && existing.seed() == seed) {
-      return existing;
-    }
+  /** Test-only constructor that accepts an explicit snapshot store. */
+  public SessionRegistry(
+      final CanonicalGameData canonical,
+      final ProSessionSnapshotStore snapshotStore) {
+    this.canonical = canonical;
+    this.snapshotStore = snapshotStore;
+    this.sessionStore = new SessionStore(Path.of(
+        System.getProperty("java.io.tmpdir"), "sidecar-manifests-" + System.nanoTime()));
+  }
+
+  /**
+   * Creates a new session for {@code (key, sessionId, seed)} or returns the existing one if
+   * {@code sessionId} already exists.
+   *
+   * @param key      the (gameId, nation) pair
+   * @param sessionId deterministic ID supplied by the caller ({@code matchID:nation})
+   * @param seed     randomness seed for ProAi
+   * @return a {@link CreateResult} with the session and whether it was newly created
+   */
+  public synchronized CreateResult createOrGet(
+      final SessionKey key, final String sessionId, final long seed) {
+    final Session existing = byId.get(sessionId);
     if (existing != null) {
-      byId.remove(existing.sessionId());
-      existing.offensiveExecutor().shutdownNow();
+      return new CreateResult(existing, false);
     }
-    final GameData data = canonical.cloneForSession();
-    final ProAi proAi = new ProAi("sidecar-" + key.gameId() + "-" + key.nation(), key.nation());
-    final String id = "s-" + UUID.randomUUID();
-    final ExecutorService offensiveExecutor =
-        Executors.newSingleThreadExecutor(
-            r -> {
-              final Thread t = new Thread(r, "sidecar-offensive-" + id);
-              t.setDaemon(true);
-              return t;
-            });
-    final Session created =
-        new Session(id, key, seed, proAi, data, new ConcurrentHashMap<>(), offensiveExecutor);
-    byKey.put(key, created);
-    byId.put(id, created);
-    return created;
+    final Session created = buildSession(key, sessionId, seed);
+    register(created);
+    final long now = System.currentTimeMillis();
+    sessionStore.save(new SessionManifest(sessionId, key.gameId(), key.nation(), seed, now, now));
+    updatedAtMap.put(key, now);
+    return new CreateResult(created, true);
+  }
+
+  /**
+   * Rehydrates sessions from disk. Call once at startup before accepting requests.
+   * Sessions already in memory (e.g. from a test) are not overwritten.
+   */
+  public synchronized void rehydrate() {
+    final List<SessionManifest> manifests = sessionStore.loadAll();
+    for (final SessionManifest m : manifests) {
+      final SessionKey key = new SessionKey(m.gameId(), m.nation());
+      if (byId.containsKey(m.sessionId())) {
+        continue; // already present — skip
+      }
+      final Session session = buildSession(key, m.sessionId(), m.seed());
+      register(session);
+      updatedAtMap.put(key, m.updatedAt());
+    }
   }
 
   public ProSessionSnapshotStore snapshotStore() {
@@ -67,8 +121,75 @@ public final class SessionRegistry {
       return false;
     }
     byKey.remove(removed.key(), removed);
+    updatedAtMap.remove(removed.key());
     removed.offensiveExecutor().shutdownNow();
     snapshotStore.delete(removed.key());
+    sessionStore.delete(removed.key());
     return true;
   }
+
+  public synchronized void deleteByKey(final SessionKey key) {
+    final Session session = byKey.get(key);
+    if (session != null) {
+      delete(session.sessionId());
+    }
+  }
+
+  /** Updates the on-disk and in-memory updatedAt for a session. Called by lifecycle handler. */
+  public void touchUpdatedAt(final SessionKey key) {
+    final long now = System.currentTimeMillis();
+    updatedAtMap.put(key, now);
+    sessionStore.updateTimestamp(key, now);
+  }
+
+  /**
+   * Returns all session keys whose {@code updatedAt} is strictly before {@code beforeMs}.
+   * Used by {@link SessionReaper}.
+   */
+  public List<SessionKey> findStale(final long beforeMs) {
+    final List<SessionKey> stale = new ArrayList<>();
+    for (final java.util.Map.Entry<SessionKey, Long> e : updatedAtMap.entrySet()) {
+      if (e.getValue() < beforeMs) {
+        stale.add(e.getKey());
+      }
+    }
+    return stale;
+  }
+
+  /** Returns the number of live sessions. Used in tests. */
+  public int sessionCount() {
+    return byId.size();
+  }
+
+  /**
+   * Test-only: override the updatedAt for a session key to simulate staleness.
+   * Also updates the on-disk manifest so that reaper can read it.
+   */
+  public void setUpdatedAtForTesting(final SessionKey key, final long updatedAt) {
+    updatedAtMap.put(key, updatedAt);
+    sessionStore.updateTimestamp(key, updatedAt);
+  }
+
+  // --- private helpers ---
+
+  private Session buildSession(final SessionKey key, final String sessionId, final long seed) {
+    final GameData data = canonical.cloneForSession();
+    final ProAi proAi = new ProAi("sidecar-" + key.gameId() + "-" + key.nation(), key.nation());
+    final ExecutorService offensiveExecutor =
+        Executors.newSingleThreadExecutor(
+            r -> {
+              final Thread t = new Thread(r, "sidecar-offensive-" + sessionId);
+              t.setDaemon(true);
+              return t;
+            });
+    return new Session(sessionId, key, seed, proAi, data, new ConcurrentHashMap<>(), offensiveExecutor);
+  }
+
+  private void register(final Session session) {
+    byKey.put(session.key(), session);
+    byId.put(session.sessionId(), session);
+  }
+
+  /** Result of {@link #createOrGet}. */
+  public record CreateResult(Session session, boolean created) {}
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionStore.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionStore.java
@@ -1,0 +1,110 @@
+package org.triplea.ai.sidecar.session;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Persists {@link SessionManifest} records to
+ * {@code <dataDir>/<gameId>/<nation>.json} using atomic rename.
+ *
+ * <p>Thread safety: callers are responsible for serialising writes to the same
+ * {@code (gameId, nation)} key. SessionRegistry's per-instance lock is
+ * sufficient — only one thread ever calls {@code save} or {@code delete} for
+ * a given key at a time.
+ */
+public final class SessionStore {
+
+  private static final System.Logger LOG =
+      System.getLogger(SessionStore.class.getName());
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final Path dataDir;
+
+  public SessionStore(final Path dataDir) {
+    this.dataDir = dataDir;
+  }
+
+  /**
+   * Writes {@code manifest} to disk atomically. Creates parent directories as needed.
+   */
+  public void save(final SessionManifest manifest) {
+    final Path target = pathFor(new SessionKey(manifest.gameId(), manifest.nation()));
+    final Path tmp = target.resolveSibling(target.getFileName() + ".tmp");
+    try {
+      Files.createDirectories(target.getParent());
+      MAPPER.writeValue(tmp.toFile(), manifest);
+      try {
+        Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+      } catch (final AtomicMoveNotSupportedException ex) {
+        Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } catch (final IOException e) {
+      LOG.log(System.Logger.Level.WARNING, "Failed to save session manifest " + manifest.sessionId(), e);
+      try { Files.deleteIfExists(tmp); } catch (final IOException ignored) {}
+    }
+  }
+
+  /**
+   * Updates only the {@code updatedAt} timestamp in the stored manifest.
+   * No-op if no manifest file exists for the key.
+   */
+  public void updateTimestamp(final SessionKey key, final long updatedAt) {
+    final Path target = pathFor(key);
+    if (!Files.exists(target)) {
+      return;
+    }
+    try {
+      final SessionManifest existing = MAPPER.readValue(target.toFile(), SessionManifest.class);
+      save(existing.withUpdatedAt(updatedAt));
+    } catch (final IOException e) {
+      LOG.log(System.Logger.Level.WARNING, "Failed to update timestamp for " + key, e);
+    }
+  }
+
+  /** Deletes the manifest file for {@code key}. No-op if not present. */
+  public void delete(final SessionKey key) {
+    try {
+      Files.deleteIfExists(pathFor(key));
+    } catch (final IOException e) {
+      LOG.log(System.Logger.Level.WARNING, "Failed to delete session manifest for " + key, e);
+    }
+  }
+
+  /**
+   * Loads all session manifests from the data directory tree.
+   * Returns an empty list if the directory does not exist or contains no valid files.
+   */
+  public List<SessionManifest> loadAll() {
+    final List<SessionManifest> result = new ArrayList<>();
+    if (!Files.isDirectory(dataDir)) {
+      return result;
+    }
+    try {
+      Files.walk(dataDir)
+          .filter(p -> p.toString().endsWith(".json") && !p.toString().endsWith(".tmp"))
+          .forEach(p -> {
+            try {
+              result.add(MAPPER.readValue(p.toFile(), SessionManifest.class));
+            } catch (final IOException e) {
+              LOG.log(System.Logger.Level.WARNING, "Skipping unreadable session manifest: " + p, e);
+            }
+          });
+    } catch (final IOException e) {
+      LOG.log(System.Logger.Level.WARNING, "Failed to walk session data directory", e);
+    }
+    return result;
+  }
+
+  private Path pathFor(final SessionKey key) {
+    // Sanitize to avoid path traversal.
+    final String safeGameId = key.gameId().replaceAll("[^A-Za-z0-9\\-]", "_");
+    final String safeNation = key.nation().replaceAll("[^A-Za-z0-9]", "_");
+    return dataDir.resolve(safeGameId).resolve(safeNation + ".json");
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionStore.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionStore.java
@@ -86,7 +86,11 @@ public final class SessionStore {
       return result;
     }
     try {
-      Files.walk(dataDir)
+      // Only read files at exactly depth 2 (dataDir/{gameId}/{nation}.json).
+      // The snapshots/ subdirectory (written by ProSessionSnapshotStore) is at depth 1
+      // and its files are a different schema — skip them by constraining the walk depth.
+      Files.walk(dataDir, 2)
+          .filter(p -> p.getNameCount() == dataDir.getNameCount() + 2)
           .filter(p -> p.toString().endsWith(".json") && !p.toString().endsWith(".tmp"))
           .forEach(p -> {
             try {

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/SessionCreateRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/SessionCreateRequest.java
@@ -1,3 +1,10 @@
 package org.triplea.ai.sidecar.wire;
 
-public record SessionCreateRequest(String gameId, String nation, long seed) {}
+/**
+ * v2 session-create request.
+ *
+ * <p>{@code sessionId} is deterministic and supplied by the caller as
+ * {@code matchID:nation}. It must equal {@code gameId + ":" + nation};
+ * the handler returns 400 if it does not.
+ */
+public record SessionCreateRequest(String sessionId, String gameId, String nation, long seed) {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/SessionCreateResponse.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/SessionCreateResponse.java
@@ -1,3 +1,9 @@
 package org.triplea.ai.sidecar.wire;
 
-public record SessionCreateResponse(String sessionId) {}
+/**
+ * v2 session-create response.
+ *
+ * <p>{@code created} is {@code true} if a new session was written to disk,
+ * {@code false} if an existing session was found (idempotent re-open).
+ */
+public record SessionCreateResponse(String sessionId, boolean created) {}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/Phase2DefensiveDecisionsIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/Phase2DefensiveDecisionsIntegrationTest.java
@@ -58,20 +58,19 @@ class Phase2DefensiveDecisionsIntegrationTest {
     // Create a session for the DEFENDER — production path: defender is queried while the
     // attacker holds the top-level turn (ctx.currentPlayer = attacker) and the defender is
     // in an activePlayers stage.
+    final String gameId = "integration-defensive";
+    sessionId = gameId + ":" + DEFENDER;
     final HttpResponse<String> create =
         client.send(
-            HttpRequest.newBuilder(URI.create(base + "/session"))
+            HttpRequest.newBuilder(URI.create(base + "/sessions"))
                 .header("Authorization", auth)
                 .POST(
                     HttpRequest.BodyPublishers.ofString(
-                        "{\"gameId\":\"integration-defensive\",\"nation\":\""
-                            + DEFENDER
-                            + "\",\"seed\":42}"))
+                        "{\"sessionId\":\"" + sessionId + "\",\"gameId\":\"" + gameId
+                            + "\",\"nation\":\"" + DEFENDER + "\",\"seed\":42}"))
                 .build(),
             HttpResponse.BodyHandlers.ofString());
     assertEquals(200, create.statusCode(), "Session create must return 200");
-    sessionId = extractField(create.body(), "sessionId");
-    assertNotNull(sessionId, "sessionId must be present in create response");
   }
 
   @AfterAll

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/Phase3PurchaseIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/Phase3PurchaseIntegrationTest.java
@@ -74,20 +74,19 @@ class Phase3PurchaseIntegrationTest {
     base = "http://127.0.0.1:" + port;
     auth = "Bearer dev-token";
 
+    final String gameId = "integration-purchase";
+    sessionId = gameId + ":" + NATION;
     final HttpResponse<String> create =
         client.send(
-            HttpRequest.newBuilder(URI.create(base + "/session"))
+            HttpRequest.newBuilder(URI.create(base + "/sessions"))
                 .header("Authorization", auth)
                 .POST(
                     HttpRequest.BodyPublishers.ofString(
-                        "{\"gameId\":\"integration-purchase\",\"nation\":\""
-                            + NATION
-                            + "\",\"seed\":42}"))
+                        "{\"sessionId\":\"" + sessionId + "\",\"gameId\":\"" + gameId
+                            + "\",\"nation\":\"" + NATION + "\",\"seed\":42}"))
                 .build(),
             HttpResponse.BodyHandlers.ofString());
     assertEquals(200, create.statusCode(), "Session create must return 200");
-    sessionId = extractField(create.body(), "sessionId");
-    assertNotNull(sessionId, "sessionId must be present in create response");
   }
 
   @AfterAll

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarConfigTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarConfigTest.java
@@ -13,6 +13,8 @@ class SidecarConfigTest {
     assertEquals(8099, c.port());
     assertEquals(4, c.workerCount());
     assertEquals("dev-token", c.authToken());
+    assertEquals("data/sessions", c.dataDir());
+    assertEquals(null, c.serverUrl());
   }
 
   @Test

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarIntegrationTest.java
@@ -8,10 +8,12 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
 import org.triplea.ai.sidecar.http.HttpService;
 
@@ -23,6 +25,8 @@ class SidecarIntegrationTest {
       "{\"kind\":\"purchase\",\"state\":{\"territories\":[],\"players\":[],\"round\":1,"
           + "\"phase\":\"purchase\",\"currentPlayer\":\"Germans\"}}";
 
+  @TempDir Path tempDir;
+
   @BeforeAll
   static void initPrefs() {
     ClientSetting.setPreferences(new MemoryPreferences());
@@ -31,7 +35,10 @@ class SidecarIntegrationTest {
   @Test
   void fullLifecycleRoundTrip() throws Exception {
     final HttpService svc =
-        SidecarMain.startForTest(Map.of("SIDECAR_BIND_HOST", "127.0.0.1", "SIDECAR_PORT", "0"));
+        SidecarMain.startForTest(Map.of(
+            "SIDECAR_BIND_HOST", "127.0.0.1",
+            "SIDECAR_PORT", "0",
+            "SIDECAR_DATA_DIR", tempDir.toString()));
     try {
       final int port = svc.boundPort();
       final HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarIntegrationTest.java
@@ -38,17 +38,18 @@ class SidecarIntegrationTest {
       final String base = "http://127.0.0.1:" + port;
       final String auth = "Bearer dev-token";
 
-      // 1. create
+      // 1. create via v2 /sessions endpoint (deterministic sessionId)
       final HttpResponse<String> create =
           client.send(
-              HttpRequest.newBuilder(URI.create(base + "/session"))
+              HttpRequest.newBuilder(URI.create(base + "/sessions"))
                   .header("Authorization", auth)
                   .POST(HttpRequest.BodyPublishers.ofString(
-                      "{\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}"))
+                      "{\"sessionId\":\"g-1:Germans\",\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}"))
                   .build(),
               HttpResponse.BodyHandlers.ofString());
       assertEquals(200, create.statusCode());
-      final String sessionId = extractSessionId(create.body());
+      assertTrue(create.body().contains("\"created\":true"));
+      final String sessionId = "g-1:Germans"; // deterministic — no extraction needed
 
       // 2. update
       final HttpResponse<String> update =
@@ -96,9 +97,4 @@ class SidecarIntegrationTest {
     }
   }
 
-  private static String extractSessionId(final String body) {
-    final int start = body.indexOf("\"sessionId\":\"") + "\"sessionId\":\"".length();
-    final int end = body.indexOf('"', start);
-    return body.substring(start, end);
-  }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarMainIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarMainIntegrationTest.java
@@ -39,14 +39,14 @@ class SidecarMainIntegrationTest {
 
       final HttpResponse<String> create =
           client.send(
-              HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/session"))
+              HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/sessions"))
                   .header("Authorization", "Bearer dev-token")
                   .POST(HttpRequest.BodyPublishers.ofString(
-                      "{\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}"))
+                      "{\"sessionId\":\"g-1:Germans\",\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}"))
                   .build(),
               HttpResponse.BodyHandlers.ofString());
       assertEquals(200, create.statusCode());
-      assertTrue(create.body().contains("\"sessionId\""));
+      assertTrue(create.body().contains("\"sessionId\":\"g-1:Germans\""));
     } finally {
       svc.stop();
     }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarPersistenceIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarPersistenceIntegrationTest.java
@@ -1,0 +1,79 @@
+package org.triplea.ai.sidecar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import games.strategy.triplea.settings.ClientSetting;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.http.HttpService;
+
+/**
+ * Integration test: sessions persist to disk and rehydrate after a sidecar "restart"
+ * (creating a new HttpService instance with the same data directory).
+ */
+class SidecarPersistenceIntegrationTest {
+
+  @TempDir Path dataDir;
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+  }
+
+  @Test
+  void sessionSurvivesRestart() throws Exception {
+    final Map<String, String> env = Map.of(
+        "SIDECAR_BIND_HOST", "127.0.0.1",
+        "SIDECAR_PORT", "0",
+        "SIDECAR_DATA_DIR", dataDir.toString());
+    final HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+
+    // --- First sidecar instance ---
+    final HttpService svc1 = SidecarMain.startForTest(env);
+    final int port1 = svc1.boundPort();
+    try {
+      // Create session
+      final HttpResponse<String> create = client.send(
+          HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port1 + "/sessions"))
+              .header("Authorization", "Bearer dev-token")
+              .POST(HttpRequest.BodyPublishers.ofString(
+                  "{\"sessionId\":\"m1:Germans\",\"gameId\":\"m1\",\"nation\":\"Germans\",\"seed\":42}"))
+              .build(),
+          HttpResponse.BodyHandlers.ofString());
+      assertEquals(200, create.statusCode());
+      assertTrue(create.body().contains("\"created\":true"));
+    } finally {
+      svc1.stop();
+    }
+
+    // --- Second sidecar instance (same data dir = simulated restart) ---
+    final HttpService svc2 = SidecarMain.startForTest(env);
+    final int port2 = svc2.boundPort();
+    try {
+      // Re-open session — should return created=false (rehydrated from disk)
+      final HttpResponse<String> reopen = client.send(
+          HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port2 + "/sessions"))
+              .header("Authorization", "Bearer dev-token")
+              .POST(HttpRequest.BodyPublishers.ofString(
+                  "{\"sessionId\":\"m1:Germans\",\"gameId\":\"m1\",\"nation\":\"Germans\",\"seed\":42}"))
+              .build(),
+          HttpResponse.BodyHandlers.ofString());
+      assertEquals(200, reopen.statusCode());
+      assertTrue(
+          reopen.body().contains("\"created\":false"),
+          "expected created=false after restart, got: " + reopen.body());
+    } finally {
+      svc2.stop();
+    }
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerPurchaseTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerPurchaseTest.java
@@ -53,7 +53,7 @@ class DecisionHandlerPurchaseTest {
   }
 
   private Session newSession(final SessionRegistry registry) {
-    return registry.createOrGet(new SessionKey("g-purchase-test", "Germans"), 42L);
+    return registry.createOrGet(new SessionKey("g-purchase-test", "Germans"), "g-purchase-test:Germans", 42L).session();
   }
 
   /**

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
@@ -64,7 +64,7 @@ class DecisionHandlerTest {
   }
 
   private Session newSession(final SessionRegistry registry) {
-    return registry.createOrGet(new SessionKey("g-1", "Germans"), 42L);
+    return registry.createOrGet(new SessionKey("g-1", "Germans"), "g-1:Germans", 42L).session();
   }
 
   private static DecisionHandler handler(

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerWireFormatTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerWireFormatTest.java
@@ -95,7 +95,7 @@ class DecisionHandlerWireFormatTest {
   }
 
   private Session newSession(final SessionRegistry registry) {
-    return registry.createOrGet(new SessionKey("g-1", "Germans"), 42L);
+    return registry.createOrGet(new SessionKey("g-1", "Germans"), "g-1:Germans", 42L).session();
   }
 
   private DecisionHandler stubHandler(

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/HttpServiceTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/HttpServiceTest.java
@@ -25,7 +25,7 @@ class HttpServiceTest {
 
   @Test
   void healthEndpointReturns200OverHttp() throws Exception {
-    final SidecarConfig cfg = new SidecarConfig("127.0.0.1", 0, 2, "test-token");
+    final SidecarConfig cfg = new SidecarConfig("127.0.0.1", 0, 2, "test-token", "data/sessions", null);
     final SessionRegistry reg = new SessionRegistry(CanonicalGameData.load());
     final HttpService svc = HttpService.start(cfg, reg);
     try {
@@ -43,8 +43,8 @@ class HttpServiceTest {
   }
 
   @Test
-  void sessionEndpointRequiresAuth() throws Exception {
-    final SidecarConfig cfg = new SidecarConfig("127.0.0.1", 0, 2, "test-token");
+  void sessionsEndpointRequiresAuth() throws Exception {
+    final SidecarConfig cfg = new SidecarConfig("127.0.0.1", 0, 2, "test-token", "data/sessions", null);
     final SessionRegistry reg = new SessionRegistry(CanonicalGameData.load());
     final HttpService svc = HttpService.start(cfg, reg);
     try {
@@ -52,21 +52,23 @@ class HttpServiceTest {
       final HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
       final HttpResponse<String> unauth =
           client.send(
-              HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/session"))
-                  .POST(HttpRequest.BodyPublishers.ofString("{\"gameId\":\"g\",\"nation\":\"Germans\",\"seed\":1}"))
+              HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/sessions"))
+                  .POST(HttpRequest.BodyPublishers.ofString(
+                      "{\"sessionId\":\"g:Germans\",\"gameId\":\"g\",\"nation\":\"Germans\",\"seed\":1}"))
                   .build(),
               HttpResponse.BodyHandlers.ofString());
       assertEquals(401, unauth.statusCode());
 
       final HttpResponse<String> ok =
           client.send(
-              HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/session"))
+              HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/sessions"))
                   .header("Authorization", "Bearer test-token")
-                  .POST(HttpRequest.BodyPublishers.ofString("{\"gameId\":\"g\",\"nation\":\"Germans\",\"seed\":1}"))
+                  .POST(HttpRequest.BodyPublishers.ofString(
+                      "{\"sessionId\":\"g:Germans\",\"gameId\":\"g\",\"nation\":\"Germans\",\"seed\":1}"))
                   .build(),
               HttpResponse.BodyHandlers.ofString());
       assertEquals(200, ok.statusCode());
-      assertTrue(ok.body().contains("\"sessionId\""));
+      assertTrue(ok.body().contains("\"sessionId\":\"g:Germans\""));
     } finally {
       svc.stop();
     }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/JsonBodiesTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/JsonBodiesTest.java
@@ -11,14 +11,17 @@ class JsonBodiesTest {
   void readValueParsesKnownDto() throws Exception {
     final SessionCreateRequest r =
         JsonBodies.readValue(
-            "{\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":7}", SessionCreateRequest.class);
+            "{\"sessionId\":\"g-1:Germans\",\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":7}",
+            SessionCreateRequest.class);
+    assertEquals("g-1:Germans", r.sessionId());
     assertEquals("g-1", r.gameId());
   }
 
   @Test
   void writeValueSerializes() throws Exception {
-    final String s = JsonBodies.writeValue(new SessionCreateRequest("g-1", "Germans", 7));
+    final String s = JsonBodies.writeValue(new SessionCreateRequest("g-1:Germans", "g-1", "Germans", 7));
     assertTrue(s.contains("\"gameId\":\"g-1\""));
+    assertTrue(s.contains("\"sessionId\":\"g-1:Germans\""));
   }
 
   @Test

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/SessionCreateHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/SessionCreateHandlerTest.java
@@ -23,17 +23,20 @@ class SessionCreateHandlerTest {
     final SessionCreateHandler h = new SessionCreateHandler(registry);
     final FakeHttpExchange ex =
         new FakeHttpExchange(
-            "POST", "/session", "{\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}");
+            "POST",
+            "/sessions",
+            "{\"sessionId\":\"g-1:Germans\",\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}");
     h.handle(ex);
     assertEquals(200, ex.responseCode());
-    assertTrue(ex.responseBodyString().contains("\"sessionId\":\"s-"));
+    assertTrue(ex.responseBodyString().contains("\"sessionId\":\"g-1:Germans\""));
+    assertTrue(ex.responseBodyString().contains("\"created\":true"));
   }
 
   @Test
   void rejectsNonPost() throws Exception {
     final SessionCreateHandler h =
         new SessionCreateHandler(new SessionRegistry(CanonicalGameData.load()));
-    final FakeHttpExchange ex = new FakeHttpExchange("GET", "/session", null);
+    final FakeHttpExchange ex = new FakeHttpExchange("GET", "/sessions", null);
     h.handle(ex);
     assertEquals(405, ex.responseCode());
   }
@@ -42,20 +45,24 @@ class SessionCreateHandlerTest {
   void rejectsMalformedBody() throws Exception {
     final SessionCreateHandler h =
         new SessionCreateHandler(new SessionRegistry(CanonicalGameData.load()));
-    final FakeHttpExchange ex = new FakeHttpExchange("POST", "/session", "not-json");
+    final FakeHttpExchange ex = new FakeHttpExchange("POST", "/sessions", "not-json");
     h.handle(ex);
     assertEquals(400, ex.responseCode());
   }
 
   @Test
-  void idempotentCreateReturnsSameId() throws Exception {
+  void idempotentCreateReturnsSameIdAndFalse() throws Exception {
     final SessionRegistry registry = new SessionRegistry(CanonicalGameData.load());
     final SessionCreateHandler h = new SessionCreateHandler(registry);
-    final String body = "{\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}";
-    final FakeHttpExchange ex1 = new FakeHttpExchange("POST", "/session", body);
+    final String body =
+        "{\"sessionId\":\"g-1:Germans\",\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}";
+    final FakeHttpExchange ex1 = new FakeHttpExchange("POST", "/sessions", body);
     h.handle(ex1);
-    final FakeHttpExchange ex2 = new FakeHttpExchange("POST", "/session", body);
+    assertTrue(ex1.responseBodyString().contains("\"created\":true"));
+
+    final FakeHttpExchange ex2 = new FakeHttpExchange("POST", "/sessions", body);
     h.handle(ex2);
-    assertEquals(ex1.responseBodyString(), ex2.responseBodyString());
+    assertTrue(ex2.responseBodyString().contains("\"sessionId\":\"g-1:Germans\""));
+    assertTrue(ex2.responseBodyString().contains("\"created\":false"));
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/SessionCreateHandlerV2Test.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/SessionCreateHandlerV2Test.java
@@ -1,0 +1,111 @@
+package org.triplea.ai.sidecar.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import games.strategy.triplea.settings.ClientSetting;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.session.SessionRegistry;
+import org.triplea.ai.sidecar.session.SessionStore;
+
+/**
+ * TDD tests for the v2 session-create contract:
+ * - sessionId is deterministic and supplied by the caller.
+ * - POST /sessions is idempotent: re-opening an existing session returns created=false.
+ * - sessionId is validated: must equal gameId + ":" + nation.
+ * - Sessions are persisted to disk after creation.
+ */
+class SessionCreateHandlerV2Test {
+
+  @TempDir Path dataDir;
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+  }
+
+  private SessionRegistry registry;
+  private SessionCreateHandler handler;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    registry = new SessionRegistry(CanonicalGameData.load(), dataDir);
+    handler = new SessionCreateHandler(registry);
+  }
+
+  @Test
+  void createsSessionWithDeterministicId() throws Exception {
+    final FakeHttpExchange ex =
+        new FakeHttpExchange(
+            "POST",
+            "/sessions",
+            "{\"sessionId\":\"g-1:Germans\",\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}");
+    handler.handle(ex);
+    assertEquals(200, ex.responseCode());
+    assertTrue(ex.responseBodyString().contains("\"sessionId\":\"g-1:Germans\""));
+    assertTrue(ex.responseBodyString().contains("\"created\":true"));
+  }
+
+  @Test
+  void idempotentOpenReturnsFalse() throws Exception {
+    final String body =
+        "{\"sessionId\":\"g-1:Germans\",\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}";
+    final FakeHttpExchange ex1 = new FakeHttpExchange("POST", "/sessions", body);
+    handler.handle(ex1);
+    assertTrue(ex1.responseBodyString().contains("\"created\":true"));
+
+    final FakeHttpExchange ex2 = new FakeHttpExchange("POST", "/sessions", body);
+    handler.handle(ex2);
+    assertEquals(200, ex2.responseCode());
+    assertTrue(ex2.responseBodyString().contains("\"sessionId\":\"g-1:Germans\""));
+    assertTrue(ex2.responseBodyString().contains("\"created\":false"));
+  }
+
+  @Test
+  void rejectsSessionIdMismatch() throws Exception {
+    final FakeHttpExchange ex =
+        new FakeHttpExchange(
+            "POST",
+            "/sessions",
+            "{\"sessionId\":\"wrong:Germans\",\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}");
+    handler.handle(ex);
+    assertEquals(400, ex.responseCode());
+    assertTrue(ex.responseBodyString().contains("sessionId"));
+  }
+
+  @Test
+  void rejectsMissingSessionId() throws Exception {
+    // v1 body without sessionId — must be rejected by v2 handler
+    final FakeHttpExchange ex =
+        new FakeHttpExchange(
+            "POST",
+            "/sessions",
+            "{\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}");
+    handler.handle(ex);
+    assertEquals(400, ex.responseCode());
+  }
+
+  @Test
+  void persistsSessionToDisk() throws Exception {
+    final FakeHttpExchange ex =
+        new FakeHttpExchange(
+            "POST",
+            "/sessions",
+            "{\"sessionId\":\"g-1:Germans\",\"gameId\":\"g-1\",\"nation\":\"Germans\",\"seed\":42}");
+    handler.handle(ex);
+    assertEquals(200, ex.responseCode());
+
+    // Session manifest should exist at dataDir/g-1/Germans.json
+    final Path manifest = dataDir.resolve("g-1").resolve("Germans.json");
+    assertTrue(Files.exists(manifest), "manifest file not written at " + manifest);
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/SessionLifecycleHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/SessionLifecycleHandlerTest.java
@@ -26,7 +26,7 @@ class SessionLifecycleHandlerTest {
   @Test
   void updateReturns204ForKnownSession() throws Exception {
     final SessionRegistry registry = new SessionRegistry(CanonicalGameData.load());
-    final Session s = registry.createOrGet(new SessionKey("g-1", "Germans"), 42L);
+    final Session s = registry.createOrGet(new SessionKey("g-1", "Germans"), "g-1:Germans", 42L).session();
     final SessionLifecycleHandler h = new SessionLifecycleHandler(registry);
     final FakeHttpExchange ex =
         new FakeHttpExchange("POST", "/session/" + s.sessionId() + "/update", UPDATE_BODY);
@@ -46,7 +46,7 @@ class SessionLifecycleHandlerTest {
   @Test
   void updateRejectsMalformedBody() throws Exception {
     final SessionRegistry registry = new SessionRegistry(CanonicalGameData.load());
-    final Session s = registry.createOrGet(new SessionKey("g-1", "Germans"), 42L);
+    final Session s = registry.createOrGet(new SessionKey("g-1", "Germans"), "g-1:Germans", 42L).session();
     final SessionLifecycleHandler h = new SessionLifecycleHandler(registry);
     final FakeHttpExchange ex =
         new FakeHttpExchange("POST", "/session/" + s.sessionId() + "/update", "not-json");
@@ -57,7 +57,7 @@ class SessionLifecycleHandlerTest {
   @Test
   void deleteReturns204ForKnownSession() throws Exception {
     final SessionRegistry registry = new SessionRegistry(CanonicalGameData.load());
-    final Session s = registry.createOrGet(new SessionKey("g-1", "Germans"), 42L);
+    final Session s = registry.createOrGet(new SessionKey("g-1", "Germans"), "g-1:Germans", 42L).session();
     final SessionLifecycleHandler h = new SessionLifecycleHandler(registry);
     final FakeHttpExchange ex = new FakeHttpExchange("DELETE", "/session/" + s.sessionId(), null);
     h.handle(ex);
@@ -77,7 +77,7 @@ class SessionLifecycleHandlerTest {
   @Test
   void rejectsUnknownMethod() throws Exception {
     final SessionRegistry registry = new SessionRegistry(CanonicalGameData.load());
-    final Session s = registry.createOrGet(new SessionKey("g-1", "Germans"), 42L);
+    final Session s = registry.createOrGet(new SessionKey("g-1", "Germans"), "g-1:Germans", 42L).session();
     final SessionLifecycleHandler h = new SessionLifecycleHandler(registry);
     final FakeHttpExchange ex = new FakeHttpExchange("PUT", "/session/" + s.sessionId(), null);
     h.handle(ex);

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/ProSessionSnapshotStoreTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/ProSessionSnapshotStoreTest.java
@@ -102,7 +102,7 @@ class ProSessionSnapshotStoreTest {
     final SessionRegistry registry =
         new SessionRegistry(org.triplea.ai.sidecar.CanonicalGameData.load(), store);
 
-    final Session session = registry.createOrGet(new SessionKey("g-1", "Germans"), 42L);
+    final Session session = registry.createOrGet(new SessionKey("g-1", "Germans"), "g-1:Germans", 42L).session();
     store.save(session.key(), emptySnapshot());
     assertTrue(store.load(session.key()).isPresent(), "snapshot should exist before delete");
 

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionOffensiveExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionOffensiveExecutorTest.java
@@ -20,7 +20,7 @@ class SessionOffensiveExecutorTest {
   @Test
   void sessionHasSingleThreadOffensiveExecutor() throws Exception {
     final SessionRegistry reg = new SessionRegistry(CanonicalGameData.load());
-    final Session s = reg.createOrGet(new SessionKey("g-1", "Germans"), 42L);
+    final Session s = reg.createOrGet(new SessionKey("g-1", "Germans"), "g-1:Germans", 42L).session();
     assertNotNull(s.offensiveExecutor());
     final Future<String> f =
         s.offensiveExecutor().submit(() -> Thread.currentThread().getName());

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionReaperTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionReaperTest.java
@@ -1,0 +1,62 @@
+package org.triplea.ai.sidecar.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import games.strategy.triplea.settings.ClientSetting;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+
+/**
+ * TDD tests for SessionReaper.
+ * - Sessions updated within 30 days are NOT reaped.
+ * - Sessions with updatedAt older than 30 days ARE reaped.
+ */
+class SessionReaperTest {
+
+  @TempDir Path dataDir;
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+  }
+
+  @Test
+  void doesNotReapRecentSession() throws Exception {
+    final long now = System.currentTimeMillis();
+    final SessionRegistry registry = new SessionRegistry(CanonicalGameData.load(), dataDir);
+    // Create a session — updatedAt = now
+    registry.createOrGet(new SessionKey("g-1", "Germans"), "g-1:Germans", 42L);
+
+    final Clock clock = Clock.fixed(Instant.ofEpochMilli(now), ZoneId.systemDefault());
+    final SessionReaper reaper = new SessionReaper(registry, clock, null);
+    reaper.runOnce();
+
+    assertEquals(1, registry.sessionCount(), "recent session should not be reaped");
+  }
+
+  @Test
+  void reapsStaleSession() throws Exception {
+    final long now = System.currentTimeMillis();
+    // Set updatedAt to 31 days ago
+    final long stalePast = now - TimeUnit.DAYS.toMillis(31);
+    final SessionRegistry registry = new SessionRegistry(CanonicalGameData.load(), dataDir);
+    registry.createOrGet(new SessionKey("g-1", "Germans"), "g-1:Germans", 42L);
+    // Override updatedAt to simulate staleness
+    registry.setUpdatedAtForTesting(new SessionKey("g-1", "Germans"), stalePast);
+
+    final Clock clock = Clock.fixed(Instant.ofEpochMilli(now), ZoneId.systemDefault());
+    final SessionReaper reaper = new SessionReaper(registry, clock, null);
+    reaper.runOnce();
+
+    assertEquals(0, registry.sessionCount(), "stale session should be reaped");
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionRegistryTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionRegistryTest.java
@@ -19,37 +19,44 @@ class SessionRegistryTest {
     ClientSetting.setPreferences(new MemoryPreferences());
   }
 
+  // Convenience helper: derives deterministic sessionId as gameId:nation
+  private static Session create(final SessionRegistry r, final SessionKey key, final long seed) {
+    return r.createOrGet(key, key.gameId() + ":" + key.nation(), seed).session();
+  }
+
   @Test
   void createReturnsNewSession() {
     final SessionRegistry r = new SessionRegistry(CanonicalGameData.load());
-    final Session s = r.createOrGet(new SessionKey("g-1", "Germans"), 42L);
-    assertNotNull(s.sessionId());
+    final Session s = create(r, new SessionKey("g-1", "Germans"), 42L);
+    assertEquals("g-1:Germans", s.sessionId());
     assertEquals("g-1", s.key().gameId());
     assertEquals("Germans", s.key().nation());
     assertEquals(42L, s.seed());
   }
 
   @Test
-  void createIsIdempotentOnGameIdNationSeed() {
+  void createIsIdempotentOnSessionId() {
     final SessionRegistry r = new SessionRegistry(CanonicalGameData.load());
-    final Session first = r.createOrGet(new SessionKey("g-1", "Germans"), 42L);
-    final Session second = r.createOrGet(new SessionKey("g-1", "Germans"), 42L);
+    final Session first = create(r, new SessionKey("g-1", "Germans"), 42L);
+    final Session second = create(r, new SessionKey("g-1", "Germans"), 42L);
     assertSame(first, second);
   }
 
   @Test
-  void differentSeedReplacesSession() {
+  void reopenWithSameSessionIdReturnsFalseCreated() {
     final SessionRegistry r = new SessionRegistry(CanonicalGameData.load());
-    final Session first = r.createOrGet(new SessionKey("g-1", "Germans"), 42L);
-    final Session second = r.createOrGet(new SessionKey("g-1", "Germans"), 99L);
-    assertEquals(99L, second.seed());
-    assertTrue(first != second);
+    final SessionKey key = new SessionKey("g-1", "Germans");
+    final SessionRegistry.CreateResult first = r.createOrGet(key, "g-1:Germans", 42L);
+    final SessionRegistry.CreateResult second = r.createOrGet(key, "g-1:Germans", 42L);
+    assertTrue(first.created());
+    assertTrue(!second.created());
+    assertSame(first.session(), second.session());
   }
 
   @Test
   void getBySessionIdReturnsSessionWhenPresent() {
     final SessionRegistry r = new SessionRegistry(CanonicalGameData.load());
-    final Session s = r.createOrGet(new SessionKey("g-1", "Germans"), 42L);
+    final Session s = create(r, new SessionKey("g-1", "Germans"), 42L);
     final Optional<Session> found = r.get(s.sessionId());
     assertTrue(found.isPresent());
     assertSame(s, found.get());
@@ -64,7 +71,7 @@ class SessionRegistryTest {
   @Test
   void deleteRemovesSession() {
     final SessionRegistry r = new SessionRegistry(CanonicalGameData.load());
-    final Session s = r.createOrGet(new SessionKey("g-1", "Germans"), 42L);
+    final Session s = create(r, new SessionKey("g-1", "Germans"), 42L);
     assertTrue(r.delete(s.sessionId()));
     assertTrue(r.get(s.sessionId()).isEmpty());
   }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionStoreTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionStoreTest.java
@@ -1,0 +1,85 @@
+package org.triplea.ai.sidecar.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * TDD tests for SessionStore disk persistence.
+ * - save/load round-trip
+ * - atomic rename (no .tmp left behind on save)
+ * - delete removes file
+ * - loadAll loads every manifest in the data dir
+ */
+class SessionStoreTest {
+
+  @TempDir Path dataDir;
+
+  @Test
+  void saveAndLoadRoundTrip() throws IOException {
+    final SessionStore store = new SessionStore(dataDir);
+    final SessionManifest manifest =
+        new SessionManifest("g-1:Germans", "g-1", "Germans", 42L, 1000L, 1000L);
+    store.save(manifest);
+
+    final List<SessionManifest> loaded = store.loadAll();
+    assertEquals(1, loaded.size());
+    final SessionManifest got = loaded.get(0);
+    assertEquals("g-1:Germans", got.sessionId());
+    assertEquals("g-1", got.gameId());
+    assertEquals("Germans", got.nation());
+    assertEquals(42L, got.seed());
+  }
+
+  @Test
+  void noTmpFilesLeftAfterSave() throws IOException {
+    final SessionStore store = new SessionStore(dataDir);
+    store.save(new SessionManifest("g-1:Germans", "g-1", "Germans", 42L, 1000L, 1000L));
+    final long tmpCount =
+        Files.walk(dataDir)
+            .filter(p -> p.toString().endsWith(".tmp"))
+            .count();
+    assertEquals(0, tmpCount, "temp files remain after save");
+  }
+
+  @Test
+  void deleteRemovesFile() throws IOException {
+    final SessionStore store = new SessionStore(dataDir);
+    store.save(new SessionManifest("g-1:Germans", "g-1", "Germans", 42L, 1000L, 1000L));
+    store.delete(new SessionKey("g-1", "Germans"));
+
+    final List<SessionManifest> after = store.loadAll();
+    assertTrue(after.isEmpty(), "manifest should be deleted");
+  }
+
+  @Test
+  void loadAllFindsMultipleManifests() throws IOException {
+    final SessionStore store = new SessionStore(dataDir);
+    store.save(new SessionManifest("g-1:Germans", "g-1", "Germans", 1L, 1000L, 1000L));
+    store.save(new SessionManifest("g-1:Russians", "g-1", "Russians", 2L, 1000L, 1000L));
+    store.save(new SessionManifest("g-2:Japanese", "g-2", "Japanese", 3L, 1000L, 1000L));
+
+    final List<SessionManifest> loaded = store.loadAll();
+    assertEquals(3, loaded.size());
+  }
+
+  @Test
+  void updateTimestampPreservesOtherFields() throws IOException {
+    final SessionStore store = new SessionStore(dataDir);
+    final long createdAt = 1000L;
+    store.save(new SessionManifest("g-1:Germans", "g-1", "Germans", 42L, createdAt, createdAt));
+    store.updateTimestamp(new SessionKey("g-1", "Germans"), 9999L);
+
+    final SessionManifest updated = store.loadAll().get(0);
+    assertEquals(createdAt, updated.createdAt(), "createdAt should not change on update");
+    assertEquals(9999L, updated.updatedAt(), "updatedAt should be refreshed");
+    assertEquals(42L, updated.seed(), "seed should not change on update");
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/RequestResponseDtoTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/RequestResponseDtoTest.java
@@ -12,16 +12,20 @@ class RequestResponseDtoTest {
   @Test
   void sessionCreateRequest() throws Exception {
     final SessionCreateRequest r =
-        om.readValue("{\"gameId\":\"m-8812\",\"nation\":\"Germans\",\"seed\":42}", SessionCreateRequest.class);
+        om.readValue(
+            "{\"sessionId\":\"m-8812:Germans\",\"gameId\":\"m-8812\",\"nation\":\"Germans\",\"seed\":42}",
+            SessionCreateRequest.class);
+    assertEquals("m-8812:Germans", r.sessionId());
     assertEquals("m-8812", r.gameId());
     assertEquals("Germans", r.nation());
     assertEquals(42L, r.seed());
   }
 
   @Test
-  void sessionCreateResponseSerializesSessionId() throws Exception {
-    final String json = om.writeValueAsString(new SessionCreateResponse("s-abc"));
-    assertTrue(json.contains("\"sessionId\":\"s-abc\""));
+  void sessionCreateResponseSerializesSessionIdAndCreated() throws Exception {
+    final String json = om.writeValueAsString(new SessionCreateResponse("m-1:Germans", true));
+    assertTrue(json.contains("\"sessionId\":\"m-1:Germans\""));
+    assertTrue(json.contains("\"created\":true"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- **Deterministic session ID**: `sessionId = matchID + ":" + nation` enforced by `SessionCreateHandler` (400 if mismatch). Idempotent `POST /sessions` — reopening an existing session returns `created: false` without reinitializing ProData.
- **Disk persistence**: `SessionManifest` written atomically to `data/sessions/{gameId}/{nation}.json` via tmp-rename. `SessionRegistry.rehydrate()` walks the directory on startup and restores all previously-created sessions from disk.
- **Session reaper**: `SessionReaper` runs a daemon thread every 5 minutes via `ScheduledExecutorService`. Reaps sessions with `updatedAt > 30 days` ago. Gameover check via `GET {serverUrl}/api/matches/{matchID}` is a **TODO** — `SIDECAR_SERVER_URL` is wired into `SidecarConfig` but the reaper only uses it as a guard; the full HTTP check is not yet implemented (flagged in code comment and below).
- **`/sessions` endpoint** (plural): replaces `/session` for create. Per-session ops remain at `/session/{id}/...`.
- **`SessionLifecycleHandler`**: calls `registry.touchUpdatedAt(key)` on `/update` so the reaper correctly tracks active sessions.

## Known gaps / follow-up

- **Gameover reaping**: `SessionReaper.runOnce()` has a `// TODO` block for calling `GET {serverUrl}/api/matches/{matchID}`. Until that is wired, stale-age-based reaping is the only cleanup path.
- **Docker publish**: this PR does not update `docker/docker-compose.dev.yaml` — that will follow in a separate map-room PR after this merges and the `ghcr.io/map-room/ai-sidecar:phase2-persistent` image is published.
- **`SIDECAR_SERVER_URL`** is not yet passed through to the docker-compose env block.

## Test plan

- [x] `SessionStoreTest` — save/load round-trip, no tmp files left, delete, loadAll, updateTimestamp
- [x] `SessionReaperTest` — does not reap recent session; reaps stale session
- [x] `SessionCreateHandlerV2Test` — creates session, idempotent reopen, mismatch rejection, disk persistence
- [x] `SidecarPersistenceIntegrationTest.sessionSurvivesRestart` — two sequential `HttpService` instances sharing the same `dataDir`; second instance rehydrates sessions from the first
- [x] All existing tests updated for new API signatures — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)