### PR TITLE
fix(ai-sidecar): apply WireUnit.movesUsed to TripleA Unit.alreadyMoved

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -272,12 +272,23 @@ public final class WireStateApplier {
               : wireOwner;
       final Unit existing = findUnitById(territory.getUnits(), uuid);
       final Unit unit;
+      final java.math.BigDecimal desiredAlreadyMoved = java.math.BigDecimal.valueOf(wu.movesUsed());
       if (existing != null) {
         unit = existing;
         if (wu.hitsTaken() != unit.getHits()) {
           // Route through ChangeFactory.unitsHit so game-data listeners fire. The IntegerMap
           // value is the absolute new hit count (ChangeFactory.unitsHit sets, not adds).
           existingUnitHitDeltas.put(unit, wu.hitsTaken());
+        }
+        // Pro AI's Non-Combat Move planner consults Unit.alreadyMoved when picking
+        // landing destinations for air units (movesLeft = maxMovementAllowed -
+        // alreadyMoved). Without this sync, every plane appears unmoved and the AI
+        // generates landings the engine rejects (e.g., a tac bomber with 1 move
+        // left planning a 5-hex landing).
+        if (unit.getAlreadyMoved().compareTo(desiredAlreadyMoved) != 0) {
+          out.add(
+              ChangeFactory.unitPropertyChange(
+                  unit, desiredAlreadyMoved, Unit.PropertyName.ALREADY_MOVED));
         }
       } else {
         unit = new Unit(uuid, type, unitOwner, gameData);
@@ -290,6 +301,11 @@ public final class WireStateApplier {
         if (wu.hitsTaken() != unit.getHits()) {
           // Safe: unit is not yet attached to any territory, no listeners to bypass.
           unit.setHits(wu.hitsTaken());
+        }
+        // Same rationale as the existing-unit branch above; safe to set directly
+        // because the unit is not yet attached to a territory.
+        if (unit.getAlreadyMoved().compareTo(desiredAlreadyMoved) != 0) {
+          unit.setAlreadyMoved(desiredAlreadyMoved);
         }
       }
       desired.add(unit);

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
@@ -373,6 +373,67 @@ class WireStateApplierTest {
   }
 
   @Test
+  void appliesMovesUsedToAlreadyMoved_newUnit() {
+    // Regression: WireUnit.movesUsed (the moves a unit has already spent this
+    // turn on the Map Room side) was parsed from JSON but never applied to
+    // TripleA's Unit.alreadyMoved field. Pro AI then planned movement as if
+    // every air unit had its full movement budget left, generating moves the
+    // engine rejects (e.g., trying to land a tac bomber 5 hexes away when
+    // only 1 move remains).
+    final GameData gd = fresh();
+    final WireState wire =
+        new WireState(
+            List.of(
+                new WireTerritory(
+                    "Germany",
+                    "Germans",
+                    List.of(new WireUnit("u-tac-1", "tactical_bomber", 0, 4)))),
+            List.of(),
+            1,
+            "noncombat",
+            "Germans");
+    WireStateApplier.apply(gd, wire, freshIdMap());
+    final Territory germany = gd.getMap().getTerritoryOrThrow("Germany");
+    final Unit tac = germany.getUnits().iterator().next();
+    assertThat(tac.getAlreadyMoved()).isEqualTo(new java.math.BigDecimal(4));
+  }
+
+  @Test
+  void appliesMovesUsedToAlreadyMoved_existingUnit() {
+    // Same regression, exercising the existing-unit branch (apply called twice
+    // with different movesUsed values for the same unitId).
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    final WireState first =
+        new WireState(
+            List.of(
+                new WireTerritory(
+                    "Germany",
+                    "Germans",
+                    List.of(new WireUnit("u-fighter-1", "fighter", 0, 0)))),
+            List.of(),
+            1,
+            "combat",
+            "Germans");
+    WireStateApplier.apply(gd, first, idMap);
+    final WireState second =
+        new WireState(
+            List.of(
+                new WireTerritory(
+                    "Germany",
+                    "Germans",
+                    List.of(new WireUnit("u-fighter-1", "fighter", 0, 3)))),
+            List.of(),
+            1,
+            "noncombat",
+            "Germans");
+    WireStateApplier.apply(gd, second, idMap);
+    final Territory germany = gd.getMap().getTerritoryOrThrow("Germany");
+    final Unit fighter = germany.getUnits().iterator().next();
+    assertThat(fighter.getAlreadyMoved()).isEqualTo(new java.math.BigDecimal(3));
+  }
+
+  @Test
   void techFlag_setsAttachmentProperty() {
     final GameData gd = fresh();
     final WireState wire =


### PR DESCRIPTION
## Summary

\`WireStateApplier\` parsed \`WireUnit.movesUsed\` from JSON but never propagated it to TripleA's \`Unit.alreadyMoved\` field. Pro AI's Non-Combat Move planner consults \`alreadyMoved\` when picking landing destinations for air units (movesLeft = \`maxMovementAllowed - alreadyMoved\`). With every unit appearing unmoved, the planner generated landings the Map Room engine then rejected at \`endMovement\`.

Reproducer (from a real game): tactical bomber with 1 movement left being routed 5 hexes away by Pro AI.

## Fix

Set \`unit.alreadyMoved = BigDecimal.valueOf(wu.movesUsed())\` on both the new-unit and existing-unit paths in \`applyTerritory\`:
- **Existing units** route through \`ChangeFactory.unitPropertyChange(unit, ..., Unit.PropertyName.ALREADY_MOVED)\` so game-data listeners fire.
- **New units** use the direct setter (safe because the unit isn't attached to a territory yet, so no listeners to bypass — same pattern the existing hits sync uses on line 290-293).

## Tests

Two regression tests in \`WireStateApplierTest\`:
- \`appliesMovesUsedToAlreadyMoved_newUnit\` — wire ships a tactical_bomber with movesUsed=4; expect \`unit.getAlreadyMoved()\` = 4.
- \`appliesMovesUsedToAlreadyMoved_existingUnit\` — apply the same fighter twice with different movesUsed values; second apply must overwrite the first.

Both fail before the change (expected 4/3, got 0). Both pass after.

\`\`\`
./gradlew :game-app:ai-sidecar:test
BUILD SUCCESSFUL
\`\`\`

## Test plan

- [x] Two new regression tests for new-unit and existing-unit branches
- [x] Full ai-sidecar test suite still passes
- [ ] 🧑 Manual: deploy with map-room PR #1823 (which serializes \`conqueredThisTurn\`) and verify Germany clears noncombat-move cleanly with all air landings within remaining movement range.

## Pairs with

map-room/map-room#1823 — that PR populates \`WireTerritory.conqueredThisTurn\`. This PR makes the sidecar respect \`movesUsed\`. Together they close the gap that left the bot stuck after a fresh capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)