### PR TITLE
fix(ai-sidecar): drop placement captures at conquered-this-turn territories

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PlaceExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PlaceExecutor.java
@@ -2,12 +2,16 @@ package org.triplea.ai.sidecar.exec;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.delegate.battle.BattleTracker;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.triplea.ai.sidecar.dto.PlaceOrder;
@@ -113,11 +117,41 @@ public final class PlaceExecutor implements DecisionExecutor<PlaceRequest, Place
       throw new RuntimeException("PlaceExecutor failed", cause);
     }
 
-    // Group captures by territory name (land-first order is preserved because ProPurchaseAi
-    // iterates land territories before sea territories).
+    // The map-room engine rejects placement at any territory captured this turn
+    // (rules §16/§20: a freshly captured factory cannot produce in the same turn).
+    // Pro AI's purchase planner does not consult wasConquered when picking placement
+    // targets, and RecordingPlaceDelegate accepts every placeUnits call without
+    // validation — so without this filter, freshly conquered territories show up in
+    // the plan and the engine rejects the whole place phase, leaving the bot stuck.
+    final Set<Territory> conqueredThisTurn = collectConqueredThisTurn(data);
+
+    return groupCapturesIntoPlan(recorder.captured(), conqueredThisTurn, session.key().toString());
+  }
+
+  static Set<Territory> collectConqueredThisTurn(final GameData data) {
+    if (data.getBattleDelegate() == null) {
+      return Set.of();
+    }
+    final BattleTracker tracker = data.getBattleDelegate().getBattleTracker();
+    return new HashSet<>(tracker.getConquered());
+  }
+
+  /**
+   * Groups recorded placeUnits captures into a {@link PlacePlan}, dropping any capture whose
+   * territory was conquered this turn. Public-package for direct unit testing.
+   */
+  static PlacePlan groupCapturesIntoPlan(
+      final List<RecordingPlaceDelegate.PlaceCapture> captures,
+      final Set<Territory> conqueredThisTurn,
+      final String sessionKey) {
     final Map<String, List<String>> byTerritory = new LinkedHashMap<>();
     int totalCaptured = 0;
-    for (final RecordingPlaceDelegate.PlaceCapture cap : recorder.captured()) {
+    int droppedConquered = 0;
+    for (final RecordingPlaceDelegate.PlaceCapture cap : captures) {
+      if (conqueredThisTurn.contains(cap.territory())) {
+        droppedConquered += cap.units().size();
+        continue;
+      }
       final String tName = cap.territory().getName();
       final List<String> types = byTerritory.computeIfAbsent(tName, k -> new ArrayList<>());
       for (final Unit unit : cap.units()) {
@@ -126,11 +160,18 @@ public final class PlaceExecutor implements DecisionExecutor<PlaceRequest, Place
       }
     }
 
-    if (totalCaptured == 0 && !recorder.captured().isEmpty()) {
+    if (droppedConquered > 0) {
+      LOG.log(
+          System.Logger.Level.INFO,
+          "PlaceExecutor: dropped " + droppedConquered
+              + " unit placements at conquered-this-turn territories for session " + sessionKey);
+    }
+
+    if (totalCaptured == 0 && !captures.isEmpty() && droppedConquered == 0) {
       // Captures exist but all had empty unit lists — type-mismatch no-op path
       LOG.log(System.Logger.Level.WARNING,
           "PlaceExecutor: all placeUnits calls returned empty unit lists for session "
-              + session.key() + " — player.getUnitCollection() likely missing purchased units");
+              + sessionKey + " — player.getUnitCollection() likely missing purchased units");
     }
 
     final List<PlaceOrder> placements = new ArrayList<>();

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PlaceExecutorFilterTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PlaceExecutorFilterTest.java
@@ -1,0 +1,104 @@
+package org.triplea.ai.sidecar.exec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.dto.PlacePlan;
+
+/**
+ * Unit tests for {@link PlaceExecutor#groupCapturesIntoPlan}: any {@link
+ * RecordingPlaceDelegate.PlaceCapture} whose territory was conquered this turn must be
+ * dropped from the resulting {@link PlacePlan}, since the map-room engine rejects placement
+ * at freshly captured territories (rules §16/§20). Pro AI itself does not consult
+ * wasConquered when picking placement targets, so this filter is the safety net.
+ */
+class PlaceExecutorFilterTest {
+
+  private static CanonicalGameData canonical;
+
+  @BeforeAll
+  static void init() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+  }
+
+  @Test
+  void groupCapturesIntoPlan_dropsCapturesAtConqueredTerritories() {
+    final GameData gd = canonical.cloneForSession();
+    final Territory germany = gd.getMap().getTerritoryOrThrow("Germany");
+    final Territory france = gd.getMap().getTerritoryOrThrow("France");
+    final UnitType infantry =
+        gd.getUnitTypeList().getUnitType("infantry").orElseThrow();
+    final Unit infInGermany =
+        new Unit(UUID.randomUUID(), infantry, gd.getPlayerList().getPlayerId("Germans"), gd);
+    final Unit infInFrance =
+        new Unit(UUID.randomUUID(), infantry, gd.getPlayerList().getPlayerId("Germans"), gd);
+
+    final List<RecordingPlaceDelegate.PlaceCapture> captures =
+        List.of(
+            new RecordingPlaceDelegate.PlaceCapture(List.of(infInGermany), germany),
+            new RecordingPlaceDelegate.PlaceCapture(List.of(infInFrance), france));
+
+    final PlacePlan plan =
+        PlaceExecutor.groupCapturesIntoPlan(captures, Set.of(france), "test-session");
+
+    assertThat(plan.placements()).hasSize(1);
+    assertThat(plan.placements().get(0).territoryName()).isEqualTo("Germany");
+    assertThat(plan.placements().get(0).unitTypes()).containsExactly("infantry");
+  }
+
+  @Test
+  void groupCapturesIntoPlan_keepsAllWhenNoConqueredTerritories() {
+    final GameData gd = canonical.cloneForSession();
+    final Territory germany = gd.getMap().getTerritoryOrThrow("Germany");
+    final Territory france = gd.getMap().getTerritoryOrThrow("France");
+    final UnitType infantry =
+        gd.getUnitTypeList().getUnitType("infantry").orElseThrow();
+    final Unit infInGermany =
+        new Unit(UUID.randomUUID(), infantry, gd.getPlayerList().getPlayerId("Germans"), gd);
+    final Unit infInFrance =
+        new Unit(UUID.randomUUID(), infantry, gd.getPlayerList().getPlayerId("Germans"), gd);
+
+    final List<RecordingPlaceDelegate.PlaceCapture> captures =
+        List.of(
+            new RecordingPlaceDelegate.PlaceCapture(List.of(infInGermany), germany),
+            new RecordingPlaceDelegate.PlaceCapture(List.of(infInFrance), france));
+
+    final PlacePlan plan =
+        PlaceExecutor.groupCapturesIntoPlan(captures, Set.of(), "test-session");
+
+    assertThat(plan.placements()).hasSize(2);
+    assertThat(plan.placements())
+        .extracting(p -> p.territoryName())
+        .containsExactlyInAnyOrder("Germany", "France");
+  }
+
+  @Test
+  void groupCapturesIntoPlan_returnsEmptyPlanWhenAllCapturesAreConquered() {
+    final GameData gd = canonical.cloneForSession();
+    final Territory france = gd.getMap().getTerritoryOrThrow("France");
+    final UnitType infantry =
+        gd.getUnitTypeList().getUnitType("infantry").orElseThrow();
+    final Unit infInFrance =
+        new Unit(UUID.randomUUID(), infantry, gd.getPlayerList().getPlayerId("Germans"), gd);
+
+    final PlacePlan plan =
+        PlaceExecutor.groupCapturesIntoPlan(
+            List.of(new RecordingPlaceDelegate.PlaceCapture(List.of(infInFrance), france)),
+            Set.of(france),
+            "test-session");
+
+    assertThat(plan.placements()).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

Same family of bugs as the air-landing fix in #17. Pro AI's purchase planner does not consult \`wasConquered\` when picking placement targets, and \`RecordingPlaceDelegate\` (the sidecar's stub place delegate) accepts every \`placeUnits\` call without validation. So when Germany conquers France this turn, Pro AI happily plans placement at France's factory, the sidecar returns those placements in the \`PlacePlan\`, and the map-room engine rejects the whole place phase (rules §16/§20: a freshly captured factory cannot produce in the same turn). Bot sits stuck.

The real \`AbstractPlaceDelegate\` (\`AbstractPlaceDelegate.java:546, 690, 1664\`) gates production by \`wasConquered(producer)\`. Our recording stub doesn't, so the safety net has to live in \`PlaceExecutor\`.

## Fix

Mirror the \`wasConquered\` guard at the sidecar boundary: read \`BattleTracker.getConquered()\` (already populated by \`WireStateApplier.applyConqueredThisTurn\` from the wire flag added in map-room/map-room#1823) and drop any captured placement whose territory is in that set.

Refactored \`PlaceExecutor.execute()\` so the grouping + filtering step is a package-static \`groupCapturesIntoPlan()\` helper that takes the conquered set explicitly. That makes the filter unit-testable without having to drive Pro AI to propose specific placements (which is hard to fixture deterministically).

## Tests

Three new unit tests in \`PlaceExecutorFilterTest\`:
- \`groupCapturesIntoPlan_dropsCapturesAtConqueredTerritories\` — France in conquered set, Germany not. Plan has only Germany.
- \`groupCapturesIntoPlan_keepsAllWhenNoConqueredTerritories\` — empty conquered set, both kept.
- \`groupCapturesIntoPlan_returnsEmptyPlanWhenAllCapturesAreConquered\` — single capture at conquered France → empty plan.

\`\`\`
./gradlew :game-app:ai-sidecar:test
BUILD SUCCESSFUL
\`\`\`

Plus an INFO log when captures are dropped, so we can see the filter firing in container logs after deploy.

## Pairs with

- map-room/map-room#1823 — populates \`WireTerritory.conqueredThisTurn\` on the wire.
- map-room/triplea#17 — propagates \`movesUsed\` to \`Unit.alreadyMoved\` so air units land within remaining range.

Together these three close the just-conquered-territory class of bugs end-to-end (landings, factory placement, and the underlying movement-tracking gap).

## Test plan

- [x] Three new unit tests for the conquered-territory filter
- [x] Full ai-sidecar test suite still passes
- [ ] 🧑 Manual: deploy with all three PRs, run a Germany turn that captures France, verify both noncombat-move and place complete cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)