### PR TITLE
fix(wire): hydrate transportedBy, submerged, wasInCombat in WireStateApplier

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -18,6 +18,7 @@ import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -87,6 +88,7 @@ public final class WireStateApplier {
     // damage branch references are live on the board.
     applyConqueredThisTurn(gameData, wire);
     applyOperationalDamage(gameData, wire, unitIdMap);
+    applyUnitProperties(gameData, wire, unitIdMap);
     // Round/step last — GameSequence mutation has no interaction with the earlier branches,
     // but keeping it at the tail means nothing downstream can overwrite it.
     applyRoundAndStep(gameData, wire);
@@ -340,6 +342,73 @@ public final class WireStateApplier {
     }
     if (!toAdd.isEmpty()) {
       out.add(ChangeFactory.addUnits(territory, toAdd));
+    }
+  }
+
+  /**
+   * Hydrate per-unit transient state (transportedBy, submerged, wasInCombat) after all units are
+   * live on the board. Runs after the main {@link CompositeChange} so that transporter units
+   * referenced by transportedBy are guaranteed to exist in game data.
+   */
+  private static void applyUnitProperties(
+      final GameData gameData,
+      final WireState wire,
+      final ConcurrentMap<String, UUID> unitIdMap) {
+    // Index every live unit by UUID for O(1) transport resolution across territories.
+    final Map<UUID, Unit> allUnitsById = new HashMap<>();
+    for (final Territory t : gameData.getMap().getTerritories()) {
+      for (final Unit u : t.getUnits()) {
+        allUnitsById.put(u.getId(), u);
+      }
+    }
+
+    for (final WireTerritory wt : wire.territories()) {
+      final Territory t = gameData.getMap().getTerritoryOrNull(wt.territoryId());
+      if (t == null) {
+        continue;
+      }
+      final CompositeChange changes = new CompositeChange();
+      for (final WireUnit wu : wt.units()) {
+        final UUID uuid = unitIdMap.get(wu.unitId());
+        if (uuid == null) {
+          continue;
+        }
+        final Unit unit = allUnitsById.get(uuid);
+        if (unit == null) {
+          continue;
+        }
+
+        if (wu.submerged() != unit.getSubmerged()) {
+          changes.add(
+              ChangeFactory.unitPropertyChange(
+                  unit, wu.submerged(), Unit.PropertyName.SUBMERGED));
+        }
+        if (wu.wasInCombat() != unit.getWasInCombat()) {
+          changes.add(
+              ChangeFactory.unitPropertyChange(
+                  unit, wu.wasInCombat(), Unit.PropertyName.WAS_IN_COMBAT));
+        }
+
+        final String wireTransportedById = wu.transportedBy();
+        final Unit currentTransportedBy = unit.getTransportedBy();
+        if (wireTransportedById != null) {
+          final UUID transporterUuid = unitIdMap.get(wireTransportedById);
+          if (transporterUuid != null) {
+            final Unit transporter = allUnitsById.get(transporterUuid);
+            if (transporter != null && !transporter.equals(currentTransportedBy)) {
+              changes.add(
+                  ChangeFactory.unitPropertyChange(
+                      unit, transporter, Unit.PropertyName.TRANSPORTED_BY));
+            }
+          }
+        } else if (currentTransportedBy != null) {
+          changes.add(
+              ChangeFactory.unitPropertyChange(unit, null, Unit.PropertyName.TRANSPORTED_BY));
+        }
+      }
+      if (!changes.isEmpty()) {
+        gameData.performChange(changes);
+      }
     }
   }
 

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireUnit.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireUnit.java
@@ -6,7 +6,10 @@ import javax.annotation.Nullable;
 
 public record WireUnit(
     String unitId, String unitType, int hitsTaken, int movesUsed, int bombingDamage,
-    @Nullable String owner) {
+    @Nullable String owner,
+    @Nullable String transportedBy,
+    boolean submerged,
+    boolean wasInCombat) {
   @JsonCreator
   public static WireUnit of(
       @JsonProperty("unitId") final String unitId,
@@ -14,26 +17,40 @@ public record WireUnit(
       @JsonProperty("hitsTaken") final Integer hitsTaken,
       @JsonProperty("movesUsed") final Integer movesUsed,
       @JsonProperty("bombingDamage") final Integer bombingDamage,
-      @JsonProperty("owner") final String owner) {
+      @JsonProperty("owner") final String owner,
+      @JsonProperty("transportedBy") final String transportedBy,
+      @JsonProperty("submerged") final Boolean submerged,
+      @JsonProperty("wasInCombat") final Boolean wasInCombat) {
     return new WireUnit(
         unitId,
         unitType,
         hitsTaken == null ? 0 : hitsTaken,
         movesUsed == null ? 0 : movesUsed,
         bombingDamage == null ? 0 : bombingDamage,
-        owner);
+        owner,
+        transportedBy,
+        submerged != null && submerged,
+        wasInCombat != null && wasInCombat);
   }
 
   /** Backward-compat constructor used by existing tests that don't specify an owner. */
   public WireUnit(
       final String unitId, final String unitType, final int hitsTaken, final int movesUsed) {
-    this(unitId, unitType, hitsTaken, movesUsed, 0, null);
+    this(unitId, unitType, hitsTaken, movesUsed, 0, null, null, false, false);
   }
 
   /** Backward-compat constructor for tests that specify bombingDamage but not owner. */
   public WireUnit(
       final String unitId, final String unitType,
       final int hitsTaken, final int movesUsed, final int bombingDamage) {
-    this(unitId, unitType, hitsTaken, movesUsed, bombingDamage, null);
+    this(unitId, unitType, hitsTaken, movesUsed, bombingDamage, null, null, false, false);
+  }
+
+  /** Backward-compat constructor for tests that specify an owner but not the new fields. */
+  public WireUnit(
+      final String unitId, final String unitType,
+      final int hitsTaken, final int movesUsed, final int bombingDamage,
+      final String owner) {
+    this(unitId, unitType, hitsTaken, movesUsed, bombingDamage, owner, null, false, false);
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
@@ -322,9 +322,9 @@ class WireStateApplierTest {
     // 112 Sea Zone: territory owner is Germans but the cruiser belongs to Italians.
     // This mirrors the bug scenario where sea zones hold ships from allied nations.
     final WireUnit germanSub =
-        WireUnit.of("u-sub-1", "submarine", 0, 0, 0, "Germans");
+        WireUnit.of("u-sub-1", "submarine", 0, 0, 0, "Germans", null, false, false);
     final WireUnit italianCruiser =
-        WireUnit.of("u-cru-1", "cruiser", 0, 0, 0, "Italians");
+        WireUnit.of("u-cru-1", "cruiser", 0, 0, 0, "Italians", null, false, false);
     final WireState wire =
         new WireState(
             List.of(new WireTerritory("112 Sea Zone", "Germans", List.of(germanSub, italianCruiser))),
@@ -370,6 +370,88 @@ class WireStateApplierTest {
     assertThat(germany).isNotNull();
     assertThat(germany.getUnits()).hasSize(1);
     assertThat(germany.getUnits().iterator().next().getOwner().getName()).isEqualTo("Germans");
+  }
+
+  // ---------- transportedBy / submerged / wasInCombat hydration (#1831) ----------
+
+  @Test
+  void submerged_trueOnWire_setsSubmergedOnUnit() {
+    final GameData gd = fresh();
+    final WireUnit sub =
+        WireUnit.of("u-sub-1", "submarine", 0, 0, 0, "Germans", null, true, false);
+    final WireState wire =
+        new WireState(
+            List.of(new WireTerritory("112 Sea Zone", "Germans", List.of(sub))),
+            List.of(),
+            1,
+            "combatMove",
+            "Germans");
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    WireStateApplier.apply(gd, wire, idMap);
+
+    final Territory seaZone = gd.getMap().getTerritoryOrNull("112 Sea Zone");
+    assertThat(seaZone).isNotNull();
+    final Unit liveUnit = seaZone.getUnits().iterator().next();
+    assertThat(liveUnit.getSubmerged()).isTrue();
+  }
+
+  @Test
+  void wasInCombat_trueOnWire_setsWasInCombatOnUnit() {
+    final GameData gd = fresh();
+    final WireUnit infantry =
+        WireUnit.of("u-inf-1", "infantry", 0, 0, 0, "Germans", null, false, true);
+    final WireState wire =
+        new WireState(
+            List.of(new WireTerritory("Germany", "Germans", List.of(infantry))),
+            List.of(),
+            1,
+            "nonCombatMove",
+            "Germans");
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    WireStateApplier.apply(gd, wire, idMap);
+
+    final Territory germany = gd.getMap().getTerritoryOrNull("Germany");
+    assertThat(germany).isNotNull();
+    final Unit liveUnit = germany.getUnits().iterator().next();
+    assertThat(liveUnit.getWasInCombat()).isTrue();
+  }
+
+  @Test
+  void transportedBy_unitIdOnWire_linksInfantryToTransport() {
+    final GameData gd = fresh();
+    final WireUnit transport =
+        WireUnit.of("u-trn-1", "transport", 0, 0, 0, "Germans", null, false, false);
+    final WireUnit infantry =
+        WireUnit.of("u-inf-1", "infantry", 0, 0, 0, "Germans", "u-trn-1", false, false);
+    final WireState wire =
+        new WireState(
+            List.of(new WireTerritory("112 Sea Zone", "Germans", List.of(transport, infantry))),
+            List.of(),
+            1,
+            "combatMove",
+            "Germans");
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    WireStateApplier.apply(gd, wire, idMap);
+
+    final Territory seaZone = gd.getMap().getTerritoryOrNull("112 Sea Zone");
+    assertThat(seaZone).isNotNull();
+    final UUID transportUuid = idMap.get("u-trn-1");
+    final UUID infantryUuid = idMap.get("u-inf-1");
+    assertThat(transportUuid).isNotNull();
+    assertThat(infantryUuid).isNotNull();
+
+    Unit transportUnit = null;
+    Unit infantryUnit = null;
+    for (final Unit u : seaZone.getUnits()) {
+      if (u.getId().equals(transportUuid)) {
+        transportUnit = u;
+      } else if (u.getId().equals(infantryUuid)) {
+        infantryUnit = u;
+      }
+    }
+    assertThat(transportUnit).isNotNull();
+    assertThat(infantryUnit).isNotNull();
+    assertThat(infantryUnit.getTransportedBy()).isEqualTo(transportUnit);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Companion to map-room/map-room#1836 (Map Room issue #1831).

Three `UnitState` fields already tracked by Map Room were not crossing the wire to the sidecar. ProAI saw `null` transportedBy and `false` submerged/wasInCombat for every unit, causing broken transport-chain validation, submarine first-strike logic, and units that fought being proposed for noncombat move.

- **`WireUnit`** — adds `transportedBy` (`@Nullable String`), `submerged` (`boolean`), `wasInCombat` (`boolean`) with null/false defaults in `of()` and existing backward-compat constructors, preserving all callers.
- **`WireStateApplier.applyUnitProperties`** — new post-apply step that runs after all units are live on the board. Hydrates all three via `ChangeFactory.unitPropertyChange`. Post-apply timing is required so `transportedBy` can resolve the transporter `Unit` across territories via the fully-populated `allUnitsById` index.
- **`WireStateApplierTest`** — three new tests: `submerged_trueOnWire_setsSubmergedOnUnit`, `wasInCombat_trueOnWire_setsWasInCombatOnUnit`, `transportedBy_unitIdOnWire_linksInfantryToTransport`.

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:test --tests "org.triplea.ai.sidecar.wire.*"` — all pass including 3 new tests
- [x] Compilation clean (`compileJava` + `compileTestJava`)
- [x] Backward compat: existing 4-arg and 5-arg `WireUnit` constructors unchanged; `of()` new fields default to null/false when absent from JSON