### PR TITLE
fix(ai-sidecar): reinit proData in combat-move + noncombat-move executors

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/CombatMoveExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/CombatMoveExecutor.java
@@ -90,12 +90,18 @@ public final class CombatMoveExecutor implements DecisionExecutor<CombatMoveRequ
     // Step 4: submit combat-move to the session's single-threaded offensive executor.
     // Politics was already run by PoliticsExecutor in the preceding /decide call; the WireState
     // received here already reflects the post-declaration relationship graph.
+    //
+    // reinitializeProDataForSidecar() re-binds proData.getData() to the session GameData
+    // before planning — otherwise purchase's simulation dataCopy leaks through and
+    // ProCombatMoveAi reads stale alreadyMoved values. Same pattern as PoliticsExecutor
+    // and NoncombatMoveExecutor.
     final RecordingMoveDelegate recorder = new RecordingMoveDelegate(proAi);
     final Future<Void> future =
         session
             .offensiveExecutor()
             .submit(
                 () -> {
+                  proAi.reinitializeProDataForSidecar();
                   proAi.invokeCombatMoveForSidecar(recorder, data, player);
                   return null;
                 });

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
@@ -86,13 +86,20 @@ public final class NoncombatMoveExecutor
               + " — purchase must run before noncombat-move");
     }
 
-    // Step 4: dispatch on the session's single-threaded offensive executor
+    // Step 4: dispatch on the session's single-threaded offensive executor.
+    // reinitializeProDataForSidecar() re-binds proData.getData() to the session GameData
+    // before planning — otherwise purchase's simulation dataCopy leaks through and
+    // ProNonCombatMoveAi reads stale alreadyMoved values, producing plans that move
+    // units the engine already recorded as spent (INVALID_MOVE: "<unit> already moved
+    // during combat move"). Same pattern applied to PoliticsExecutor and
+    // CombatMoveExecutor.
     final RecordingMoveDelegate recorder = new RecordingMoveDelegate(proAi);
     final Future<Void> future =
         session
             .offensiveExecutor()
             .submit(
                 () -> {
+                  proAi.reinitializeProDataForSidecar();
                   proAi.invokeNonCombatMoveForSidecar(recorder, data, player);
                   return null;
                 });


### PR DESCRIPTION
## Problem

After purchase runs its lookahead simulation, `proData.getData()` points at the purchase's `dataCopy` — not the session's live GameData. Without reinitializing before the next planner runs, `ProCombatMoveAi` and `ProNonCombatMoveAi` read stale \`alreadyMoved\` values from the simulation copy, producing plans that move units the engine has already recorded as spent.

Observed symptom (reported from live match):
- Germany (AI) combat-moves armor X from A → B.
- Engine sets \`X.movedThisTurn = 1\`.
- NCM phase: sidecar plans armor X to move B → C.
- Bot dispatches. Engine rejects: \`INVALID_MOVE: Armor already moved during combat move\`.

## Fix

`PoliticsExecutor` already called \`reinitializeProDataForSidecar()\` (landed with the initial politics wiring, map-room#1824). `CombatMoveExecutor` and `NoncombatMoveExecutor` need the same call; apply the same pattern at the same lambda-entry point so proData re-binds to the session GameData before each planner runs.

## Files

- \`game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/CombatMoveExecutor.java\` — add \`proAi.reinitializeProDataForSidecar()\` before \`invokeCombatMoveForSidecar\`.
- \`game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java\` — same pattern before \`invokeNonCombatMoveForSidecar\`.

## Test plan

- [x] \`./gradlew :game-app:ai-sidecar:test --tests 'org.triplea.ai.sidecar.exec.*'\` passes.
- [ ] 🧑 Manual: play an AI turn where ground units attack in combat. Confirm NCM does NOT try to move those same units. (Air units should still be able to land in NCM as they always could.)