### PR TITLE
fix(ai-sidecar): reinit proData in PlaceExecutor

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PlaceExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PlaceExecutor.java
@@ -94,13 +94,19 @@ public final class PlaceExecutor implements DecisionExecutor<PlaceRequest, Place
               + " — check restore path and dispatch order");
     }
 
-    // Step 4: dispatch on the session's single-threaded offensive executor
+    // Step 4: dispatch on the session's single-threaded offensive executor.
+    // reinitializeProDataForSidecar() re-binds proData.getData() to the session GameData
+    // so ProPurchaseAi's placement pass sees the live BattleTracker (populated by
+    // WireStateApplier.applyConqueredThisTurn) — otherwise ProAi plans placements at
+    // newly-captured territories like France and groupCapturesIntoPlan has to drop them.
+    // Same pattern as CombatMove/NoncombatMove/PoliticsExecutor.
     final RecordingPlaceDelegate recorder = new RecordingPlaceDelegate();
     final Future<Void> future =
         session
             .offensiveExecutor()
             .submit(
                 () -> {
+                  proAi.reinitializeProDataForSidecar();
                   proAi.invokePlaceForSidecar(recorder, data, player);
                   return null;
                 });

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
@@ -399,7 +399,8 @@ class WireStateApplierTest {
             List.of(),
             1,
             "combatMove",
-            "Germans");
+            "Germans",
+            List.of());
     final ConcurrentMap<String, UUID> idMap = freshIdMap();
     WireStateApplier.apply(gd, wire, idMap);
 
@@ -420,7 +421,8 @@ class WireStateApplierTest {
             List.of(),
             1,
             "nonCombatMove",
-            "Germans");
+            "Germans",
+            List.of());
     final ConcurrentMap<String, UUID> idMap = freshIdMap();
     WireStateApplier.apply(gd, wire, idMap);
 
@@ -443,7 +445,8 @@ class WireStateApplierTest {
             List.of(),
             1,
             "combatMove",
-            "Germans");
+            "Germans",
+            List.of());
     final ConcurrentMap<String, UUID> idMap = freshIdMap();
     WireStateApplier.apply(gd, wire, idMap);
 
@@ -545,7 +548,8 @@ class WireStateApplierTest {
             List.of(),
             1,
             "combatMove",
-            "Germans");
+            "Germans",
+            List.of());
     final ConcurrentMap<String, UUID> idMap = freshIdMap();
     WireStateApplier.apply(gd, wire, idMap);
 
@@ -566,7 +570,8 @@ class WireStateApplierTest {
             List.of(),
             1,
             "combatMove",
-            "Germans");
+            "Germans",
+            List.of());
     final ConcurrentMap<String, UUID> idMap = freshIdMap();
     WireStateApplier.apply(gd, wire, idMap);
 
@@ -587,7 +592,8 @@ class WireStateApplierTest {
             List.of(),
             1,
             "combatMove",
-            "Germans");
+            "Germans",
+            List.of());
     final ConcurrentMap<String, UUID> idMap = freshIdMap();
     WireStateApplier.apply(gd, wire, idMap);
 


### PR DESCRIPTION
Follow-on to #22 (combat + ncm reinit). Same pattern applied to PlaceExecutor.

## Problem

proData.getData() points at purchase's simulation dataCopy after the lookahead runs. When ProPurchaseAi's placement pass reads the BattleTracker, it sees the simulation copy's tracker (no conquered-this-turn entries) instead of the session's live tracker.

Observed symptom: AI plans placements at conquered-this-turn territories (e.g., France after Germans capture it on round 1). Map-room's PlaceExecutor.groupCapturesIntoPlan already catches these and drops them:
\`\`\`
INFO: PlaceExecutor: dropped 3 unit placements at conquered-this-turn territories for session SessionKey[gameId=..., nation=Germans]
\`\`\`
But ideally ProAi wouldn't plan them in the first place.

## Fix

Add \`proAi.reinitializeProDataForSidecar()\` before \`invokePlaceForSidecar\` in the offensive-executor lambda. Same pattern as #22 applied to CombatMoveExecutor and NoncombatMoveExecutor.

## Pre-existing compile fix

PR #21 added tests to WireStateApplierTest that call the 5-arg WireState constructor, but PR #20 made WireState 6-arg (adding \`relationships\`). Six test sites needed \`List.of()\` as the sixth arg. Fixing inline since this blocks the build.

## Test plan

- [x] \`./gradlew :game-app:ai-sidecar:test --tests 'org.triplea.ai.sidecar.exec.*' --tests 'org.triplea.ai.sidecar.wire.WireStateApplierTest'\` passes.
- [ ] 🧑 Manual: AI plays a turn where they capture a territory; verify no \"PlaceExecutor: dropped N unit placements\" INFO log messages.