### PR TITLE
feat(ai-sidecar): wire load/unload kind + transportId on CombatMoveOrder

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/CombatMoveOrder.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/CombatMoveOrder.java
@@ -1,5 +1,7 @@
 package org.triplea.ai.sidecar.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /**
@@ -7,5 +9,47 @@ import java.util.List;
  *
  * <p>{@code unitIds} are Map Room wire IDs (the string keys from the wire state), not Java UUIDs.
  * {@code from} and {@code to} are territory names as they appear in the canonical map.
+ *
+ * <p>{@code kind} distinguishes the three move types the Map Room engine handles separately:
+ * <ul>
+ *   <li>{@code "move"} (default) — plain unit movement via {@code client.moves.moveUnit}.
+ *   <li>{@code "load"} — cargo boarding a sea transport; dispatched via
+ *       {@code client.moves.loadOnTransport(unitIds, from, seaZone, transportId)}.
+ *   <li>{@code "unload"} — cargo leaving a sea transport; dispatched via
+ *       {@code client.moves.unloadFromTransport(unitIds, seaZone, to)}.
+ * </ul>
+ *
+ * <p>{@code transportId} is the wire ID of the sea transport involved. Required for {@code "load"};
+ * populated but not consumed by the engine for {@code "unload"} (the engine infers the transport
+ * from the cargo's {@code transportedBy} field). Absent/null for {@code "move"}.
+ *
+ * <p>Jackson backwards-compatibility: absent {@code kind} / {@code transportId} fields in the
+ * JSON payload default to {@code "move"} / {@code null} respectively, so existing fixtures and
+ * older TS clients don't need to be updated.
  */
-public record CombatMoveOrder(List<String> unitIds, String from, String to) {}
+public record CombatMoveOrder(
+    List<String> unitIds,
+    String from,
+    String to,
+    String kind,
+    String transportId) {
+
+  @JsonCreator
+  public CombatMoveOrder(
+      @JsonProperty("unitIds") final List<String> unitIds,
+      @JsonProperty("from") final String from,
+      @JsonProperty("to") final String to,
+      @JsonProperty("kind") final String kind,
+      @JsonProperty("transportId") final String transportId) {
+    this.unitIds = unitIds;
+    this.from = from;
+    this.to = to;
+    this.kind = kind == null ? "move" : kind;
+    this.transportId = transportId;
+  }
+
+  /** Convenience constructor for plain moves — {@code kind} defaults to {@code "move"}. */
+  public CombatMoveOrder(final List<String> unitIds, final String from, final String to) {
+    this(unitIds, from, to, null, null);
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/CombatMoveExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/CombatMoveExecutor.java
@@ -2,7 +2,6 @@ package org.triplea.ai.sidecar.exec;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
-import games.strategy.engine.data.Unit;
 import games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -129,20 +128,10 @@ public final class CombatMoveExecutor implements DecisionExecutor<CombatMoveRequ
     final List<CombatMoveOrder> sbrMoves = new ArrayList<>();
 
     for (final RecordingMoveDelegate.CapturedMove captured : recorder.captured()) {
-      final List<String> unitIds = new ArrayList<>();
-      for (final Unit unit : captured.move().getUnits()) {
-        final String wireId = uuidToWireId.get(unit.getId());
-        if (wireId != null) {
-          unitIds.add(wireId);
-        }
-      }
-      final String from = captured.move().getRoute().getStart().getName();
-      final String to = captured.move().getRoute().getEnd().getName();
-      final CombatMoveOrder order = new CombatMoveOrder(unitIds, from, to);
       if (captured.isBombing()) {
-        sbrMoves.add(order);
+        sbrMoves.addAll(ExecutorSupport.projectOrders(captured.move(), uuidToWireId));
       } else {
-        moves.add(order);
+        moves.addAll(ExecutorSupport.projectOrders(captured.move(), uuidToWireId));
       }
     }
 

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/ExecutorSupport.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/ExecutorSupport.java
@@ -2,13 +2,23 @@ package org.triplea.ai.sidecar.exec;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.MoveDescription;
+import games.strategy.engine.data.Unit;
 import games.strategy.engine.player.PlayerBridge;
 import games.strategy.triplea.ai.pro.ProAi;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.battle.IBattle;
+
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
+import org.triplea.ai.sidecar.dto.CombatMoveOrder;
 import org.triplea.ai.sidecar.session.Session;
 
 /**
@@ -102,5 +112,79 @@ final class ExecutorSupport {
     } catch (final IllegalAccessException e) {
       throw new IllegalStateException("Cannot reflectively access BattleTracker.pendingBattles", e);
     }
+  }
+
+  /**
+   * Projects a single validated {@link MoveDescription} to one or more {@link CombatMoveOrder}s.
+   *
+   * <p>Three cases:
+   * <ul>
+   *   <li><b>Load</b> ({@code route.isLoad()}): land → sea zone. {@code unitsToSeaTransports}
+   *       maps cargo→transport. Grouped by transport so each transport emits one order with all
+   *       its cargo. {@code kind="load"}, {@code transportId} = wire ID of the transport.
+   *   <li><b>Unload</b> ({@code route.isUnload()}): sea zone → land. All units are cargo; the
+   *       engine infers the transport from {@code transportedBy}. One order is emitted for the
+   *       whole batch. {@code kind="unload"}, {@code transportId} = wire ID of first sea unit in
+   *       the move (for traceability; engine does not consume it).
+   *   <li><b>Plain move</b>: single order, {@code kind="move"}.
+   * </ul>
+   *
+   * @param move the captured move description
+   * @param uuidToWireId reverse map from Java UUID to Map Room wire ID
+   * @return list of orders (may be empty if all unit IDs resolved to null)
+   */
+  static List<CombatMoveOrder> projectOrders(
+      final MoveDescription move, final Map<UUID, String> uuidToWireId) {
+    final String from = move.getRoute().getStart().getName();
+    final String to = move.getRoute().getEnd().getName();
+
+    if (move.getRoute().isLoad()) {
+      // Group cargo by transport; emit one order per transport.
+      final Map<Unit, List<Unit>> cargoByTransport = new LinkedHashMap<>();
+      for (final Map.Entry<Unit, Unit> e : move.getUnitsToSeaTransports().entrySet()) {
+        cargoByTransport.computeIfAbsent(e.getValue(), k -> new ArrayList<>()).add(e.getKey());
+      }
+      // If unitsToSeaTransports is empty despite isLoad(), fall through to plain-move.
+      if (!cargoByTransport.isEmpty()) {
+        final List<CombatMoveOrder> orders = new ArrayList<>();
+        for (final Map.Entry<Unit, List<Unit>> e : cargoByTransport.entrySet()) {
+          final String transportWireId = uuidToWireId.get(e.getKey().getId());
+          final List<String> cargoWireIds = e.getValue().stream()
+              .map(u -> uuidToWireId.get(u.getId()))
+              .filter(Objects::nonNull)
+              .toList();
+          if (cargoWireIds.isEmpty()) {
+            continue;
+          }
+          orders.add(new CombatMoveOrder(cargoWireIds, from, to, "load", transportWireId));
+        }
+        if (!orders.isEmpty()) {
+          return orders;
+        }
+      }
+    } else if (move.getRoute().isUnload()) {
+      // All non-transport units in the move are cargo. Find the transport for traceability.
+      final List<String> cargoWireIds = move.getUnits().stream()
+          .filter(u -> !u.getUnitAttachment().isTransportCapacity())
+          .map(u -> uuidToWireId.get(u.getId()))
+          .filter(Objects::nonNull)
+          .toList();
+      if (!cargoWireIds.isEmpty()) {
+        final String transportWireId = move.getUnits().stream()
+            .filter(u -> u.getUnitAttachment().getTransportCapacity() > 0)
+            .map(u -> uuidToWireId.get(u.getId()))
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+        return List.of(new CombatMoveOrder(cargoWireIds, from, to, "unload", transportWireId));
+      }
+    }
+
+    // Plain move (or load/unload that resolved to no cargo IDs — fall back to full unit list).
+    final List<String> unitIds = move.getUnits().stream()
+        .map(u -> uuidToWireId.get(u.getId()))
+        .filter(Objects::nonNull)
+        .toList();
+    return List.of(new CombatMoveOrder(unitIds, from, to));
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
@@ -2,7 +2,6 @@ package org.triplea.ai.sidecar.exec;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
-import games.strategy.engine.data.Unit;
 import games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -131,16 +130,7 @@ public final class NoncombatMoveExecutor
         throw new AssertionError(
             "isBombing == true in noncombat-move phase — ProAI invariant violated");
       }
-      final List<String> unitIds = new ArrayList<>();
-      for (final Unit unit : captured.move().getUnits()) {
-        final String wireId = uuidToWireId.get(unit.getId());
-        if (wireId != null) {
-          unitIds.add(wireId);
-        }
-      }
-      final String from = captured.move().getRoute().getStart().getName();
-      final String to = captured.move().getRoute().getEnd().getName();
-      moves.add(new CombatMoveOrder(unitIds, from, to));
+      moves.addAll(ExecutorSupport.projectOrders(captured.move(), uuidToWireId));
     }
 
     return new NoncombatMovePlan(moves);

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/CombatMoveOrderTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/CombatMoveOrderTest.java
@@ -1,0 +1,80 @@
+package org.triplea.ai.sidecar.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Wire-contract tests for {@link CombatMoveOrder}.
+ *
+ * <p>These tests verify the Jackson round-trip behaviour introduced in #1761:
+ * <ul>
+ *   <li>Absent {@code kind} field defaults to {@code "move"} (backwards-compat for old payloads).
+ *   <li>{@code kind="load"} and {@code transportId} round-trip correctly.
+ *   <li>{@code kind="unload"} round-trips correctly.
+ *   <li>3-arg convenience constructor produces {@code kind="move"} and null {@code transportId}.
+ * </ul>
+ */
+class CombatMoveOrderTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void absentKindDefaultsToMove() throws Exception {
+    // Legacy payload: no kind or transportId field.
+    final String json =
+        "{\"unitIds\":[\"u1\",\"u2\"],\"from\":\"Germany\",\"to\":\"Poland\"}";
+    final CombatMoveOrder order = MAPPER.readValue(json, CombatMoveOrder.class);
+    assertThat(order.unitIds()).containsExactly("u1", "u2");
+    assertThat(order.from()).isEqualTo("Germany");
+    assertThat(order.to()).isEqualTo("Poland");
+    assertThat(order.kind()).isEqualTo("move");
+    assertThat(order.transportId()).isNull();
+  }
+
+  @Test
+  void loadOrderRoundTrips() throws Exception {
+    final CombatMoveOrder original =
+        new CombatMoveOrder(List.of("inf1"), "France", "Sea Zone 7", "load", "transport1");
+    final String json = MAPPER.writeValueAsString(original);
+    final CombatMoveOrder restored = MAPPER.readValue(json, CombatMoveOrder.class);
+    assertThat(restored.unitIds()).containsExactly("inf1");
+    assertThat(restored.from()).isEqualTo("France");
+    assertThat(restored.to()).isEqualTo("Sea Zone 7");
+    assertThat(restored.kind()).isEqualTo("load");
+    assertThat(restored.transportId()).isEqualTo("transport1");
+  }
+
+  @Test
+  void unloadOrderRoundTrips() throws Exception {
+    final CombatMoveOrder original =
+        new CombatMoveOrder(List.of("inf1", "arm1"), "Sea Zone 7", "Normandy", "unload", "transport1");
+    final String json = MAPPER.writeValueAsString(original);
+    final CombatMoveOrder restored = MAPPER.readValue(json, CombatMoveOrder.class);
+    assertThat(restored.unitIds()).containsExactly("inf1", "arm1");
+    assertThat(restored.from()).isEqualTo("Sea Zone 7");
+    assertThat(restored.to()).isEqualTo("Normandy");
+    assertThat(restored.kind()).isEqualTo("unload");
+    assertThat(restored.transportId()).isEqualTo("transport1");
+  }
+
+  @Test
+  void convenienceConstructorProducesPlainMove() {
+    final CombatMoveOrder order =
+        new CombatMoveOrder(List.of("tank1"), "Germany", "Poland");
+    assertThat(order.kind()).isEqualTo("move");
+    assertThat(order.transportId()).isNull();
+  }
+
+  @Test
+  void nullKindInJsonDefaultsToMove() throws Exception {
+    // Explicit null kind field should also default to "move" via the @JsonCreator.
+    final String json =
+        "{\"unitIds\":[\"u1\"],\"from\":\"A\",\"to\":\"B\",\"kind\":null,\"transportId\":null}";
+    final CombatMoveOrder order = MAPPER.readValue(json, CombatMoveOrder.class);
+    assertThat(order.kind()).isEqualTo("move");
+    assertThat(order.transportId()).isNull();
+  }
+}


### PR DESCRIPTION
## Summary

- Extends `CombatMoveOrder` record with `kind` (`"move"` | `"load"` | `"unload"`, defaults to `"move"` when absent) and `transportId` fields, preserving full Jackson backwards-compatibility with existing payloads.
- `CombatMoveExecutor` and `NoncombatMoveExecutor` now detect load/unload moves via `Route.isLoad()` / `Route.isUnload()` and emit typed `CombatMoveOrder` entries; the shared projection logic lives in `ExecutorSupport.projectOrders()`.
- Load orders group cargo by transport (one order per transport with its cargo batch). Unload orders bundle all cargo in one order. Plain moves keep the existing projection path.
- New `CombatMoveOrderTest` pins the Jackson round-trip contract for all three kinds (including absent-`kind` legacy payloads).

Part of a cross-repo PR pair — companion TS PR: map-room/map-room (closes #1761).

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:test` — 221+ tests pass, including new `CombatMoveOrderTest` (5 new cases)
- [x] `CombatMoveExecutorIntegrationTest` and `NoncombatMoveExecutorIntegrationTest` pass (verified plain-move projection unchanged)
- [ ] 🧑 Manual: Run sidecar against a game where Germans load infantry onto a transport and verify `CombatMovePlan.moves` contains an entry with `kind="load"` and correct `transportId`.