### PR TITLE
obs(ai-sidecar): single-line structured AI-TRACE logs (purchase/place/politics)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
@@ -1,0 +1,140 @@
+package org.triplea.ai.sidecar;
+
+import games.strategy.engine.data.MoveDescription;
+import games.strategy.engine.data.Unit;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Emits single-line structured AI-TRACE log entries for sidecar executor decisions.
+ *
+ * <p>Format: {@code [AI-TRACE] side=sidecar nation=X phase=Y key=value ...} Arrays use {@code
+ * [a,b,c]} notation; unit counts use {@code type×N} notation; territory names containing spaces are
+ * double-quoted.
+ */
+public final class AiTraceLogger {
+
+  private static final System.Logger LOG = System.getLogger(AiTraceLogger.class.getName());
+
+  private AiTraceLogger() {}
+
+  /**
+   * Log a captured move from CombatMoveExecutor or NoncombatMoveExecutor.
+   *
+   * @param uuidToWireId reverse map (Java UUID → Map Room wire ID) for transport resolution
+   */
+  public static void logCapturedMove(
+      final String nation,
+      final String phase,
+      final MoveDescription move,
+      final boolean isBombing,
+      final Map<UUID, String> uuidToWireId) {
+    final String kind =
+        isBombing
+            ? "sbr"
+            : move.getRoute().isLoad() ? "load" : move.getRoute().isUnload() ? "unload" : "move";
+    final String from = maybeQuote(move.getRoute().getStart().getName());
+    final String to = maybeQuote(move.getRoute().getEnd().getName());
+    final String units = unitTypeCounts(move.getUnits());
+    final String transportId = resolveTransportId(move, uuidToWireId);
+    LOG.log(
+        System.Logger.Level.INFO,
+        "[AI-TRACE] side=sidecar nation={0} phase={1} kind={2} from={3} to={4} units=[{5}] transportId={6}",
+        nation,
+        phase,
+        kind,
+        from,
+        to,
+        units,
+        transportId);
+  }
+
+  /** Log a single purchase order (call once per order in the trimmed plan). */
+  public static void logPurchaseOrder(final String nation, final String unitType, final int count) {
+    LOG.log(
+        System.Logger.Level.INFO,
+        "[AI-TRACE] side=sidecar nation={0} phase=purchase units=[{1}×{2}]",
+        nation,
+        unitType,
+        count);
+  }
+
+  /** Log a single place order (call once per territory in the place plan). */
+  public static void logPlaceOrder(
+      final String nation, final String territory, final Collection<String> unitTypes) {
+    LOG.log(
+        System.Logger.Level.INFO,
+        "[AI-TRACE] side=sidecar nation={0} phase=place territory={1} units=[{2}]",
+        nation,
+        maybeQuote(territory),
+        stringTypeCounts(unitTypes));
+  }
+
+  /** Log a war declaration from PoliticsExecutor. */
+  public static void logWarDeclaration(final String nation, final String target) {
+    LOG.log(
+        System.Logger.Level.INFO,
+        "[AI-TRACE] side=sidecar nation={0} phase=politics target={1}",
+        nation,
+        target);
+  }
+
+  // --- package-private for tests ---
+
+  static String unitTypeCounts(final Collection<Unit> units) {
+    final Map<String, Integer> counts = new LinkedHashMap<>();
+    for (final Unit u : units) {
+      counts.merge(u.getType().getName(), 1, Integer::sum);
+    }
+    return buildCountString(counts);
+  }
+
+  static String stringTypeCounts(final Collection<String> types) {
+    final Map<String, Integer> counts = new LinkedHashMap<>();
+    for (final String t : types) {
+      counts.merge(t, 1, Integer::sum);
+    }
+    return buildCountString(counts);
+  }
+
+  private static String buildCountString(final Map<String, Integer> counts) {
+    if (counts.isEmpty()) {
+      return "";
+    }
+    final StringBuilder sb = new StringBuilder();
+    counts.forEach(
+        (type, n) -> {
+          if (sb.length() > 0) {
+            sb.append(',');
+          }
+          sb.append(type).append('×').append(n);
+        });
+    return sb.toString();
+  }
+
+  private static String resolveTransportId(
+      final MoveDescription move, final Map<UUID, String> uuidToWireId) {
+    if (move.getRoute().isLoad()) {
+      return move.getUnitsToSeaTransports().values().stream()
+          .findFirst()
+          .map(t -> uuidToWireId.get(t.getId()))
+          .map(id -> id == null ? "null" : id)
+          .orElse("null");
+    }
+    if (move.getRoute().isUnload()) {
+      return move.getUnits().stream()
+          .filter(u -> u.getUnitAttachment().getTransportCapacity() > 0)
+          .map(u -> uuidToWireId.get(u.getId()))
+          .filter(id -> id != null)
+          .findFirst()
+          .orElse("null");
+    }
+    return "null";
+  }
+
+  private static String maybeQuote(final String s) {
+    return s != null && s.contains(" ") ? '"' + s + '"' : s;
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/CombatMoveExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/CombatMoveExecutor.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.triplea.ai.sidecar.AiTraceLogger;
 import org.triplea.ai.sidecar.dto.CombatMoveOrder;
 import org.triplea.ai.sidecar.dto.CombatMovePlan;
 import org.triplea.ai.sidecar.dto.CombatMoveRequest;
@@ -20,33 +21,35 @@ import org.triplea.ai.sidecar.wire.WireStateApplier;
 
 /**
  * Runs {@link games.strategy.triplea.ai.pro.ProAi#invokeCombatMoveForSidecar} on the session's
- * bounded offensive executor, captures every {@link games.strategy.engine.data.MoveDescription}
- * via a {@link RecordingMoveDelegate}, partitions captured moves into standard moves and
+ * bounded offensive executor, captures every {@link games.strategy.engine.data.MoveDescription} via
+ * a {@link RecordingMoveDelegate}, partitions captured moves into standard moves and
  * strategic-bombing-raid moves, and projects each to a wire-shaped {@link CombatMoveOrder}.
  *
  * <h2>Ordering contract</h2>
  *
  * <p>The bot must call the {@code politics} decision kind first (handled by {@link
  * PoliticsExecutor}), which dispatches war declarations server-side and sends a fresh
- * post-declaration {@link org.triplea.ai.sidecar.wire.WireState} in the subsequent
- * {@code combat-move} request. This executor therefore receives a WireState that already
- * reflects post-politics relationships.
+ * post-declaration {@link org.triplea.ai.sidecar.wire.WireState} in the subsequent {@code
+ * combat-move} request. This executor therefore receives a WireState that already reflects
+ * post-politics relationships.
  *
  * <p>Before dispatching to the ProAi this executor enforces the contract established in #1763:
+ *
  * <ol>
- *   <li>Load the session snapshot (if present) and call
- *       {@link ProSessionSnapshotStore#restoreUnitIdMap} — pre-seeds the live {@code unitIdMap}
- *       so that {@code computeIfAbsent} inside {@link WireStateApplier} assigns the same UUIDs
- *       that the purchase snapshot used, not fresh random ones.
- *   <li>{@link WireStateApplier#apply} — hydrates live {@link GameData} from wire state,
- *       including the {@code relationships} field that reflects the post-politics graph.
+ *   <li>Load the session snapshot (if present) and call {@link
+ *       ProSessionSnapshotStore#restoreUnitIdMap} — pre-seeds the live {@code unitIdMap} so that
+ *       {@code computeIfAbsent} inside {@link WireStateApplier} assigns the same UUIDs that the
+ *       purchase snapshot used, not fresh random ones.
+ *   <li>{@link WireStateApplier#apply} — hydrates live {@link GameData} from wire state, including
+ *       the {@code relationships} field that reflects the post-politics graph.
  *   <li>{@link games.strategy.triplea.ai.pro.ProAi#restoreCombatMoveMapFromSnapshot} — restores
  *       {@code storedCombatMoveMap} from the snapshot. No-op if already populated this JVM session.
  *   <li>Submit {@code invokeCombatMoveForSidecar} to the session's single-threaded offensive
  *       executor.
  * </ol>
  */
-public final class CombatMoveExecutor implements DecisionExecutor<CombatMoveRequest, CombatMovePlan> {
+public final class CombatMoveExecutor
+    implements DecisionExecutor<CombatMoveRequest, CombatMovePlan> {
 
   private final ProSessionSnapshotStore snapshotStore;
 
@@ -66,8 +69,7 @@ public final class CombatMoveExecutor implements DecisionExecutor<CombatMoveRequ
     // Step 2: hydrate GameData from wire state
     WireStateApplier.apply(data, request.state(), session.unitIdMap());
 
-    final GamePlayer player =
-        data.getPlayerList().getPlayerId(request.state().currentPlayer());
+    final GamePlayer player = data.getPlayerList().getPlayerId(request.state().currentPlayer());
     if (player == null) {
       throw new IllegalArgumentException(
           "Unknown player in CombatMoveRequest: " + request.state().currentPlayer());
@@ -83,7 +85,8 @@ public final class CombatMoveExecutor implements DecisionExecutor<CombatMoveRequ
 
     if (proAi.storedCombatMoveMapIsNull()) {
       throw new IllegalStateException(
-          "storedCombatMoveMap is null for session " + session.key()
+          "storedCombatMoveMap is null for session "
+              + session.key()
               + " — purchase must run before combat-move");
     }
 
@@ -128,6 +131,8 @@ public final class CombatMoveExecutor implements DecisionExecutor<CombatMoveRequ
     final List<CombatMoveOrder> sbrMoves = new ArrayList<>();
 
     for (final RecordingMoveDelegate.CapturedMove captured : recorder.captured()) {
+      AiTraceLogger.logCapturedMove(
+          player.getName(), "combat-move", captured.move(), captured.isBombing(), uuidToWireId);
       if (captured.isBombing()) {
         sbrMoves.addAll(ExecutorSupport.projectOrders(captured.move(), uuidToWireId));
       } else {

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.triplea.ai.sidecar.AiTraceLogger;
 import org.triplea.ai.sidecar.dto.CombatMoveOrder;
 import org.triplea.ai.sidecar.dto.NoncombatMovePlan;
 import org.triplea.ai.sidecar.dto.NoncombatMoveRequest;
@@ -19,25 +20,24 @@ import org.triplea.ai.sidecar.session.Session;
 import org.triplea.ai.sidecar.wire.WireStateApplier;
 
 /**
- * Runs {@link games.strategy.triplea.ai.pro.ProAi#invokeNonCombatMoveForSidecar} on the
- * session's bounded offensive executor, captures every {@link
- * games.strategy.engine.data.MoveDescription} via a {@link RecordingMoveDelegate}, and projects
- * each to a wire-shaped {@link CombatMoveOrder}.
+ * Runs {@link games.strategy.triplea.ai.pro.ProAi#invokeNonCombatMoveForSidecar} on the session's
+ * bounded offensive executor, captures every {@link games.strategy.engine.data.MoveDescription} via
+ * a {@link RecordingMoveDelegate}, and projects each to a wire-shaped {@link CombatMoveOrder}.
  *
  * <p>The noncombat phase never issues strategic-bombing-raid moves, so all captured moves land in
- * {@code moves}; an {@link AssertionError} is thrown if any captured move has
- * {@code isBombing == true} (belt-and-suspenders invariant).
+ * {@code moves}; an {@link AssertionError} is thrown if any captured move has {@code isBombing ==
+ * true} (belt-and-suspenders invariant).
  *
  * <h2>Ordering contract</h2>
  *
  * <ol>
- *   <li>Load snapshot; call {@link ProSessionSnapshotStore#restoreUnitIdMap} before
- *       {@link WireStateApplier}.
+ *   <li>Load snapshot; call {@link ProSessionSnapshotStore#restoreUnitIdMap} before {@link
+ *       WireStateApplier}.
  *   <li>{@link WireStateApplier#apply}.
- *   <li>{@link games.strategy.triplea.ai.pro.ProAi#restoreFactoryMoveMapFromSnapshot} and
- *       {@link games.strategy.triplea.ai.pro.ProAi#restorePurchaseTerritoriesFromSnapshot} —
- *       both maps are needed; {@code storedPurchaseTerritories} is preserved (not cleared) after
- *       this phase so the place executor can consume it.
+ *   <li>{@link games.strategy.triplea.ai.pro.ProAi#restoreFactoryMoveMapFromSnapshot} and {@link
+ *       games.strategy.triplea.ai.pro.ProAi#restorePurchaseTerritoriesFromSnapshot} — both maps are
+ *       needed; {@code storedPurchaseTerritories} is preserved (not cleared) after this phase so
+ *       the place executor can consume it.
  *   <li>Submit {@code invokeNonCombatMoveForSidecar} to the session's single-threaded executor.
  * </ol>
  */
@@ -62,8 +62,7 @@ public final class NoncombatMoveExecutor
     // Step 2: hydrate GameData from wire state
     WireStateApplier.apply(data, request.state(), session.unitIdMap());
 
-    final GamePlayer player =
-        data.getPlayerList().getPlayerId(request.state().currentPlayer());
+    final GamePlayer player = data.getPlayerList().getPlayerId(request.state().currentPlayer());
     if (player == null) {
       throw new IllegalArgumentException(
           "Unknown player in NoncombatMoveRequest: " + request.state().currentPlayer());
@@ -75,14 +74,16 @@ public final class NoncombatMoveExecutor
     final var proAi = session.proAi();
 
     // Step 3: restore storedFactoryMoveMap and storedPurchaseTerritories
-    snapOpt.ifPresent(snap -> {
-      proAi.restoreFactoryMoveMapFromSnapshot(snap, data);
-      proAi.restorePurchaseTerritoriesFromSnapshot(snap, data);
-    });
+    snapOpt.ifPresent(
+        snap -> {
+          proAi.restoreFactoryMoveMapFromSnapshot(snap, data);
+          proAi.restorePurchaseTerritoriesFromSnapshot(snap, data);
+        });
 
     if (proAi.storedFactoryMoveMapIsNull()) {
       throw new IllegalStateException(
-          "storedFactoryMoveMap is null for session " + session.key()
+          "storedFactoryMoveMap is null for session "
+              + session.key()
               + " — purchase must run before noncombat-move");
     }
 
@@ -130,6 +131,8 @@ public final class NoncombatMoveExecutor
         throw new AssertionError(
             "isBombing == true in noncombat-move phase — ProAI invariant violated");
       }
+      AiTraceLogger.logCapturedMove(
+          player.getName(), "noncombat-move", captured.move(), false, uuidToWireId);
       moves.addAll(ExecutorSupport.projectOrders(captured.move(), uuidToWireId));
     }
 

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PlaceExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PlaceExecutor.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.triplea.ai.sidecar.AiTraceLogger;
 import org.triplea.ai.sidecar.dto.PlaceOrder;
 import org.triplea.ai.sidecar.dto.PlacePlan;
 import org.triplea.ai.sidecar.dto.PlaceRequest;
@@ -31,8 +32,8 @@ import org.triplea.ai.sidecar.wire.WireStateApplier;
  * <h2>Ordering contract</h2>
  *
  * <ol>
- *   <li>Load snapshot; call {@link ProSessionSnapshotStore#restoreUnitIdMap} before
- *       {@link WireStateApplier}.
+ *   <li>Load snapshot; call {@link ProSessionSnapshotStore#restoreUnitIdMap} before {@link
+ *       WireStateApplier}.
  *   <li>{@link WireStateApplier#apply}.
  *   <li>{@link games.strategy.triplea.ai.pro.ProAi#restorePurchaseTerritoriesFromSnapshot} —
  *       re-populates {@code storedPurchaseTerritories} when crossing an HTTP boundary.
@@ -43,9 +44,9 @@ import org.triplea.ai.sidecar.wire.WireStateApplier;
  *
  * <h2>Type-mismatch silent no-op</h2>
  *
- * <p>{@code ProPurchaseAi.place()} resolves each {@code placeUnit} in
- * {@code storedPurchaseTerritories} by scanning {@code player.getUnitCollection()} for a unit with
- * a matching type. If no match is found (e.g., the session's {@link GameData} was deserialized
+ * <p>{@code ProPurchaseAi.place()} resolves each {@code placeUnit} in {@code
+ * storedPurchaseTerritories} by scanning {@code player.getUnitCollection()} for a unit with a
+ * matching type. If no match is found (e.g., the session's {@link GameData} was deserialized
  * without the purchased units in the player's collection), the inner loop emits an empty list and
  * {@code doPlace()} is called with zero units. This is faithful to the reference algorithm: no
  * exception is thrown, but a WARNING is logged when the total captured unit count is smaller than
@@ -73,8 +74,7 @@ public final class PlaceExecutor implements DecisionExecutor<PlaceRequest, Place
     // Step 2: hydrate GameData from wire state
     WireStateApplier.apply(data, request.state(), session.unitIdMap());
 
-    final GamePlayer player =
-        data.getPlayerList().getPlayerId(request.state().currentPlayer());
+    final GamePlayer player = data.getPlayerList().getPlayerId(request.state().currentPlayer());
     if (player == null) {
       throw new IllegalArgumentException(
           "Unknown player in PlaceRequest: " + request.state().currentPlayer());
@@ -133,7 +133,12 @@ public final class PlaceExecutor implements DecisionExecutor<PlaceRequest, Place
     // own validation did not catch the case — a WARNING is logged in groupCapturesIntoPlan.
     final Set<Territory> conqueredThisTurn = collectConqueredThisTurn(data);
 
-    return groupCapturesIntoPlan(recorder.captured(), conqueredThisTurn, session.key().toString());
+    final PlacePlan plan =
+        groupCapturesIntoPlan(recorder.captured(), conqueredThisTurn, session.key().toString());
+    for (final PlaceOrder order : plan.placements()) {
+      AiTraceLogger.logPlaceOrder(player.getName(), order.territoryName(), order.unitTypes());
+    }
+    return plan;
   }
 
   static Set<Territory> collectConqueredThisTurn(final GameData data) {
@@ -174,16 +179,20 @@ public final class PlaceExecutor implements DecisionExecutor<PlaceRequest, Place
       // delegate-level validation did not catch the conquered-this-turn case — investigate.
       LOG.log(
           System.Logger.Level.WARNING,
-          "PlaceExecutor: belt-and-suspenders filter dropped " + droppedConquered
-              + " unit placements at conquered-this-turn territories for session " + sessionKey
+          "PlaceExecutor: belt-and-suspenders filter dropped "
+              + droppedConquered
+              + " unit placements at conquered-this-turn territories for session "
+              + sessionKey
               + " — RecordingPlaceDelegate should have rejected these at capture time");
     }
 
     if (totalCaptured == 0 && !captures.isEmpty() && droppedConquered == 0) {
       // Captures exist but all had empty unit lists — type-mismatch no-op path
-      LOG.log(System.Logger.Level.WARNING,
+      LOG.log(
+          System.Logger.Level.WARNING,
           "PlaceExecutor: all placeUnits calls returned empty unit lists for session "
-              + sessionKey + " — player.getUnitCollection() likely missing purchased units");
+              + sessionKey
+              + " — player.getUnitCollection() likely missing purchased units");
     }
 
     final List<PlaceOrder> placements = new ArrayList<>();

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PoliticsExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PoliticsExecutor.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
+import org.triplea.ai.sidecar.AiTraceLogger;
 import org.triplea.ai.sidecar.dto.PoliticsPlan;
 import org.triplea.ai.sidecar.dto.PoliticsRequest;
 import org.triplea.ai.sidecar.dto.WarDeclaration;
@@ -37,10 +38,10 @@ import org.triplea.ai.sidecar.wire.WireStateApplier;
  *
  * <h2>Session setup</h2>
  *
- * <p>Mirrors the setup in {@link CombatMoveExecutor}: snapshot restore, WireState hydration,
- * ProAi initialization, and delegate registration. In addition this executor installs the politics
- * and other required delegates (same as {@link PurchaseExecutor} does) since they may have been
- * cleared by the GameData clone round-trip.
+ * <p>Mirrors the setup in {@link CombatMoveExecutor}: snapshot restore, WireState hydration, ProAi
+ * initialization, and delegate registration. In addition this executor installs the politics and
+ * other required delegates (same as {@link PurchaseExecutor} does) since they may have been cleared
+ * by the GameData clone round-trip.
  */
 public final class PoliticsExecutor implements DecisionExecutor<PoliticsRequest, PoliticsPlan> {
 
@@ -62,8 +63,7 @@ public final class PoliticsExecutor implements DecisionExecutor<PoliticsRequest,
     // Step 2: hydrate GameData from wire state (includes relationships field)
     WireStateApplier.apply(data, request.state(), session.unitIdMap());
 
-    final GamePlayer player =
-        data.getPlayerList().getPlayerId(request.state().currentPlayer());
+    final GamePlayer player = data.getPlayerList().getPlayerId(request.state().currentPlayer());
     if (player == null) {
       throw new IllegalArgumentException(
           "Unknown player in PoliticsRequest: " + request.state().currentPlayer());
@@ -87,8 +87,7 @@ public final class PoliticsExecutor implements DecisionExecutor<PoliticsRequest,
     // (which has no ObservingPoliticsDelegate installed). The result is that the politics
     // delegate on dataCopy has attemptsLeftThisTurn=0 (already consumed in the purchase
     // simulation), filtering out all valid war actions.
-    final AtomicReference<List<WarDeclaration>> declarationsRef =
-        new AtomicReference<>(List.of());
+    final AtomicReference<List<WarDeclaration>> declarationsRef = new AtomicReference<>(List.of());
     final Future<Void> future =
         session
             .offensiveExecutor()
@@ -122,6 +121,9 @@ public final class PoliticsExecutor implements DecisionExecutor<PoliticsRequest,
       throw new RuntimeException("PoliticsExecutor failed", cause);
     }
 
+    for (final WarDeclaration decl : declarationsRef.get()) {
+      AiTraceLogger.logWarDeclaration(player.getName(), decl.target());
+    }
     return new PoliticsPlan(declarationsRef.get());
   }
 

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
@@ -9,10 +9,10 @@ import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.engine.delegate.IDelegate;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.ai.pro.ProAi;
 import games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge;
-import games.strategy.engine.delegate.IDelegate;
 import games.strategy.triplea.delegate.EndRoundDelegate;
 import games.strategy.triplea.delegate.MoveDelegate;
 import games.strategy.triplea.delegate.PlaceDelegate;
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.triplea.ai.sidecar.AiTraceLogger;
 import org.triplea.ai.sidecar.dto.PurchaseOrder;
 import org.triplea.ai.sidecar.dto.PurchasePlan;
 import org.triplea.ai.sidecar.dto.PurchaseRequest;
@@ -34,42 +35,40 @@ import org.triplea.ai.sidecar.wire.WireStateApplier;
 import org.triplea.java.collections.IntegerMap;
 
 /**
- * Runs {@link ProAi#invokePurchaseForSidecar} on the session's bounded offensive executor,
- * captures the resulting {@code IntegerMap<ProductionRule>} via a {@link
- * RecordingPurchaseDelegate}, trims the captured map to fit the session player's PU budget,
- * and projects the result into a wire-shaped {@link PurchasePlan}.
+ * Runs {@link ProAi#invokePurchaseForSidecar} on the session's bounded offensive executor, captures
+ * the resulting {@code IntegerMap<ProductionRule>} via a {@link RecordingPurchaseDelegate}, trims
+ * the captured map to fit the session player's PU budget, and projects the result into a
+ * wire-shaped {@link PurchasePlan}.
  *
  * <h2>Why trim-to-fit is a necessary backstop (not a reimplementation)</h2>
  *
- * <p>TripleA's {@code ProPurchaseAi} consults a {@code ProResourceTracker} inside the
- * per-territory purchase loop, but the final {@code IntegerMap<ProductionRule>} that is handed
- * to {@code purchaseDelegate.purchase(...)} is produced by
- * {@code ProPurchaseAi.populateProductionRuleMap} (see
- * {@code game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java:2404-2429}):
- * that method iterates {@code ProPurchaseOption}s and counts
- * {@code ProPlaceTerritory.getPlaceUnits()} entries per option. It does <b>not</b>
- * re-consult {@code ProResourceTracker} at aggregation time, so nothing forces the aggregated
- * cost to equal the cost tracked during the loop.
+ * <p>TripleA's {@code ProPurchaseAi} consults a {@code ProResourceTracker} inside the per-territory
+ * purchase loop, but the final {@code IntegerMap<ProductionRule>} that is handed to {@code
+ * purchaseDelegate.purchase(...)} is produced by {@code ProPurchaseAi.populateProductionRuleMap}
+ * (see {@code game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java:2404-2429}):
+ * that method iterates {@code ProPurchaseOption}s and counts {@code
+ * ProPlaceTerritory.getPlaceUnits()} entries per option. It does <b>not</b> re-consult {@code
+ * ProResourceTracker} at aggregation time, so nothing forces the aggregated cost to equal the cost
+ * tracked during the loop.
  *
- * <p>The map produced by {@code populateProductionRuleMap} is then passed directly to
- * {@code purchaseDelegate.purchase(purchaseMap)} at
- * {@code ProPurchaseAi.java:251} (main purchase path) and {@code ProPurchaseAi.java:380}
- * (upgrade / second-pass path), with no intervening validation. Neither
- * {@code ai/pro/util/ProPurchaseUtils.java} nor {@code ai/pro/util/ProPurchaseValidationUtils.java}
- * contains any clamp/trim/budget-check helper — a grep for {@code trim|clamp|budget|exceed}
- * across both files returns zero hits. A 123 PU overrun against a 120 PU budget has been
- * observed in practice (see Phase 3 spec §5 note); this is consistent with the gap described
- * above.
+ * <p>The map produced by {@code populateProductionRuleMap} is then passed directly to {@code
+ * purchaseDelegate.purchase(purchaseMap)} at {@code ProPurchaseAi.java:251} (main purchase path)
+ * and {@code ProPurchaseAi.java:380} (upgrade / second-pass path), with no intervening validation.
+ * Neither {@code ai/pro/util/ProPurchaseUtils.java} nor {@code
+ * ai/pro/util/ProPurchaseValidationUtils.java} contains any clamp/trim/budget-check helper — a grep
+ * for {@code trim|clamp|budget|exceed} across both files returns zero hits. A 123 PU overrun
+ * against a 120 PU budget has been observed in practice (see Phase 3 spec §5 note); this is
+ * consistent with the gap described above.
  *
- * <p>The {@link #trimToFit} backstop implemented here is therefore <b>a necessary backstop,
- * not a paraphrase of an existing TripleA routine</b>. It reads exactly the map that ProAi
- * would have handed to the live purchase delegate and drops production-rule units from the
- * lowest-priority end until the total PU cost fits the caller's budget.
+ * <p>The {@link #trimToFit} backstop implemented here is therefore <b>a necessary backstop, not a
+ * paraphrase of an existing TripleA routine</b>. It reads exactly the map that ProAi would have
+ * handed to the live purchase delegate and drops production-rule units from the lowest-priority end
+ * until the total PU cost fits the caller's budget.
  *
  * <p><b>Trim order:</b> reverse iteration over the captured {@code IntegerMap<ProductionRule>}.
  * {@code populateProductionRuleMap} iterates {@code ProPurchaseOptionMap.getAllOptions()} in
- * descending priority, so the resulting {@code IntegerMap} preserves that ordering; dropping
- * from the tail therefore drops the lowest priority rules first.
+ * descending priority, so the resulting {@code IntegerMap} preserves that ordering; dropping from
+ * the tail therefore drops the lowest priority rules first.
  */
 public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest, PurchasePlan> {
 
@@ -81,12 +80,13 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
   }
 
   /**
-   * No-arg constructor for tests and contexts where snapshot persistence is not needed. Saves go
-   * to a subdirectory of {@code java.io.tmpdir} and are harmless.
+   * No-arg constructor for tests and contexts where snapshot persistence is not needed. Saves go to
+   * a subdirectory of {@code java.io.tmpdir} and are harmless.
    */
   public PurchaseExecutor() {
-    this(new ProSessionSnapshotStore(
-        Path.of(System.getProperty("java.io.tmpdir"), "sidecar-snapshots")));
+    this(
+        new ProSessionSnapshotStore(
+            Path.of(System.getProperty("java.io.tmpdir"), "sidecar-snapshots")));
   }
 
   @Override
@@ -94,8 +94,7 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
     final GameData data = session.gameData();
     WireStateApplier.apply(data, request.state(), session.unitIdMap());
 
-    final GamePlayer player =
-        data.getPlayerList().getPlayerId(request.state().currentPlayer());
+    final GamePlayer player = data.getPlayerList().getPlayerId(request.state().currentPlayer());
     if (player == null) {
       throw new IllegalArgumentException(
           "Unknown player in PurchaseRequest: " + request.state().currentPlayer());
@@ -157,13 +156,16 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
     final IntegerMap<ProductionRule> trimmed = trimToFit(captured, pusToSpend, pus);
 
     final List<PurchaseOrder> buys = toPurchaseOrders(trimmed);
+    for (final PurchaseOrder order : buys) {
+      AiTraceLogger.logPurchaseOrder(player.getName(), order.unitType(), order.count());
+    }
     final List<RepairOrder> repairs = toRepairOrders(recorder.capturedRepair(), data);
     return new PurchasePlan(buys, repairs);
   }
 
   /**
-   * Drop rules in reverse-priority order (iterating from the tail of the captured map) until
-   * the total PU cost fits {@code pusBudget}. See the class Javadoc for the justification.
+   * Drop rules in reverse-priority order (iterating from the tail of the captured map) until the
+   * total PU cost fits {@code pusBudget}. See the class Javadoc for the justification.
    */
   static IntegerMap<ProductionRule> trimToFit(
       final IntegerMap<ProductionRule> captured, final int pusBudget, final Resource pus) {


### PR DESCRIPTION
## Summary

- Adds `AiTraceLogger` utility in `org.triplea.ai.sidecar` — emits single-line `[AI-TRACE]` structured log entries via `System.Logger`, no new deps
- Wires it into `PurchaseExecutor`, `PlaceExecutor`, and `PoliticsExecutor`
- Audited sidecar for multi-line log offenders — none found

**Deferred (pending foxtrot PR #25):** `CombatMoveExecutor` and `NoncombatMoveExecutor`. Those files are being changed by #25 (load/unload kind wiring). Will rebase and add move-executor traces after #25 merges.

## Sample log output

```
[AI-TRACE] side=sidecar nation=Germans phase=purchase units=[infantry×3,armour×1]
[AI-TRACE] side=sidecar nation=Germans phase=place territory=Germany units=[infantry×2,armour×1]
[AI-TRACE] side=sidecar nation=Germans phase=place territory="Western Germany" units=[infantry×1]
[AI-TRACE] side=sidecar nation=Japan phase=politics target=USA
```

## Format spec

- Prefix: `[AI-TRACE] side=sidecar`
- `nation=` — current player name from wire state
- `phase=` — executor phase (purchase / place / politics / combat-move / noncombat-move)
- `units=[type×N,…]` — unit counts by type (purchase: type from `PurchaseOrder`; place: from `PlaceOrder.unitTypes()`)
- Territory names with spaces are double-quoted
- All entries are single-line

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:compileJava` — compiles clean
- [x] `./gradlew :game-app:ai-sidecar:test` — all existing tests pass (0 failures)
- [x] `./gradlew :game-app:ai-sidecar:spotlessCheck` — no formatting violations in changed files
- [x] No new checkstyle violations (13 pre-existing warnings in dto/ files unchanged)
- [ ] 🧑 Manual: Start a live match, `docker compose logs ai-sidecar | grep AI-TRACE` — verify purchase/place/politics lines appear on Germans' first turn

Closes #1846 (partial — move executors to follow after foxtrot's #25 merges)