### PR TITLE
fix(ai-sidecar): filter non-primary nations from politics declarations

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PoliticsObserver.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PoliticsObserver.java
@@ -6,6 +6,7 @@ import games.strategy.triplea.attachments.PoliticalActionAttachment;
 import games.strategy.triplea.delegate.PoliticsDelegate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.triplea.ai.sidecar.dto.WarDeclaration;
 
 /**
@@ -22,6 +23,17 @@ import org.triplea.ai.sidecar.dto.WarDeclaration;
  * {@link PoliticsDelegate} (or removes the observing one if there was no original).
  */
 public final class PoliticsObserver {
+
+  /**
+   * The 9 primary Map Room nations. TripleA's ww2global40_2nd_edition.xml contains split factions
+   * like {@code UK_Pacific} and {@code Dutch} that are not first-class players in Map Room's engine.
+   * War declarations against these non-primary names are rejected by Map Room with
+   * {@code ERROR: invalid move: declareWar args: <name>}. Filter them out here so only valid
+   * targets are returned by {@link #toWarDeclarations}.
+   */
+  private static final Set<String> MAP_ROOM_PRIMARY_NATIONS =
+      Set.of("Americans", "ANZAC", "British", "Chinese", "French",
+             "Germans", "Italians", "Japanese", "Russians");
 
   private final GameData gameData;
   private final PoliticsDelegate original;
@@ -96,11 +108,18 @@ public final class PoliticsObserver {
         final String p1 = change.player1.getName();
         final String p2 = change.player2.getName();
         final String acting = actingPlayer.getName();
+        final String target;
         if (acting.equals(p1)) {
-          out.add(new WarDeclaration(p2));
+          target = p2;
         } else if (acting.equals(p2)) {
-          out.add(new WarDeclaration(p1));
+          target = p1;
+        } else {
+          continue; // action didn't involve the acting player
         }
+        if (!MAP_ROOM_PRIMARY_NATIONS.contains(target)) {
+          continue; // non-primary (UK_Pacific, Dutch, etc.) — skip
+        }
+        out.add(new WarDeclaration(target));
       }
     }
     return out;

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PoliticsObserverTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PoliticsObserverTest.java
@@ -84,6 +84,49 @@ class PoliticsObserverTest {
   }
 
   @Test
+  void filtersNonPrimaryNations_UKPacific() throws MutableProperty.InvalidValueException {
+    final GameData data = fresh();
+    // Japanese is the acting player declaring war on UK_Pacific (a TripleA split-UK faction
+    // not recognised by Map Room's engine). The observer must filter it out.
+    final GamePlayer japanese = data.getPlayerList().getPlayerId("Japanese");
+    final PoliticsObserver observer = PoliticsObserver.attach(data);
+
+    // Build an action: Japanese vs UK_Pacific → war.
+    final PoliticalActionAttachment action = buildWarAction(data, "Japanese", "UK_Pacific");
+    observer.recordAttempt(action);
+
+    assertThat(observer.toWarDeclarations(japanese)).isEmpty();
+    observer.detach();
+  }
+
+  @Test
+  void filtersNonPrimaryNations_Dutch() throws MutableProperty.InvalidValueException {
+    final GameData data = fresh();
+    final GamePlayer japanese = data.getPlayerList().getPlayerId("Japanese");
+    final PoliticsObserver observer = PoliticsObserver.attach(data);
+
+    final PoliticalActionAttachment action = buildWarAction(data, "Japanese", "Dutch");
+    observer.recordAttempt(action);
+
+    assertThat(observer.toWarDeclarations(japanese)).isEmpty();
+    observer.detach();
+  }
+
+  @Test
+  void keepsPrimaryNationsInWarDeclarations() throws MutableProperty.InvalidValueException {
+    final GameData data = fresh();
+    final GamePlayer japanese = data.getPlayerList().getPlayerId("Japanese");
+    final PoliticsObserver observer = PoliticsObserver.attach(data);
+
+    // British is a primary — must be kept.
+    final PoliticalActionAttachment action = buildWarAction(data, "Japanese", "British");
+    observer.recordAttempt(action);
+
+    assertThat(observer.toWarDeclarations(japanese)).containsExactly(new WarDeclaration("British"));
+    observer.detach();
+  }
+
+  @Test
   void capturedListIsAccessibleAfterDetach() throws MutableProperty.InvalidValueException {
     final GameData data = fresh();
     final GamePlayer germans = data.getPlayerList().getPlayerId("Germans");


### PR DESCRIPTION
## Summary

Fixes part of map-room/map-room#1849.

- `PoliticsObserver.toWarDeclarations` now filters out TripleA-internal split factions (`UK_Pacific`, `Dutch`, etc.) that Map Room's engine doesn't recognise as valid `declareWar` targets.
- Added `MAP_ROOM_PRIMARY_NATIONS` constant (the 9 Map Room primaries) as a guard in the inner loop.
- Three new test cases: `filtersNonPrimaryNations_UKPacific`, `filtersNonPrimaryNations_Dutch`, `keepsPrimaryNationsInWarDeclarations`.

## Root cause

Japan's politics phase included `UK_Pacific` in a `relationshipChange`. Map Room rejected it with `INVALID_MOVE`, which then cascaded stale stateID failures for every subsequent dispatch.

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:test --tests 'org.triplea.ai.sidecar.exec.PoliticsObserverTest'` — all 8 tests pass (5 existing + 3 new)
- [x] `./gradlew :game-app:ai-sidecar:test` — full ai-sidecar suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)