### PR TITLE
feat(ai-sidecar): route ProLogger to stdout + log-level env var

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/SidecarMain.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/SidecarMain.java
@@ -1,11 +1,17 @@
 package org.triplea.ai.sidecar;
 
+import games.strategy.triplea.ai.pro.logging.ProLogSettings;
+import games.strategy.triplea.ai.pro.logging.ProLogUi;
 import games.strategy.triplea.settings.ClientSetting;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 import org.triplea.ai.sidecar.http.HttpService;
 import org.triplea.ai.sidecar.session.SessionReaper;
 import org.triplea.ai.sidecar.session.SessionRegistry;
@@ -14,6 +20,7 @@ public final class SidecarMain {
   private SidecarMain() {}
 
   public static void main(final String[] args) throws IOException, InterruptedException {
+    initializeLogging();
     ClientSetting.initialize();
 
     final SidecarConfig cfg = SidecarConfig.fromEnv(System.getenv());
@@ -56,5 +63,54 @@ public final class SidecarMain {
     final SessionRegistry registry = new SessionRegistry(canonical, dataDir);
     registry.rehydrate();
     return HttpService.start(cfg, registry);
+  }
+
+  private static void initializeLogging() {
+    // Load baseline config from classpath resource first.
+    try (final var is = SidecarMain.class.getResourceAsStream("/logging.properties")) {
+      if (is != null) {
+        LogManager.getLogManager().readConfiguration(is);
+      }
+    } catch (final IOException e) {
+      System.err.println("Failed to load sidecar logging.properties: " + e.getMessage());
+    }
+
+    // Apply SIDECAR_LOG_LEVEL env var override on top of the baseline.
+    final Level julLevel = parseJulLevel(System.getenv("SIDECAR_LOG_LEVEL"));
+    final Logger root = Logger.getLogger("");
+    root.setLevel(julLevel);
+    for (final var handler : root.getHandlers()) {
+      handler.setLevel(julLevel);
+    }
+
+    // Route ProLogger messages (game-core ProAi debug output) to stdout via System.Logger.
+    final System.Logger proLogger = System.getLogger("ProAi");
+    ProLogUi.setExternalHandler(
+        message -> proLogger.log(System.Logger.Level.INFO, "[ProAI] {0}", message));
+
+    // Mirror the level into ProLogSettings so ProLogger's own depth filter matches.
+    ProLogSettings.loadSettings().setLogLevel(julLevel);
+
+    System.getLogger(SidecarMain.class.getName())
+        .log(
+            System.Logger.Level.INFO,
+            "Sidecar logging initialized: level={0}",
+            julLevel.getName());
+  }
+
+  static Level parseJulLevel(final String envValue) {
+    if (envValue == null || envValue.isBlank()) {
+      return Level.INFO;
+    }
+    try {
+      return Level.parse(envValue.toUpperCase(Locale.ROOT));
+    } catch (final IllegalArgumentException e) {
+      System.err.println(
+          "SIDECAR_LOG_LEVEL="
+              + envValue
+              + " is not a valid java.util.logging level; "
+              + "defaulting to INFO. Valid: SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST.");
+      return Level.INFO;
+    }
   }
 }

--- a/game-app/ai-sidecar/src/main/resources/logging.properties
+++ b/game-app/ai-sidecar/src/main/resources/logging.properties
@@ -1,0 +1,12 @@
+# Default sidecar logging configuration.
+# Overridden at runtime by the SIDECAR_LOG_LEVEL env var applied in SidecarMain.initializeLogging.
+
+handlers = java.util.logging.ConsoleHandler
+.level = INFO
+
+# ConsoleHandler writes to stderr by default; docker logs captures both stdout and stderr.
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# Compact single-line format: timestamp level logger - message
+java.util.logging.SimpleFormatter.format = %1$tFT%1$tT %4$s %3$s - %5$s%6$s%n

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarMainLoggingTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarMainLoggingTest.java
@@ -1,0 +1,64 @@
+package org.triplea.ai.sidecar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.logging.Level;
+import org.junit.jupiter.api.Test;
+
+class SidecarMainLoggingTest {
+
+  @Test
+  void parseJulLevelReturnsInfoForNull() {
+    assertEquals(Level.INFO, SidecarMain.parseJulLevel(null));
+  }
+
+  @Test
+  void parseJulLevelReturnsInfoForEmpty() {
+    assertEquals(Level.INFO, SidecarMain.parseJulLevel(""));
+  }
+
+  @Test
+  void parseJulLevelReturnsInfoForBlank() {
+    assertEquals(Level.INFO, SidecarMain.parseJulLevel("   "));
+  }
+
+  @Test
+  void parseJulLevelReturnsInfoForGarbage() {
+    assertEquals(Level.INFO, SidecarMain.parseJulLevel("NONSENSE"));
+  }
+
+  @Test
+  void parseJulLevelReturnsFineForLowerCase() {
+    assertEquals(Level.FINE, SidecarMain.parseJulLevel("fine"));
+  }
+
+  @Test
+  void parseJulLevelReturnsFineForUpperCase() {
+    assertEquals(Level.FINE, SidecarMain.parseJulLevel("FINE"));
+  }
+
+  @Test
+  void parseJulLevelReturnsFineForMixedCase() {
+    assertEquals(Level.FINE, SidecarMain.parseJulLevel("Fine"));
+  }
+
+  @Test
+  void parseJulLevelReturnsFiner() {
+    assertEquals(Level.FINER, SidecarMain.parseJulLevel("FINER"));
+  }
+
+  @Test
+  void parseJulLevelReturnsFinest() {
+    assertEquals(Level.FINEST, SidecarMain.parseJulLevel("FINEST"));
+  }
+
+  @Test
+  void parseJulLevelReturnsWarning() {
+    assertEquals(Level.WARNING, SidecarMain.parseJulLevel("WARNING"));
+  }
+
+  @Test
+  void parseJulLevelReturnsSevere() {
+    assertEquals(Level.SEVERE, SidecarMain.parseJulLevel("SEVERE"));
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogSettings.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogSettings.java
@@ -17,7 +17,7 @@ import org.triplea.io.IoUtils;
 @Getter
 @Setter
 @Slf4j
-final class ProLogSettings implements Serializable {
+public final class ProLogSettings implements Serializable {
   private static final long serialVersionUID = 5532153908942939829L;
   private static final String PROGRAM_SETTINGS = "Program Settings";
   private static ProLogSettings currentSettings;
@@ -27,7 +27,7 @@ final class ProLogSettings implements Serializable {
   private boolean logEnabled = true;
   private Level logLevel = Level.FINEST;
 
-  static ProLogSettings loadSettings() {
+  public static ProLogSettings loadSettings() {
     if (currentSettings == null) {
       currentSettings = loadSettingsImpl();
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogUi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogUi.java
@@ -6,6 +6,7 @@ import games.strategy.triplea.ui.menubar.debug.AiPlayerDebugOption;
 import games.strategy.ui.Util;
 import java.awt.Frame;
 import java.util.List;
+import java.util.function.Consumer;
 import javax.swing.SwingUtilities;
 import lombok.experimental.UtilityClass;
 import org.triplea.swing.key.binding.KeyCode;
@@ -16,6 +17,18 @@ public final class ProLogUi {
   private static ProLogWindow settingsWindow = null;
   private static String currentName = "";
   private static int currentRound = 0;
+  /**
+   * Optional external sink for AI log messages. Set by headless consumers (the AI sidecar) that
+   * need to route ProLogger output to stdout / System.Logger instead of the Swing settings window.
+   * When set, messages are delivered to this handler <em>in addition to</em> the settings window
+   * (if any) — it never replaces the existing UI path.
+   */
+  private static Consumer<String> externalHandler = null;
+
+  /** Set or clear the external log sink. Pass {@code null} to restore UI-only behavior. */
+  public static void setExternalHandler(final Consumer<String> handler) {
+    externalHandler = handler;
+  }
 
   public static List<AiPlayerDebugOption> buildDebugOptions(final Frame frame) {
     Util.ensureOnEventDispatchThread();
@@ -48,6 +61,11 @@ public final class ProLogUi {
   }
 
   static void notifyAiLogMessage(final String message) {
+    final Consumer<String> handler = externalHandler;
+    if (handler != null) {
+      // Direct delivery — no Swing indirection. Safe to call from any thread.
+      handler.accept(message);
+    }
     SwingUtilities.invokeLater(
         () -> {
           if (settingsWindow != null) {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/logging/ProLogUiTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/logging/ProLogUiTest.java
@@ -1,0 +1,52 @@
+package games.strategy.triplea.ai.pro.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ProLogUiTest {
+
+  @AfterEach
+  void clearHandler() {
+    ProLogUi.setExternalHandler(null);
+  }
+
+  @Test
+  void externalHandlerReceivesLogMessages() {
+    final List<String> captured = new ArrayList<>();
+    ProLogUi.setExternalHandler(captured::add);
+
+    // ProLogger.info maps to Level.FINE; default ProLogSettings.logLevel is FINEST,
+    // so FINE passes the depth filter and notifyAiLogMessage is called synchronously
+    // via the external handler (no Swing indirection).
+    ProLogger.info("test message");
+
+    assertThat(captured).hasSize(1);
+    assertThat(captured.get(0)).contains("test message");
+  }
+
+  @Test
+  void externalHandlerReceivesDebugMessages() {
+    final List<String> captured = new ArrayList<>();
+    ProLogUi.setExternalHandler(captured::add);
+
+    ProLogger.debug("debug detail");
+
+    assertThat(captured).hasSize(1);
+    assertThat(captured.get(0)).contains("debug detail");
+  }
+
+  @Test
+  void clearingHandlerStopsCapture() {
+    final List<String> captured = new ArrayList<>();
+    ProLogUi.setExternalHandler(captured::add);
+    ProLogUi.setExternalHandler(null);
+
+    ProLogger.info("should not appear");
+
+    assertThat(captured).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

ProAi's rich debug output (`ProLogger.debug("Possible factory territories: ...")`) was being silently dropped in the headless sidecar because `ProLogUi.notifyAiLogMessage` only posts to a Swing `settingsWindow` that is never initialized in a container.

This PR makes that output visible in `docker logs ai-sidecar`.

### Changes

**`ProLogUi`** — adds an `externalHandler: Consumer<String>` static field (set via `setExternalHandler`). When non-null, `notifyAiLogMessage` delivers the message directly on the calling thread *in addition to* the Swing path (which continues to work normally for UI users). No `@UtilityClass` conflict — the field is mutable static state gated behind a public setter.

**`ProLogSettings`** — widened from package-private to `public` so `SidecarMain` (a different package) can call `loadSettings()`.

**`SidecarMain.initializeLogging()`** (new private method, called first in `main`):
1. Loads `logging.properties` from classpath to configure a compact single-line `ConsoleHandler`.
2. Parses `SIDECAR_LOG_LEVEL` env var (j.u.l level name, case-insensitive; defaults to `INFO`).
3. Applies the level to the j.u.l root logger + all handlers.
4. Wires `ProLogUi.setExternalHandler` to a `System.Logger("ProAi")` so ProAi lines appear with a `[ProAI]` prefix.
5. Mirrors the same level into `ProLogSettings.logLevel` so ProLogger's own depth filter matches.

**`logging.properties`** (new resource) — baseline console config with compact timestamp format.

### Usage

```bash
# Verbose ProAi planning output:
AI_SIDECAR_LOG_LEVEL=FINER docker compose -f docker/docker-compose.dev.yaml up -d ai-sidecar
docker compose -f docker/docker-compose.dev.yaml logs -f ai-sidecar
# Look for lines like:
# 2026-04-17T14:23:01 INFO ProAi - [ProAI]   Possible factory territories: [Germany, France]
```

### Tests

- `ProLogUiTest` — external handler receives/clears messages
- `SidecarMainLoggingTest` — `parseJulLevel` handles null/empty/garbage/valid inputs (11 cases)

## Test plan

- [x] `./gradlew :game-app:game-core:test --tests 'games.strategy.triplea.ai.pro.logging.ProLogUiTest'` passes
- [x] `./gradlew :game-app:ai-sidecar:test --tests 'org.triplea.ai.sidecar.SidecarMainLoggingTest'` passes
- [ ] 🧑 Manual: Set `AI_SIDECAR_LOG_LEVEL=FINER`, start sidecar via docker-compose, trigger a Germans purchase phase, confirm `[ProAI]` lines appear in `docker logs ai-sidecar`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)