### PR TITLE
fix(ai-sidecar): split aircraft from load/unload projection

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/ExecutorSupport.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/ExecutorSupport.java
@@ -9,7 +9,6 @@ import games.strategy.triplea.ai.pro.ProAi;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.battle.IBattle;
-
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -27,16 +26,15 @@ import org.triplea.ai.sidecar.session.Session;
  * <p>Three concerns show up in every defensive executor and are centralised here:
  *
  * <ul>
- *   <li>Lazy {@link PlayerBridge}/{@link GamePlayer} initialisation on the session's {@link
- *       ProAi} (constructed bridge-less by {@link
- *       org.triplea.ai.sidecar.session.SessionRegistry}). Required so {@code
- *       AbstractBasePlayer.getGameData()} — called transitively from {@code
+ *   <li>Lazy {@link PlayerBridge}/{@link GamePlayer} initialisation on the session's {@link ProAi}
+ *       (constructed bridge-less by {@link org.triplea.ai.sidecar.session.SessionRegistry}).
+ *       Required so {@code AbstractBasePlayer.getGameData()} — called transitively from {@code
  *       ProData.initialize} — returns the session's cloned {@link GameData} rather than NPE.
- *   <li>Lazy {@link BattleDelegate} re-registration after a {@code GameData} round-trip clears
- *       the delegate map during {@code postDeSerialize}.
- *   <li>Reflective splicing of a {@link SyntheticBattle} into {@link
- *       BattleTracker#pendingBattles pendingBattles} so ProAi entry points that read the
- *       tracker by battle {@link java.util.UUID} see non-null battle state.
+ *   <li>Lazy {@link BattleDelegate} re-registration after a {@code GameData} round-trip clears the
+ *       delegate map during {@code postDeSerialize}.
+ *   <li>Reflective splicing of a {@link SyntheticBattle} into {@link BattleTracker#pendingBattles
+ *       pendingBattles} so ProAi entry points that read the tracker by battle {@link
+ *       java.util.UUID} see non-null battle state.
  * </ul>
  *
  * <p>Package-private: consumed only by executors in this package.
@@ -59,14 +57,14 @@ final class ExecutorSupport {
   private ExecutorSupport() {}
 
   /**
-   * Attach a {@link PlayerBridge} + {@link GamePlayer} to the session's {@link ProAi} on first
-   * use. No-op if already initialised.
+   * Attach a {@link PlayerBridge} + {@link GamePlayer} to the session's {@link ProAi} on first use.
+   * No-op if already initialised.
    *
    * <p>Synchronized on the {@link Session} instance to prevent a check-then-act race: two
-   * concurrent HTTP threads on the same session could both observe {@code
-   * proAi.getGamePlayer() == null} and call {@code initialize} twice, corrupting the ProAi
-   * internal state. The session record is a stable reference shared across all executors on the
-   * same session, so it is a safe monitor.
+   * concurrent HTTP threads on the same session could both observe {@code proAi.getGamePlayer() ==
+   * null} and call {@code initialize} twice, corrupting the ProAi internal state. The session
+   * record is a stable reference shared across all executors on the same session, so it is a safe
+   * monitor.
    */
   static void ensureProAiInitialized(final Session session, final GamePlayer player) {
     synchronized (session) {
@@ -81,8 +79,8 @@ final class ExecutorSupport {
 
   /**
    * Ensure the cloned game data has a registered {@code battle} delegate. {@link
-   * org.triplea.ai.sidecar.CanonicalGameData#cloneForSession} round-trips {@link GameData}
-   * via {@code ObjectOutputStream}; the delegate map is transient and cleared by {@code
+   * org.triplea.ai.sidecar.CanonicalGameData#cloneForSession} round-trips {@link GameData} via
+   * {@code ObjectOutputStream}; the delegate map is transient and cleared by {@code
    * postDeSerialize()}, so a fresh {@link BattleDelegate} is re-registered here on first use.
    */
   static void ensureBattleDelegate(final GameData data) {
@@ -118,14 +116,18 @@ final class ExecutorSupport {
    * Projects a single validated {@link MoveDescription} to one or more {@link CombatMoveOrder}s.
    *
    * <p>Three cases:
+   *
    * <ul>
-   *   <li><b>Load</b> ({@code route.isLoad()}): land → sea zone. {@code unitsToSeaTransports}
-   *       maps cargo→transport. Grouped by transport so each transport emits one order with all
-   *       its cargo. {@code kind="load"}, {@code transportId} = wire ID of the transport.
-   *   <li><b>Unload</b> ({@code route.isUnload()}): sea zone → land. All units are cargo; the
-   *       engine infers the transport from {@code transportedBy}. One order is emitted for the
-   *       whole batch. {@code kind="unload"}, {@code transportId} = wire ID of first sea unit in
-   *       the move (for traceability; engine does not consume it).
+   *   <li><b>Load</b> ({@code route.isLoad()}): land → sea zone. {@code unitsToSeaTransports} maps
+   *       cargo→transport. Aircraft in the move fly independently — they are NOT cargo and must NOT
+   *       be bundled into {@code kind="load"} orders. Non-air ground cargo is grouped by transport
+   *       so each transport emits one order with all its cargo ({@code kind="load"}, {@code
+   *       transportId} = wire ID of the transport). Aircraft emit as a separate plain-move order
+   *       (no {@code kind}, no {@code transportId}).
+   *   <li><b>Unload</b> ({@code route.isUnload()}): sea zone → land. Non-air, non-transport units
+   *       are cargo ({@code kind="unload"}, {@code transportId} = wire ID of first transport in the
+   *       move for traceability). Aircraft in the move fly independently and emit as a separate
+   *       plain-move order.
    *   <li><b>Plain move</b>: single order, {@code kind="move"}.
    * </ul>
    *
@@ -139,52 +141,91 @@ final class ExecutorSupport {
     final String to = move.getRoute().getEnd().getName();
 
     if (move.getRoute().isLoad()) {
-      // Group cargo by transport; emit one order per transport.
+      final List<Unit> airUnits =
+          move.getUnits().stream().filter(u -> u.getUnitAttachment().isAir()).toList();
+
+      // Group non-air cargo by transport; emit one order per transport.
+      // getUnitsToSeaTransports() can include air→carrier pairs in TripleA's internal
+      // representation — skip those so aircraft never appear in a load order.
       final Map<Unit, List<Unit>> cargoByTransport = new LinkedHashMap<>();
       for (final Map.Entry<Unit, Unit> e : move.getUnitsToSeaTransports().entrySet()) {
+        if (e.getKey().getUnitAttachment().isAir()) {
+          continue; // aircraft-on-carrier pairs: aircraft fly, not loaded
+        }
         cargoByTransport.computeIfAbsent(e.getValue(), k -> new ArrayList<>()).add(e.getKey());
       }
-      // If unitsToSeaTransports is empty despite isLoad(), fall through to plain-move.
-      if (!cargoByTransport.isEmpty()) {
-        final List<CombatMoveOrder> orders = new ArrayList<>();
-        for (final Map.Entry<Unit, List<Unit>> e : cargoByTransport.entrySet()) {
-          final String transportWireId = uuidToWireId.get(e.getKey().getId());
-          final List<String> cargoWireIds = e.getValue().stream()
+
+      final List<CombatMoveOrder> orders = new ArrayList<>();
+      for (final Map.Entry<Unit, List<Unit>> e : cargoByTransport.entrySet()) {
+        final String transportWireId = uuidToWireId.get(e.getKey().getId());
+        final List<String> cargoWireIds = wireIds(e.getValue(), uuidToWireId);
+        if (cargoWireIds.isEmpty()) {
+          continue;
+        }
+        orders.add(new CombatMoveOrder(cargoWireIds, from, to, "load", transportWireId));
+      }
+
+      // Aircraft fly — emit as plain move order.
+      if (!airUnits.isEmpty()) {
+        final List<String> airWireIds = wireIds(airUnits, uuidToWireId);
+        if (!airWireIds.isEmpty()) {
+          orders.add(new CombatMoveOrder(airWireIds, from, to));
+        }
+      }
+
+      if (!orders.isEmpty()) {
+        return orders;
+      }
+      // Fall through to plain-move for edge cases where nothing resolved.
+    } else if (move.getRoute().isUnload()) {
+      final List<Unit> airUnits =
+          move.getUnits().stream().filter(u -> u.getUnitAttachment().isAir()).toList();
+
+      // Non-air, non-transport units are ground cargo being unloaded from a sea transport.
+      final List<String> cargoWireIds =
+          move.getUnits().stream()
+              .filter(u -> !u.getUnitAttachment().isAir())
+              .filter(u -> !u.getUnitAttachment().isTransportCapacity())
               .map(u -> uuidToWireId.get(u.getId()))
               .filter(Objects::nonNull)
               .toList();
-          if (cargoWireIds.isEmpty()) {
-            continue;
-          }
-          orders.add(new CombatMoveOrder(cargoWireIds, from, to, "load", transportWireId));
-        }
-        if (!orders.isEmpty()) {
-          return orders;
+
+      final List<CombatMoveOrder> orders = new ArrayList<>();
+      if (!cargoWireIds.isEmpty()) {
+        final String transportWireId =
+            move.getUnits().stream()
+                .filter(u -> u.getUnitAttachment().getTransportCapacity() > 0)
+                .map(u -> uuidToWireId.get(u.getId()))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+        orders.add(new CombatMoveOrder(cargoWireIds, from, to, "unload", transportWireId));
+      }
+
+      // Aircraft fly — emit as plain move order.
+      if (!airUnits.isEmpty()) {
+        final List<String> airWireIds = wireIds(airUnits, uuidToWireId);
+        if (!airWireIds.isEmpty()) {
+          orders.add(new CombatMoveOrder(airWireIds, from, to));
         }
       }
-    } else if (move.getRoute().isUnload()) {
-      // All non-transport units in the move are cargo. Find the transport for traceability.
-      final List<String> cargoWireIds = move.getUnits().stream()
-          .filter(u -> !u.getUnitAttachment().isTransportCapacity())
-          .map(u -> uuidToWireId.get(u.getId()))
-          .filter(Objects::nonNull)
-          .toList();
-      if (!cargoWireIds.isEmpty()) {
-        final String transportWireId = move.getUnits().stream()
-            .filter(u -> u.getUnitAttachment().getTransportCapacity() > 0)
-            .map(u -> uuidToWireId.get(u.getId()))
-            .filter(Objects::nonNull)
-            .findFirst()
-            .orElse(null);
-        return List.of(new CombatMoveOrder(cargoWireIds, from, to, "unload", transportWireId));
+
+      if (!orders.isEmpty()) {
+        return orders;
       }
     }
 
     // Plain move (or load/unload that resolved to no cargo IDs — fall back to full unit list).
-    final List<String> unitIds = move.getUnits().stream()
-        .map(u -> uuidToWireId.get(u.getId()))
-        .filter(Objects::nonNull)
-        .toList();
+    final List<String> unitIds = wireIds(new ArrayList<>(move.getUnits()), uuidToWireId);
     return List.of(new CombatMoveOrder(unitIds, from, to));
+  }
+
+  /**
+   * Maps a list of units to their Map Room wire IDs, dropping any unit whose ID is not present in
+   * the reverse map (e.g. units that were never registered on the wire state).
+   */
+  private static List<String> wireIds(
+      final List<Unit> units, final Map<UUID, String> uuidToWireId) {
+    return units.stream().map(u -> uuidToWireId.get(u.getId())).filter(Objects::nonNull).toList();
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ProjectOrdersTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ProjectOrdersTest.java
@@ -1,0 +1,345 @@
+package org.triplea.ai.sidecar.exec;
+
+import static games.strategy.triplea.delegate.GameDataTestUtil.bomber;
+import static games.strategy.triplea.delegate.GameDataTestUtil.carrier;
+import static games.strategy.triplea.delegate.GameDataTestUtil.fighter;
+import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
+import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.MoveDescription;
+import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.dto.CombatMoveOrder;
+
+/**
+ * Unit tests for {@link ExecutorSupport#projectOrders}.
+ *
+ * <p>Uses real {@link GameData} from {@link CanonicalGameData} to obtain real unit types so that
+ * {@link games.strategy.triplea.attachments.UnitAttachment#isAir()} returns meaningful values.
+ * Territories are resolved from the canonical map so that {@link Route#isLoad()} and {@link
+ * Route#isUnload()} behave correctly (land→water = load, water→land = unload).
+ */
+class ProjectOrdersTest {
+
+  private static CanonicalGameData canonical;
+  private static GameData data;
+
+  /** A land territory (not water). */
+  private static Territory landTerr;
+
+  /** A water territory adjacent to {@link #landTerr}. */
+  private static Territory seaTerr;
+
+  private static GamePlayer germans;
+
+  @BeforeAll
+  static void init() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+    data = canonical.cloneForSession();
+    germans = data.getPlayerList().getPlayerId("Germans");
+
+    // Find a land territory that has at least one water neighbour, so we can form
+    // a valid load route (land → water) and unload route (water → land).
+    for (final Territory t : data.getMap().getTerritories()) {
+      if (t.isWater()) {
+        continue;
+      }
+      for (final Territory neighbour : data.getMap().getNeighbors(t)) {
+        if (neighbour.isWater()) {
+          landTerr = t;
+          seaTerr = neighbour;
+          break;
+        }
+      }
+      if (landTerr != null) {
+        break;
+      }
+    }
+    assertThat(landTerr).as("must find a land territory adjacent to water").isNotNull();
+    assertThat(seaTerr).as("must find a water territory adjacent to land").isNotNull();
+  }
+
+  // -----------------------------------------------------------------------
+  // Helper: build a wire ID map for a collection of units.
+  // -----------------------------------------------------------------------
+
+  private static Map<UUID, String> wireMap(final List<Unit> units) {
+    final Map<UUID, String> map = new HashMap<>();
+    int i = 0;
+    for (final Unit u : units) {
+      map.put(u.getId(), "wire-" + i++);
+    }
+    return map;
+  }
+
+  private static List<String> wireIds(final List<Unit> units, final Map<UUID, String> wm) {
+    return units.stream().map(u -> wm.get(u.getId())).toList();
+  }
+
+  private static Unit unit(final UnitType type) {
+    return type.create(germans);
+  }
+
+  // -----------------------------------------------------------------------
+  // Load branch tests
+  // -----------------------------------------------------------------------
+
+  /**
+   * Test 1 — Mixed cargo on load: infantry go into a load order; fighter emits as plain move.
+   *
+   * <p>The move carries 2 infantry (via transport) and 1 fighter. The transport map has
+   * {inf1→transport, inf2→transport}. Fighter is not in the transport map.
+   */
+  @Test
+  void loadBranch_mixedCargo_airEmittedAsPlainMove() {
+    final Unit inf1 = unit(infantry(data));
+    final Unit inf2 = unit(infantry(data));
+    final Unit fighter1 = unit(fighter(data));
+    final Unit sea = unit(transport(data));
+
+    final List<Unit> allUnits = List.of(inf1, inf2, fighter1, sea);
+    final Map<UUID, String> wm = wireMap(allUnits);
+
+    final Route route = new Route(landTerr, seaTerr);
+    assertThat(route.isLoad()).as("route must be a load route").isTrue();
+
+    // Only ground units in the transport map.
+    final Map<Unit, Unit> seaTransportMap = Map.of(inf1, sea, inf2, sea);
+    final MoveDescription move = new MoveDescription(allUnits, route, seaTransportMap);
+
+    final List<CombatMoveOrder> orders = ExecutorSupport.projectOrders(move, wm);
+
+    assertThat(orders).hasSize(2);
+
+    final CombatMoveOrder loadOrder =
+        orders.stream().filter(o -> "load".equals(o.kind())).findFirst().orElse(null);
+    assertThat(loadOrder).as("must have a load order").isNotNull();
+    assertThat(loadOrder.unitIds())
+        .containsExactlyInAnyOrder(wm.get(inf1.getId()), wm.get(inf2.getId()));
+    assertThat(loadOrder.transportId()).isEqualTo(wm.get(sea.getId()));
+
+    final CombatMoveOrder airOrder =
+        orders.stream().filter(o -> "move".equals(o.kind())).findFirst().orElse(null);
+    assertThat(airOrder).as("must have a plain-move order for aircraft").isNotNull();
+    assertThat(airOrder.unitIds()).containsExactly(wm.get(fighter1.getId()));
+    assertThat(airOrder.transportId()).isNull();
+  }
+
+  /**
+   * Test 2 — Air-in-cargoByTransport (the bug pattern): move contains 1 fighter, and TripleA's
+   * internal representation puts the fighter in {@code getUnitsToSeaTransports()} paired with a
+   * carrier. Expect 1 plain move order for the fighter (no load, no carrier ID).
+   */
+  @Test
+  void loadBranch_aircraftInTransportMap_emittedAsPlainMoveNotLoad() {
+    final Unit fighter1 = unit(fighter(data));
+    final Unit carrierUnit = unit(carrier(data));
+
+    final List<Unit> allUnits = List.of(fighter1, carrierUnit);
+    final Map<UUID, String> wm = wireMap(allUnits);
+
+    final Route route = new Route(landTerr, seaTerr);
+    assertThat(route.isLoad()).as("route must be a load route").isTrue();
+
+    // Simulates TripleA including an air→carrier pair in the map.
+    final Map<Unit, Unit> seaTransportMap = Map.of(fighter1, carrierUnit);
+    final MoveDescription move = new MoveDescription(allUnits, route, seaTransportMap);
+
+    final List<CombatMoveOrder> orders = ExecutorSupport.projectOrders(move, wm);
+
+    // No load orders — carrier pairing must be filtered out.
+    assertThat(orders.stream().anyMatch(o -> "load".equals(o.kind())))
+        .as("no load orders — aircraft must not be treated as transport cargo")
+        .isFalse();
+
+    // One plain-move order for the aircraft.
+    assertThat(orders).hasSize(1);
+    final CombatMoveOrder airOrder = orders.get(0);
+    assertThat(airOrder.kind()).isEqualTo("move");
+    assertThat(airOrder.unitIds()).containsExactly(wm.get(fighter1.getId()));
+    assertThat(airOrder.transportId()).isNull();
+  }
+
+  /**
+   * Test 3 — Existing load grouping regression: 3 infantry across 2 transports. Expect exactly 2
+   * load orders (one per transport), no air order.
+   */
+  @Test
+  void loadBranch_multipleTransports_oneOrderPerTransport() {
+    final Unit inf1 = unit(infantry(data));
+    final Unit inf2 = unit(infantry(data));
+    final Unit inf3 = unit(infantry(data));
+    final Unit sea1 = unit(transport(data));
+    final Unit sea2 = unit(transport(data));
+
+    final List<Unit> allUnits = List.of(inf1, inf2, inf3, sea1, sea2);
+    final Map<UUID, String> wm = wireMap(allUnits);
+
+    final Route route = new Route(landTerr, seaTerr);
+    assertThat(route.isLoad()).isTrue();
+
+    final Map<Unit, Unit> seaTransportMap = Map.of(inf1, sea1, inf2, sea1, inf3, sea2);
+    final MoveDescription move = new MoveDescription(allUnits, route, seaTransportMap);
+
+    final List<CombatMoveOrder> orders = ExecutorSupport.projectOrders(move, wm);
+
+    final List<CombatMoveOrder> loadOrders =
+        orders.stream().filter(o -> "load".equals(o.kind())).toList();
+    assertThat(loadOrders).as("must produce 2 load orders (one per transport)").hasSize(2);
+    assertThat(orders.stream().anyMatch(o -> "move".equals(o.kind())))
+        .as("no plain-move orders — no aircraft in this move")
+        .isFalse();
+
+    // Verify cargo assignment by transport.
+    final CombatMoveOrder orderForSea1 =
+        loadOrders.stream()
+            .filter(o -> wm.get(sea1.getId()).equals(o.transportId()))
+            .findFirst()
+            .orElse(null);
+    assertThat(orderForSea1).as("load order for sea1 must exist").isNotNull();
+    assertThat(orderForSea1.unitIds())
+        .containsExactlyInAnyOrder(wm.get(inf1.getId()), wm.get(inf2.getId()));
+
+    final CombatMoveOrder orderForSea2 =
+        loadOrders.stream()
+            .filter(o -> wm.get(sea2.getId()).equals(o.transportId()))
+            .findFirst()
+            .orElse(null);
+    assertThat(orderForSea2).as("load order for sea2 must exist").isNotNull();
+    assertThat(orderForSea2.unitIds()).containsExactly(wm.get(inf3.getId()));
+  }
+
+  // -----------------------------------------------------------------------
+  // Unload branch tests
+  // -----------------------------------------------------------------------
+
+  /**
+   * Test 4 — Mixed cargo unload: 2 infantry + 2 bombers. Expect 2 orders: one {@code kind="unload"}
+   * for infantry, one plain move for bombers.
+   */
+  @Test
+  void unloadBranch_mixedCargo_airEmittedAsPlainMove() {
+    final Unit inf1 = unit(infantry(data));
+    final Unit inf2 = unit(infantry(data));
+    final Unit bomber1 = unit(bomber(data));
+    final Unit bomber2 = unit(bomber(data));
+    final Unit sea = unit(transport(data));
+
+    final List<Unit> allUnits = List.of(inf1, inf2, bomber1, bomber2, sea);
+    final Map<UUID, String> wm = wireMap(allUnits);
+
+    final Route route = new Route(seaTerr, landTerr);
+    assertThat(route.isUnload()).as("route must be an unload route").isTrue();
+
+    final MoveDescription move = new MoveDescription(allUnits, route, Map.of());
+
+    final List<CombatMoveOrder> orders = ExecutorSupport.projectOrders(move, wm);
+
+    assertThat(orders).hasSize(2);
+
+    final CombatMoveOrder unloadOrder =
+        orders.stream().filter(o -> "unload".equals(o.kind())).findFirst().orElse(null);
+    assertThat(unloadOrder).as("must have an unload order").isNotNull();
+    assertThat(unloadOrder.unitIds())
+        .containsExactlyInAnyOrder(wm.get(inf1.getId()), wm.get(inf2.getId()));
+
+    final CombatMoveOrder airOrder =
+        orders.stream().filter(o -> "move".equals(o.kind())).findFirst().orElse(null);
+    assertThat(airOrder).as("must have a plain-move order for aircraft").isNotNull();
+    assertThat(airOrder.unitIds())
+        .containsExactlyInAnyOrder(wm.get(bomber1.getId()), wm.get(bomber2.getId()));
+    assertThat(airOrder.transportId()).isNull();
+  }
+
+  /**
+   * Test 5 — Air-only unload (from german-turn.log 2026-04-19): move contains only aircraft,
+   * route.isUnload()=true. Expect 1 plain move order; no unload order emitted.
+   */
+  @Test
+  void unloadBranch_airOnly_noUnloadOrderEmitted() {
+    final Unit fighter1 = unit(fighter(data));
+    final Unit bomber1 = unit(bomber(data));
+
+    final List<Unit> allUnits = List.of(fighter1, bomber1);
+    final Map<UUID, String> wm = wireMap(allUnits);
+
+    final Route route = new Route(seaTerr, landTerr);
+    assertThat(route.isUnload()).as("route must be an unload route").isTrue();
+
+    final MoveDescription move = new MoveDescription(allUnits, route, Map.of());
+
+    final List<CombatMoveOrder> orders = ExecutorSupport.projectOrders(move, wm);
+
+    assertThat(orders.stream().anyMatch(o -> "unload".equals(o.kind())))
+        .as("no unload order — aircraft are not cargo")
+        .isFalse();
+
+    assertThat(orders).hasSize(1);
+    final CombatMoveOrder airOrder = orders.get(0);
+    assertThat(airOrder.kind()).isEqualTo("move");
+    assertThat(airOrder.unitIds())
+        .containsExactlyInAnyOrder(wm.get(fighter1.getId()), wm.get(bomber1.getId()));
+  }
+
+  // -----------------------------------------------------------------------
+  // Plain-move branch (unchanged)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Test 6 — Pure plain move: route.isLoad()=false, route.isUnload()=false. Unchanged behavior:
+   * single order with all units, kind="move".
+   */
+  @Test
+  void plainMove_allUnitsInSingleOrder() {
+    // Pick two land territories to get a plain-move route.
+    final Territory t1 =
+        data.getMap().getTerritories().stream().filter(t -> !t.isWater()).findFirst().orElseThrow();
+    // Find a second land territory adjacent to t1 (or any land territory if none adjacent).
+    final Territory t2 =
+        data.getMap().getNeighbors(t1).stream()
+            .filter(t -> !t.isWater())
+            .findFirst()
+            .orElseGet(
+                () ->
+                    data.getMap().getTerritories().stream()
+                        .filter(t -> !t.isWater() && !t.equals(t1))
+                        .findFirst()
+                        .orElseThrow());
+
+    final Unit inf1 = unit(infantry(data));
+    final Unit inf2 = unit(infantry(data));
+    final List<Unit> allUnits = List.of(inf1, inf2);
+    final Map<UUID, String> wm = wireMap(allUnits);
+
+    // Build a plain route (land → land); isLoad and isUnload must both be false.
+    final Route route = new Route(t1, t2);
+    assertThat(route.isLoad()).isFalse();
+    assertThat(route.isUnload()).isFalse();
+
+    final MoveDescription move = new MoveDescription(allUnits, route, Map.of());
+
+    final List<CombatMoveOrder> orders = ExecutorSupport.projectOrders(move, wm);
+
+    assertThat(orders).hasSize(1);
+    final CombatMoveOrder order = orders.get(0);
+    assertThat(order.kind()).isEqualTo("move");
+    assertThat(order.unitIds())
+        .containsExactlyInAnyOrder(wm.get(inf1.getId()), wm.get(inf2.getId()));
+    assertThat(order.transportId()).isNull();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes map-room/map-room#1862.

`ExecutorSupport.projectOrders` incorrectly bundled aircraft into `kind='load'` or `kind='unload'` `CombatMoveOrder`s. Two observable symptoms:

1. **Client UI**: fighters marked as loaded onto transports during combat-move.
2. **NCM dispatch logs** (german-turn.log 2026-04-19): `units=[tactical_bomber×2,fighter×2,bomber×2] kind=unload` — aircraft should never appear in an unload order.

### Root causes

- **Load branch**: `getUnitsToSeaTransports()` can contain air→carrier pairs in TripleA's internal representation. The old code iterated all entries without filtering, putting fighters/bombers landing on carriers into `kind='load'` orders.
- **Unload branch**: filtered cargo by `!isTransportCapacity()`, which is `true` for aircraft (aircraft have no transport capacity), so aircraft were included in `kind='unload'` orders.

### Fix

Both branches now split aircraft out before building transport-specific orders:

- **Load**: skip any `getUnitsToSeaTransports()` entry where the cargo unit `isAir()`. Aircraft in the move unit list emit as a separate plain `moveUnit` order.
- **Unload**: additionally filter by `!isAir()` before building the cargo list. Aircraft emit as a separate plain `moveUnit` order.
- **Plain-move branch**: unchanged.

Also extracts a `wireIds(List<Unit>, Map<UUID,String>)` helper to eliminate duplication across branches.

## Test plan

New test class `ProjectOrdersTest` using real `CanonicalGameData` unit types:

- [x] `loadBranch_mixedCargo_airEmittedAsPlainMove` — 2 infantry + 1 fighter on load route; infantry in load order, fighter in plain move
- [x] `loadBranch_aircraftInTransportMap_emittedAsPlainMoveNotLoad` — fighter in `getUnitsToSeaTransports()` paired with carrier; no load order, 1 plain move
- [x] `loadBranch_multipleTransports_oneOrderPerTransport` — 3 infantry across 2 transports; 2 load orders, no air order (regression guard)
- [x] `unloadBranch_mixedCargo_airEmittedAsPlainMove` — 2 infantry + 2 bombers on unload route; infantry in unload order, bombers in plain move
- [x] `unloadBranch_airOnly_noUnloadOrderEmitted` — fighter + bomber on unload route; 1 plain move, no unload order
- [x] `plainMove_allUnitsInSingleOrder` — land-to-land route; single `kind='move'` order (unchanged behavior)
- [x] Full `ai-sidecar` test suite: `BUILD SUCCESSFUL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)