### PR TITLE
fix(ai-pro): enforce §20 on factory placement targets

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -1251,6 +1251,14 @@ class ProPurchaseAi {
             data.getMap().getTerritories(),
             ProMatches.territoryHasNoInfraFactoryAndIsNotConqueredOwnedLand(player));
     possibleFactoryTerritories.removeAll(factoryPurchaseTerritories.keySet());
+
+    // §20 enforcement: a new factory may only be placed on territory the player controlled since
+    // the start of their turn. Even if live GameData ownership has drifted during mid-turn
+    // simulation or wire-state application, startOfTurnData is a frozen snapshot at turn-start and
+    // gives the authoritative answer.
+    possibleFactoryTerritories.removeIf(
+        t -> isNotOwnedByPlayerAtStartOfTurn(startOfTurnData, player, t));
+
     final Set<Territory> purchaseFactoryTerritories = new HashSet<>();
     final List<Territory> territoriesThatCantBeHeld = new ArrayList<>();
     for (final Territory t : possibleFactoryTerritories) {
@@ -2640,5 +2648,17 @@ class ProPurchaseAi {
               });
     }
     AbstractAi.movePause();
+  }
+
+  /**
+   * Returns true when the given territory was NOT owned by {@code player} at the start of their
+   * turn, as determined by the frozen {@code startOfTurnData} snapshot. Used as a {@code removeIf}
+   * predicate to enforce §20: a new factory may only be placed on territory the player controlled
+   * since the start of their turn.
+   */
+  static boolean isNotOwnedByPlayerAtStartOfTurn(
+      final GameState startOfTurnData, final GamePlayer player, final Territory t) {
+    final Territory startOfTurnTerritory = startOfTurnData.getMap().getTerritoryOrNull(t.getName());
+    return startOfTurnTerritory == null || !player.equals(startOfTurnTerritory.getOwner());
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPurchaseAiSection20Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPurchaseAiSection20Test.java
@@ -1,0 +1,88 @@
+package games.strategy.triplea.ai.pro;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.xml.TestMapGameData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the §20 defensive filter in {@link ProPurchaseAi#isNotOwnedByPlayerAtStartOfTurn}.
+ *
+ * <p>§20 (Global 1940): a new factory may only be placed on territory the player controlled since
+ * the start of their turn. The filter guards against mid-turn ownership drift in long-running
+ * sessions where live {@code GameData} can diverge from the turn-start snapshot.
+ */
+class ProPurchaseAiSection20Test {
+
+  private GameData startOfTurnData;
+  private GameData liveData;
+  private GamePlayer japanese;
+
+  @BeforeEach
+  void setUp() {
+    // Load two independent copies of G40: one serves as the frozen turn-start snapshot, the other
+    // as the "live" GameData that may have drifted.
+    startOfTurnData = TestMapGameData.GLOBAL1940.getGameData();
+    liveData = TestMapGameData.GLOBAL1940.getGameData();
+
+    japanese = liveData.getPlayerList().getPlayerId("Japanese");
+  }
+
+  /**
+   * Scenario: Kwangtung is UK_Pacific-owned at game start in both snapshots. Japanese player
+   * legitimately owns Japan (a Japanese-owned land territory). The filter must pass Japan and block
+   * Kwangtung.
+   */
+  @Test
+  void japaneseOwnedTerritoryIsNotFiltered() {
+    final Territory japan = liveData.getMap().getTerritoryOrNull("Japan");
+    assert japan != null : "Japan territory not found in G40 game data";
+
+    assertFalse(
+        ProPurchaseAi.isNotOwnedByPlayerAtStartOfTurn(startOfTurnData, japanese, japan),
+        "Japan is Japanese-owned at turn start — should NOT be filtered out");
+  }
+
+  /**
+   * Scenario: Live GameData incorrectly shows Kwangtung as Japanese-owned (simulating state drift),
+   * but startOfTurnData correctly shows UK_Pacific ownership. The filter must exclude Kwangtung
+   * regardless of what live GameData says.
+   */
+  @Test
+  void ukTerritoryIsFilteredEvenWhenLiveDataShowsJapaneseOwnership() {
+    final Territory kwangtungLive = liveData.getMap().getTerritoryOrNull("Kwangtung");
+    assert kwangtungLive != null : "Kwangtung territory not found in G40 game data";
+
+    // Simulate mid-turn drift: live data now shows Japan as the owner.
+    kwangtungLive.setOwner(japanese);
+
+    // Confirm the drift: live data says Japanese, but startOfTurnData still says UK_Pacific.
+    assertTrue(
+        japanese.equals(kwangtungLive.getOwner()),
+        "Precondition: live data should show Kwangtung as Japanese-owned after the simulated drift");
+
+    // The §20 filter checks startOfTurnData, not liveData — it should still filter Kwangtung out.
+    assertTrue(
+        ProPurchaseAi.isNotOwnedByPlayerAtStartOfTurn(startOfTurnData, japanese, kwangtungLive),
+        "Kwangtung was UK-owned at turn start — must be filtered out despite live drift");
+  }
+
+  /**
+   * Scenario: Territory name doesn't exist in startOfTurnData (hypothetical missing territory).
+   * Filter must treat it as blocked (return true) — null-safe.
+   */
+  @Test
+  void missingTerritoryInStartOfTurnDataIsFiltered() {
+    // Create a mock territory whose name doesn't exist in the G40 map.
+    final Territory phantom = new Territory("Phantom Island", liveData);
+
+    assertTrue(
+        ProPurchaseAi.isNotOwnedByPlayerAtStartOfTurn(startOfTurnData, japanese, phantom),
+        "A territory absent from startOfTurnData must be filtered out");
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a defensive extra filter in `ProPurchaseAi.purchaseFactory` that excludes any candidate territory not owned by the player on the `startOfTurnData` snapshot.
- Encodes §20 of Global 1940 rules: new factories may only be placed on territory the player controlled since the start of their turn.
- Shields ProAi from mid-turn ownership drift that can occur in long-running sessions.
- Extracts the filter into a package-private static helper (`isNotOwnedByPlayerAtStartOfTurn`) for direct unit testability.

## Why
Observed in map-room's ai-sidecar: Japan round 1 bought factory_minor and ProPurchaseAi picked UK-owned Kwangtung as the placement target. The live `isTerritoryOwnedBy(player)` check in the existing predicate had somehow returned true (state drift between phases in the long-running session). Combat-move correctly refused the Kwangtung attack (no war declared with UK), place phase had no valid home, factory forfeited — 12 IPC burned.

Rather than chase the mid-turn drift (which may be legitimate speculative simulation or a wire-state mapping quirk), we harden the purchase-time filter against it. `startOfTurnData` is a parameter `ProPurchaseAi.purchase(...)` already receives; it's a frozen snapshot at turn start, so ownership checks against it are robust.

## Test plan
- [x] New unit test `ProPurchaseAiSection20Test` (3 cases) exercises the scenario where live GameData shows Japan owning Kwangtung but startOfTurnData shows UK_Pacific; assertion confirms it is filtered out.
- [x] Japanese-owned territory (Japan itself) correctly passes the filter in the positive case.
- [x] Null-safe: territory absent from startOfTurnData is also filtered out.
- [x] `./gradlew :game-app:game-core:test --tests '*ProPurchaseAi*'` passes (4/4 tests).
- [x] Spotless clean.
- [ ] 🧑 Manual: rerun the Japan round 1 log scenario and confirm factory is not purchased with an unplaceable target (or, if purchased, placed on a legitimate Japan territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)