### PR TITLE
fix(ai-sidecar): suppress broken-pipe stack trace in HealthHandler

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/HealthHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/HealthHandler.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 public final class HealthHandler implements HttpHandler {
+  private static final System.Logger LOG = System.getLogger(HealthHandler.class.getName());
+
   @Override
   public void handle(final HttpExchange exchange) throws IOException {
     if (!"GET".equals(exchange.getRequestMethod())) {
@@ -18,6 +20,33 @@ public final class HealthHandler implements HttpHandler {
     exchange.sendResponseHeaders(200, body.length);
     try (OutputStream os = exchange.getResponseBody()) {
       os.write(body);
+    } catch (final IOException e) {
+      if (isClientDisconnect(e)) {
+        LOG.log(System.Logger.Level.DEBUG, "Health probe client hung up before body write completed");
+      } else {
+        throw e;
+      }
     }
+  }
+
+  private static boolean isClientDisconnect(final IOException e) {
+    if (matchesDisconnectMessage(e.getMessage())) {
+      return true;
+    }
+    for (final Throwable suppressed : e.getSuppressed()) {
+      if (suppressed instanceof IOException && matchesDisconnectMessage(suppressed.getMessage())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean matchesDisconnectMessage(final String message) {
+    if (message == null) {
+      return false;
+    }
+    return message.contains("Broken pipe")
+        || message.contains("Connection reset by peer")
+        || message.contains("insufficient bytes written");
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/HealthHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/HealthHandlerTest.java
@@ -1,8 +1,20 @@
 package org.triplea.ai.sidecar.http;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpPrincipal;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
 import org.junit.jupiter.api.Test;
 
 class HealthHandlerTest {
@@ -21,5 +33,52 @@ class HealthHandlerTest {
     final FakeHttpExchange ex = new FakeHttpExchange("POST", "/health", null);
     h.handle(ex);
     assertEquals(405, ex.responseCode());
+  }
+
+  @Test
+  void swallowsBrokenPipeWithoutRethrow() {
+    final HealthHandler h = new HealthHandler();
+    final HttpExchange ex = throwingGetExchange("Broken pipe");
+    assertDoesNotThrow(() -> h.handle(ex));
+  }
+
+  @Test
+  void rethrowsUnexpectedIoException() {
+    final HealthHandler h = new HealthHandler();
+    final HttpExchange ex = throwingGetExchange("Disk full");
+    assertThrows(IOException.class, () -> h.handle(ex));
+  }
+
+  /** Returns a minimal GET /health exchange whose response OutputStream throws on write. */
+  private static HttpExchange throwingGetExchange(final String errorMessage) {
+    return new HttpExchange() {
+      private final Headers responseHeaders = new Headers();
+      @Override public String getRequestMethod() { return "GET"; }
+      @Override public URI getRequestURI() { return URI.create("/health"); }
+      @Override public Headers getRequestHeaders() { return new Headers(); }
+      @Override public Headers getResponseHeaders() { return responseHeaders; }
+      @Override public void sendResponseHeaders(final int code, final long length) {}
+      @Override public OutputStream getResponseBody() {
+        return new OutputStream() {
+          @Override public void write(final int b) throws IOException {
+            throw new IOException(errorMessage);
+          }
+          @Override public void write(final byte[] b) throws IOException {
+            throw new IOException(errorMessage);
+          }
+        };
+      }
+      @Override public InputStream getRequestBody() { return new ByteArrayInputStream(new byte[0]); }
+      @Override public HttpContext getHttpContext() { return null; }
+      @Override public void close() {}
+      @Override public InetSocketAddress getRemoteAddress() { return null; }
+      @Override public int getResponseCode() { return -1; }
+      @Override public InetSocketAddress getLocalAddress() { return null; }
+      @Override public String getProtocol() { return "HTTP/1.1"; }
+      @Override public Object getAttribute(final String name) { return null; }
+      @Override public void setAttribute(final String name, final Object value) {}
+      @Override public void setStreams(final InputStream i, final OutputStream o) {}
+      @Override public HttpPrincipal getPrincipal() { return null; }
+    };
   }
 }


### PR DESCRIPTION
## Summary

`HealthHandler` was leaking a full `IOException: Broken pipe` stack trace to the log every time a health-probe client (docker healthcheck, bot-worker heartbeat) disconnected before the response body finished writing. Cosmetic only — real `/decision` calls unaffected — but the noise buries genuine errors.

**Fix:** catch `IOException` on the body write/close. If the message or any suppressed exception matches a known client-disconnect pattern (`Broken pipe`, `Connection reset by peer`, `insufficient bytes written`), log one `DEBUG` line and return cleanly. All other `IOException`s are re-thrown so real failures still surface.

## Changes

- `HealthHandler.java`: add `isClientDisconnect` helper + catch block
- `HealthHandlerTest.java`: two new cases — broken-pipe swallowed, unexpected IO rethrown

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:test --tests "*.HealthHandlerTest"` — 4 tests pass
- [ ] 🧑 Manual: deploy to docker-compose stack and confirm no broken-pipe traces appear during normal healthcheck probes

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)