### PR TITLE
fix(ai-sidecar): add 'battle' phase to StepNameMapper (#35)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/StepNameMapper.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/StepNameMapper.java
@@ -6,9 +6,8 @@ import java.util.Map;
  * Maps Map Room phase names (as carried in {@link WireState#phase()}) to the corresponding
  * TripleA XML step display name for {@code GameSequence.setRoundAndStep}. The convention in
  * TripleA's Global 1940 XML is {@code <PlayerName><CamelPhase>}, e.g. {@code GermansPurchase}
- * or {@code GermansCombatMove}. Phases that Phase 3 does not wire ({@code tech},
- * {@code intelligence}) are rejected — the sidecar should never receive a PurchaseRequest
- * tagged with those phases.
+ * or {@code GermansCombatMove}. Phases that the sidecar does not receive ({@code tech},
+ * {@code intelligence}) are not mapped and will throw.
  *
  * <p>This mapping is a contract between Map Room and the sidecar. Keep it in sync with the
  * phase names in {@code packages/shared/src/engine/game-def.ts}.
@@ -18,6 +17,7 @@ public final class StepNameMapper {
       Map.of(
           "purchase", "Purchase",
           "combatMove", "CombatMove",
+          "battle", "Battle",
           "nonCombatMove", "NonCombatMove",
           "place", "Place");
 

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -180,10 +180,9 @@ public final class WireStateApplier {
    * is found — which is why the {@link StepNameMapper} contract is narrow.
    */
   private static void applyRoundAndStep(final GameData gameData, final WireState wire) {
-    // StepNameMapper only covers Phase 3 wire phases (purchase / combatMove / nonCombatMove /
-    // place). Legacy / defensive callers may send phase values like "combat" that pre-date
-    // Phase 3; for those we leave the sequence untouched and log a warning — the defensive
-    // executors already tolerate a stale round/step because they dispatch directly into ProAi.
+    // StepNameMapper covers all wired phases (purchase / combatMove / battle / nonCombatMove /
+    // place). Any unmapped phase (e.g. tech, intelligence) leaves the sequence untouched and
+    // logs a warning.
     final String javaStepName;
     try {
       javaStepName = StepNameMapper.toJavaStepName(wire.phase(), wire.currentPlayer());

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/StepNameMapperTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/StepNameMapperTest.java
@@ -15,6 +15,11 @@ class StepNameMapperTest {
   }
 
   @Test
+  void mapsBattlePhaseToBattleStep() {
+    assertEquals("GermansBattle", StepNameMapper.toJavaStepName("battle", "Germans"));
+  }
+
+  @Test
   void mapsNonCombatMovePhaseToNonCombatMoveStep() {
     assertEquals("GermansNonCombatMove", StepNameMapper.toJavaStepName("nonCombatMove", "Germans"));
   }


### PR DESCRIPTION
## Summary

`WireStateApplier` was emitting a `WARNING` on every retreat/battle-input decision:
```
WireState phase 'battle' not mappable; skipping round/step apply
```

Root cause: `StepNameMapper.PHASE_SUFFIX` had no entry for `"battle"`. The canonical step name in `ww2global40_2nd_edition.xml` is `<Player>Battle` (e.g. `germansBattle`), so the fix is a one-line map addition with suffix `"Battle"`.

Also trims the stale `WireStateApplier` comment that listed only the four pre-fix phases.

## Changes

- `StepNameMapper.java`: add `"battle" → "Battle"` to `PHASE_SUFFIX`
- `WireStateApplier.java`: update comment to reflect the new phase list
- `StepNameMapperTest.java`: add `mapsBattlePhaseToBattleStep` test case

## Test plan

- [x] `StepNameMapperTest` — 6 tests pass (5 existing + 1 new)
- [x] `WireStateApplierTest` — all pass, no regressions
- [ ] 🧑 Manual: deploy sidecar + run through an Axis turn with retreats; confirm no 'not mappable' WARNING in log

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)