### PR TITLE
feat(ai-sidecar): WireStateVerifier — post-apply drift logger

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -99,6 +99,7 @@ public final class WireStateApplier {
     // Round/step last — GameSequence mutation has no interaction with the earlier branches,
     // but keeping it at the tail means nothing downstream can overwrite it.
     applyRoundAndStep(gameData, wire);
+    WireStateVerifier.verifyApply(gameData, wire, unitIdMap);
   }
 
   /**

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateVerifier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateVerifier.java
@@ -1,0 +1,315 @@
+package org.triplea.ai.sidecar.wire;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.RelationshipType;
+import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.attachments.TechAttachment;
+import games.strategy.triplea.delegate.battle.BattleTracker;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Post-apply integrity verifier. Called at the end of {@link WireStateApplier#apply} to detect
+ * drift between an incoming {@link WireState} and the live {@link GameData} after apply has run.
+ *
+ * <p>Logs one {@code WARNING} line per specific mismatch using a grep-friendly
+ * {@code apply-drift kind=...} prefix, plus one {@code INFO} summary line per apply. Never throws
+ * — this is observational instrumentation, not enforcement.
+ */
+public final class WireStateVerifier {
+
+  private static final Logger LOG = System.getLogger(WireStateVerifier.class.getName());
+
+  // Ordered list of wire-side tech names (matches WireStateApplier.TECH_PROPERTY_NAMES keys).
+  private static final List<String> TECH_NAMES =
+      List.of(
+          "heavyBomber",
+          "longRangeAir",
+          "jetPower",
+          "rocket",
+          "industrialTechnology",
+          "superSub",
+          "destroyerBombard",
+          "improvedArtillerySupport",
+          "paratroopers",
+          "increasedFactoryProduction",
+          "warBonds",
+          "mechanizedInfantry",
+          "aaRadar",
+          "shipyards");
+
+  private WireStateVerifier() {}
+
+  /**
+   * Verify that {@code gameData} now reflects every field carried in {@code wire}. Logs one
+   * WARNING per drift and one INFO summary at the end. Never throws.
+   */
+  public static void verifyApply(
+      final GameData gameData,
+      final WireState wire,
+      final ConcurrentMap<String, UUID> unitIdMap) {
+    try {
+      int mismatches = 0;
+      for (final WireTerritory wt : wire.territories()) {
+        mismatches += verifyTerritory(gameData, wt, unitIdMap);
+      }
+      for (final WirePlayer wp : wire.players()) {
+        mismatches += verifyPlayer(gameData, wp);
+      }
+      for (final WireRelationship wr : wire.relationships()) {
+        mismatches += verifyRelationship(gameData, wr);
+      }
+      final int total = mismatches;
+      LOG.log(
+          Level.INFO,
+          () ->
+              "apply-verify territories="
+                  + wire.territories().size()
+                  + " players="
+                  + wire.players().size()
+                  + " mismatches="
+                  + total);
+    } catch (final Exception e) {
+      LOG.log(Level.WARNING, () -> "apply-verify threw unexpectedly: " + e.getMessage());
+    }
+  }
+
+  private static int verifyTerritory(
+      final GameData gameData,
+      final WireTerritory wt,
+      final ConcurrentMap<String, UUID> unitIdMap) {
+    final Territory t = gameData.getMap().getTerritoryOrNull(wt.territoryId());
+    if (t == null) {
+      return 0;
+    }
+    int drift = 0;
+
+    // owner
+    final String actualOwner = t.getOwner().getName();
+    if (!wt.owner().equals(actualOwner)) {
+      LOG.log(
+          Level.WARNING,
+          () ->
+              "apply-drift kind=owner territory="
+                  + wt.territoryId()
+                  + " expected="
+                  + wt.owner()
+                  + " actual="
+                  + actualOwner);
+      drift++;
+    }
+
+    // unit count
+    final int wireUnitCount = wt.units().size();
+    final int actualUnitCount = t.getUnits().size();
+    if (wireUnitCount != actualUnitCount) {
+      LOG.log(
+          Level.WARNING,
+          () ->
+              "apply-drift kind=unit-count territory="
+                  + wt.territoryId()
+                  + " expected="
+                  + wireUnitCount
+                  + " actual="
+                  + actualUnitCount);
+      drift++;
+    }
+
+    // per-unit checks (only for units resolvable via unitIdMap)
+    for (final WireUnit wu : wt.units()) {
+      final UUID uuid = unitIdMap.get(wu.unitId());
+      if (uuid == null) {
+        continue;
+      }
+      final Unit unit = findUnitById(t.getUnits(), uuid);
+      if (unit == null) {
+        continue;
+      }
+
+      // hits
+      if (wu.hitsTaken() != unit.getHits()) {
+        LOG.log(
+            Level.WARNING,
+            () ->
+                "apply-drift kind=unit-hits territory="
+                    + wt.territoryId()
+                    + " unitId="
+                    + wu.unitId()
+                    + " expected="
+                    + wu.hitsTaken()
+                    + " actual="
+                    + unit.getHits());
+        drift++;
+      }
+
+      // alreadyMoved
+      final BigDecimal expectedMoved = BigDecimal.valueOf(wu.movesUsed());
+      if (expectedMoved.compareTo(unit.getAlreadyMoved()) != 0) {
+        LOG.log(
+            Level.WARNING,
+            () ->
+                "apply-drift kind=unit-already-moved territory="
+                    + wt.territoryId()
+                    + " unitId="
+                    + wu.unitId()
+                    + " expected="
+                    + wu.movesUsed()
+                    + " actual="
+                    + unit.getAlreadyMoved());
+        drift++;
+      }
+
+      // unit owner (fallback to territory owner when wire owner is blank)
+      final String expectedUnitOwner =
+          (wu.owner() != null && !wu.owner().isEmpty()) ? wu.owner() : wt.owner();
+      final String actualUnitOwner = unit.getOwner().getName();
+      if (!expectedUnitOwner.equals(actualUnitOwner)) {
+        LOG.log(
+            Level.WARNING,
+            () ->
+                "apply-drift kind=unit-owner territory="
+                    + wt.territoryId()
+                    + " unitId="
+                    + wu.unitId()
+                    + " expected="
+                    + expectedUnitOwner
+                    + " actual="
+                    + actualUnitOwner);
+        drift++;
+      }
+    }
+
+    // conquered-this-turn (only checkable if the battle delegate is present)
+    if (gameData.getDelegateOptional("battle").isPresent()) {
+      final BattleTracker tracker = gameData.getBattleDelegate().getBattleTracker();
+      final boolean actualConquered = tracker.getConquered().contains(t);
+      if (wt.conqueredThisTurn() != actualConquered) {
+        LOG.log(
+            Level.WARNING,
+            () ->
+                "apply-drift kind=conquered-this-turn territory="
+                    + wt.territoryId()
+                    + " expected="
+                    + wt.conqueredThisTurn()
+                    + " actual="
+                    + actualConquered);
+        drift++;
+      }
+    }
+
+    return drift;
+  }
+
+  private static int verifyPlayer(final GameData gameData, final WirePlayer wp) {
+    final GamePlayer player = gameData.getPlayerList().getPlayerId(wp.playerId());
+    if (player == null) {
+      return 0;
+    }
+    int drift = 0;
+
+    // PUs
+    final Resource pus = gameData.getResourceList().getResourceOrThrow("PUs");
+    final int actualPus = player.getResources().getQuantity(pus);
+    if (wp.pus() != actualPus) {
+      LOG.log(
+          Level.WARNING,
+          () ->
+              "apply-drift kind=player-pus player="
+                  + wp.playerId()
+                  + " expected="
+                  + wp.pus()
+                  + " actual="
+                  + actualPus);
+      drift++;
+    }
+
+    // tech — compare wire's expected set against the set of activated techs in TechAttachment
+    final TechAttachment ta = player.getTechAttachment();
+    if (ta != null && wp.tech() != null) {
+      final Set<String> expectedTech = Set.copyOf(wp.tech());
+      final Set<String> actualTech = getActivatedTechNames(ta);
+      if (!expectedTech.equals(actualTech)) {
+        final List<String> expectedSorted = sorted(expectedTech);
+        final List<String> actualSorted = sorted(actualTech);
+        LOG.log(
+            Level.WARNING,
+            () ->
+                "apply-drift kind=player-tech player="
+                    + wp.playerId()
+                    + " expected="
+                    + expectedSorted
+                    + " actual="
+                    + actualSorted);
+        drift++;
+      }
+    }
+
+    return drift;
+  }
+
+  private static int verifyRelationship(final GameData gameData, final WireRelationship wr) {
+    final GamePlayer a = gameData.getPlayerList().getPlayerId(wr.a());
+    final GamePlayer b = gameData.getPlayerList().getPlayerId(wr.b());
+    if (a == null || b == null) {
+      return 0;
+    }
+    final RelationshipType type = gameData.getRelationshipTracker().getRelationshipType(a, b);
+    if (type == null) {
+      return 0;
+    }
+    final String actualKind = type.getRelationshipTypeAttachment().getArcheType();
+    if (!wr.kind().equalsIgnoreCase(actualKind)) {
+      LOG.log(
+          Level.WARNING,
+          () ->
+              "apply-drift kind=relationship pair="
+                  + wr.a()
+                  + "-"
+                  + wr.b()
+                  + " expected="
+                  + wr.kind()
+                  + " actual="
+                  + actualKind);
+      return 1;
+    }
+    return 0;
+  }
+
+  private static Set<String> getActivatedTechNames(final TechAttachment ta) {
+    final Set<String> result = new HashSet<>();
+    for (final String name : TECH_NAMES) {
+      final var prop = ta.getPropertyOrEmpty(name);
+      if (prop.isPresent() && Boolean.TRUE.equals(prop.get().getValue())) {
+        result.add(name);
+      }
+    }
+    return result;
+  }
+
+  private static List<String> sorted(final Set<String> set) {
+    final List<String> list = new ArrayList<>(set);
+    Collections.sort(list);
+    return list;
+  }
+
+  private static Unit findUnitById(final Collection<Unit> units, final UUID id) {
+    for (final Unit u : units) {
+      if (u.getId().equals(id)) {
+        return u;
+      }
+    }
+    return null;
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateVerifierTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateVerifierTest.java
@@ -1,0 +1,351 @@
+package org.triplea.ai.sidecar.wire;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+
+class WireStateVerifierTest {
+
+  private static CanonicalGameData canonical;
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+  }
+
+  // ---- log capture ----
+
+  private final List<LogRecord> captured = new ArrayList<>();
+  private final Handler captureHandler =
+      new Handler() {
+        @Override
+        public void publish(final LogRecord record) {
+          // Force supplier evaluation so getMessage() returns the formatted string.
+          record.getMessage();
+          captured.add(record);
+        }
+
+        @Override
+        public void flush() {}
+
+        @Override
+        public void close() {}
+      };
+  private Logger verifierLogger;
+
+  @BeforeEach
+  void installLogCapture() {
+    captured.clear();
+    verifierLogger = Logger.getLogger(WireStateVerifier.class.getName());
+    verifierLogger.addHandler(captureHandler);
+    verifierLogger.setLevel(Level.ALL);
+  }
+
+  @AfterEach
+  void removeLogCapture() {
+    verifierLogger.removeHandler(captureHandler);
+  }
+
+  private List<String> warnings() {
+    return captured.stream()
+        .filter(r -> r.getLevel().intValue() >= Level.WARNING.intValue())
+        .map(r -> r.getMessage() != null ? r.getMessage() : r.getParameters() != null
+            ? String.format(r.getMessage() == null ? "%s" : r.getMessage(), r.getParameters())
+            : "(null)")
+        .collect(Collectors.toList());
+  }
+
+  private List<String> infos() {
+    return captured.stream()
+        .filter(r -> r.getLevel().equals(Level.INFO))
+        .map(LogRecord::getMessage)
+        .collect(Collectors.toList());
+  }
+
+  // ---- helpers ----
+
+  private GameData fresh() {
+    return canonical.cloneForSession();
+  }
+
+  private ConcurrentMap<String, UUID> freshIdMap() {
+    return new ConcurrentHashMap<>();
+  }
+
+  /** Apply a wire state, then run the verifier independently on the same data. */
+  private void applyAndVerify(
+      final GameData gd, final WireState wire, final ConcurrentMap<String, UUID> idMap) {
+    WireStateApplier.apply(gd, wire, idMap);
+    // The verifier is called inside apply(), so logs are already captured.
+  }
+
+  // ---- tests ----
+
+  @Test
+  void happyPath_noMismatchesAfterCleanApply() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    final WireState wire =
+        new WireState(
+            List.of(new WireTerritory("Germany", "Germans", List.of())),
+            List.of(new WirePlayer("Germans", 40, List.of(), false)),
+            1,
+            "purchase",
+            "Germans",
+            List.of());
+    applyAndVerify(gd, wire, idMap);
+
+    assertThat(warnings()).isEmpty();
+    assertThat(infos()).anyMatch(m -> m.contains("apply-verify") && m.contains("mismatches=0"));
+  }
+
+  @Test
+  void ownerDrift_detectedAfterMutatingTerritoryOwner() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    // Wire says Germany is owned by Russians; after apply it will be Russians.
+    final WireState wire =
+        new WireState(
+            List.of(new WireTerritory("Germany", "Russians", List.of())),
+            List.of(),
+            1,
+            "purchase",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, wire, idMap);
+    // Capture state after a CLEAN apply — should be 0 drifts.
+    final long cleanWarnings = warnings().stream().filter(w -> w.contains("apply-drift")).count();
+    assertThat(cleanWarnings).isZero();
+
+    // Now post-apply mutate the territory owner back to Germans to simulate drift.
+    captured.clear();
+    gd.performChange(
+        ChangeFactory.changeOwner(
+            gd.getMap().getTerritoryOrThrow("Germany"),
+            gd.getPlayerList().getPlayerId("Germans")));
+    // Run verifier directly (not via apply) to check the mutated state.
+    WireStateVerifier.verifyApply(gd, wire, idMap);
+
+    assertThat(warnings())
+        .anyMatch(
+            w ->
+                w.contains("apply-drift")
+                    && w.contains("kind=owner")
+                    && w.contains("territory=Germany")
+                    && w.contains("expected=Russians")
+                    && w.contains("actual=Germans"));
+  }
+
+  @Test
+  void unitHitsDrift_detectedAfterMutatingUnitHits() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    final String uid = "u-inf-1";
+    final WireState wire =
+        new WireState(
+            List.of(
+                new WireTerritory(
+                    "Germany",
+                    "Germans",
+                    List.of(new WireUnit(uid, "infantry", 1, 0)))),
+            List.of(),
+            1,
+            "purchase",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, wire, idMap);
+    captured.clear();
+
+    // Mutate the unit's hits to 0 to simulate drift from wire's expected 1.
+    final Territory germany = gd.getMap().getTerritoryOrThrow("Germany");
+    final UUID uuid = idMap.get(uid);
+    final Unit unit = germany.getUnits().stream().filter(u -> u.getId().equals(uuid))
+        .findFirst().orElseThrow();
+    final org.triplea.java.collections.IntegerMap<Unit> hitMap =
+        new org.triplea.java.collections.IntegerMap<>();
+    hitMap.put(unit, 0);
+    gd.performChange(ChangeFactory.unitsHit(hitMap, List.of(germany)));
+
+    WireStateVerifier.verifyApply(gd, wire, idMap);
+
+    assertThat(warnings())
+        .anyMatch(
+            w ->
+                w.contains("apply-drift")
+                    && w.contains("kind=unit-hits")
+                    && w.contains("unitId=" + uid)
+                    && w.contains("expected=1")
+                    && w.contains("actual=0"));
+  }
+
+  @Test
+  void unitAlreadyMovedDrift_detectedAfterMutatingAlreadyMoved() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    final String uid = "u-arm-1";
+    final WireState wire =
+        new WireState(
+            List.of(
+                new WireTerritory(
+                    "Germany",
+                    "Germans",
+                    List.of(new WireUnit(uid, "armour", 0, 2)))),
+            List.of(),
+            1,
+            "purchase",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, wire, idMap);
+    captured.clear();
+
+    // Reset alreadyMoved to 0 to simulate drift from wire's expected 2.
+    final Territory germany = gd.getMap().getTerritoryOrThrow("Germany");
+    final UUID uuid = idMap.get(uid);
+    final Unit unit = germany.getUnits().stream().filter(u -> u.getId().equals(uuid))
+        .findFirst().orElseThrow();
+    gd.performChange(
+        ChangeFactory.unitPropertyChange(
+            unit, java.math.BigDecimal.ZERO, Unit.PropertyName.ALREADY_MOVED));
+
+    WireStateVerifier.verifyApply(gd, wire, idMap);
+
+    assertThat(warnings())
+        .anyMatch(
+            w ->
+                w.contains("apply-drift")
+                    && w.contains("kind=unit-already-moved")
+                    && w.contains("unitId=" + uid)
+                    && w.contains("expected=2")
+                    && w.contains("actual=0"));
+  }
+
+  @Test
+  void pusDrift_detectedAfterMutatingPlayerPus() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    final WireState wire =
+        new WireState(
+            List.of(),
+            List.of(new WirePlayer("Germans", 42, List.of(), false)),
+            1,
+            "purchase",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, wire, idMap);
+    captured.clear();
+
+    // Adjust Germans' PUs to 30 to simulate drift from wire's expected 42.
+    final var pus = gd.getResourceList().getResourceOrThrow("PUs");
+    final var player = gd.getPlayerList().getPlayerId("Germans");
+    final int delta = 30 - player.getResources().getQuantity(pus);
+    gd.performChange(ChangeFactory.changeResourcesChange(player, pus, delta));
+
+    WireStateVerifier.verifyApply(gd, wire, idMap);
+
+    assertThat(warnings())
+        .anyMatch(
+            w ->
+                w.contains("apply-drift")
+                    && w.contains("kind=player-pus")
+                    && w.contains("player=Germans")
+                    && w.contains("expected=42")
+                    && w.contains("actual=30"));
+  }
+
+  @Test
+  void relationshipDrift_detectedAfterMutatingRelationship() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    // Wire declares Germans-Russians as "war".
+    final WireState wire =
+        new WireState(
+            List.of(),
+            List.of(),
+            1,
+            "purchase",
+            "Germans",
+            List.of(new WireRelationship("Germans", "Russians", "war")));
+    WireStateApplier.apply(gd, wire, idMap);
+    captured.clear();
+
+    // Mutate the relationship to "allied" to simulate drift.
+    final var a = gd.getPlayerList().getPlayerId("Germans");
+    final var b = gd.getPlayerList().getPlayerId("Russians");
+    final var alliedType = gd.getRelationshipTypeList().getAllRelationshipTypes().stream()
+        .filter(r -> "allied".equalsIgnoreCase(r.getRelationshipTypeAttachment().getArcheType()))
+        .findFirst().orElseThrow();
+    gd.getRelationshipTracker().setRelationship(a, b, alliedType);
+
+    WireStateVerifier.verifyApply(gd, wire, idMap);
+
+    assertThat(warnings())
+        .anyMatch(
+            w ->
+                w.contains("apply-drift")
+                    && w.contains("kind=relationship")
+                    && w.contains("pair=Germans-Russians")
+                    && w.contains("expected=war"));
+  }
+
+  @Test
+  void conqueredThisTurnDrift_detectedAfterRemovingFromBattleTracker() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    // Wire says Poland was conquered this turn.
+    final WireState wire =
+        new WireState(
+            List.of(new WireTerritory("Poland", "Germans", List.of(), true)),
+            List.of(),
+            1,
+            "purchase",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, wire, idMap);
+    captured.clear();
+
+    // Remove Poland from the BattleTracker conquered set to simulate drift.
+    final Territory poland = gd.getMap().getTerritoryOrThrow("Poland");
+    gd.getBattleDelegate().getBattleTracker().getConquered().remove(poland);
+
+    WireStateVerifier.verifyApply(gd, wire, idMap);
+
+    assertThat(warnings())
+        .anyMatch(
+            w ->
+                w.contains("apply-drift")
+                    && w.contains("kind=conquered-this-turn")
+                    && w.contains("territory=Poland")
+                    && w.contains("expected=true")
+                    && w.contains("actual=false"));
+  }
+
+  @Test
+  void summaryLine_alwaysEmitted() {
+    final GameData gd = fresh();
+    final WireState wire =
+        new WireState(List.of(), List.of(), 1, "purchase", "Germans", List.of());
+    WireStateVerifier.verifyApply(gd, wire, freshIdMap());
+    assertThat(infos()).anyMatch(m -> m.contains("apply-verify"));
+  }
+}


### PR DESCRIPTION
Closes #38

## What

Adds `WireStateVerifier`, a pure-observational post-apply integrity check called at the end of `WireStateApplier.apply()`. For every field in the incoming `WireState`, it compares the expected value against the live `GameData` after apply has run and logs any mismatch as a grep-friendly `WARNING` line:

```
apply-drift kind=owner territory=Germany expected=Russians actual=Germans
apply-drift kind=unit-hits territory=Germany unitId=u-inf-1 expected=1 actual=0
apply-drift kind=player-pus player=Germans expected=42 actual=30
apply-drift kind=relationship pair=Germans-Russians expected=war actual=allied
apply-drift kind=conquered-this-turn territory=Poland expected=true actual=false
```

Plus one `INFO` summary per apply:
```
apply-verify territories=2 players=3 mismatches=0
```

Never throws — wrapped in a top-level try/catch so it can't disrupt the sidecar.

## Test plan

- [x] `happyPath_noMismatchesAfterCleanApply` — 0 warnings, summary shows mismatches=0
- [x] `ownerDrift_detectedAfterMutatingTerritoryOwner` — WARNING with kind=owner
- [x] `unitHitsDrift_detectedAfterMutatingUnitHits` — WARNING with kind=unit-hits
- [x] `unitAlreadyMovedDrift_detectedAfterMutatingAlreadyMoved` — WARNING with kind=unit-already-moved
- [x] `pusDrift_detectedAfterMutatingPlayerPus` — WARNING with kind=player-pus
- [x] `relationshipDrift_detectedAfterMutatingRelationship` — WARNING with kind=relationship
- [x] `conqueredThisTurnDrift_detectedAfterRemovingFromBattleTracker` — WARNING with kind=conquered-this-turn
- [x] `summaryLine_alwaysEmitted` — INFO line present even for empty wire state

All 8 tests pass: `./gradlew :game-app:ai-sidecar:test --tests "org.triplea.ai.sidecar.wire.WireStateVerifierTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)