### PR TITLE
fix(ai-sidecar): propagate unit owner changes on existing units

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -299,6 +299,12 @@ public final class WireStateApplier {
               ChangeFactory.unitPropertyChange(
                   unit, desiredAlreadyMoved, Unit.PropertyName.ALREADY_MOVED));
         }
+        // Captured infrastructure (factories, airfields) stays in the same territory but
+        // its owner changes to the capturing nation. Without this update the ProAI sees the
+        // old owner on every subsequent apply and the verifier fires drift warnings every turn.
+        if (!unitOwner.equals(unit.getOwner())) {
+          out.add(ChangeFactory.changeOwner(List.of(unit), unitOwner, territory));
+        }
       } else {
         unit = new Unit(uuid, type, unitOwner, gameData);
         // Register with the central UnitsList so {@code GameData.getUnits().get(uuid)}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
@@ -603,6 +603,60 @@ class WireStateApplierTest {
     assertThat(liveUnit.getBonusMovement()).isEqualTo(1);
   }
 
+  // ---------- unit owner propagation on existing units (#41) ----------
+
+  @Test
+  void unitOwnerUpdated_whenExistingUnitChangesOwner() {
+    // Simulates a factory/airfield unit that was placed in France by Germans on a prior apply
+    // and then captured by Russians. The second apply carries the same unit UUID but a different
+    // owner field. The applier must update the live unit's owner, not leave it as Germans.
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+
+    final WireState first =
+        new WireState(
+            List.of(
+                new WireTerritory(
+                    "France",
+                    "Germans",
+                    List.of(
+                        WireUnit.of(
+                            "u-fac-1", "factory_major", 0, 0, 0, "Germans",
+                            null, false, false, false, false, 0)))),
+            List.of(),
+            1,
+            "combat",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, first, idMap);
+
+    assertThat(gd.getMap().getTerritoryOrThrow("France").getUnits().iterator().next()
+        .getOwner().getName()).isEqualTo("Germans");
+
+    // Second apply: same unit ID, territory now owned by Russians (captured), unit owner = Russians.
+    final WireState second =
+        new WireState(
+            List.of(
+                new WireTerritory(
+                    "France",
+                    "Russians",
+                    List.of(
+                        WireUnit.of(
+                            "u-fac-1", "factory_major", 0, 0, 0, "Russians",
+                            null, false, false, false, false, 0)))),
+            List.of(),
+            1,
+            "combat",
+            "Russians",
+            List.of());
+    WireStateApplier.apply(gd, second, idMap);
+
+    final Territory france = gd.getMap().getTerritoryOrThrow("France");
+    assertThat(france.getOwner().getName()).isEqualTo("Russians");
+    assertThat(france.getUnits()).hasSize(1);
+    assertThat(france.getUnits().iterator().next().getOwner().getName()).isEqualTo("Russians");
+  }
+
   @Test
   void techFlag_setsAttachmentProperty() {
     final GameData gd = fresh();


### PR DESCRIPTION
Closes #41

## Root cause

`applyTerritory`'s existing-unit branch updated `hits` and `alreadyMoved` but never updated the unit's owner. Captured infrastructure (factories, airfields) therefore kept the pre-capture owner on every subsequent `/update` apply. Concretely: after Germany captures France, the French factory's unit object still reads `owner=French` on the sidecar — the ProAI sees it as an enemy unit it doesn't control, and the verifier fires `apply-drift kind=unit-owner` on every turn.

## Fix

One comparison + one `ChangeFactory.changeOwner` call in the existing-unit branch (lines 285–301 of `WireStateApplier`):

```java
if (!unitOwner.equals(unit.getOwner())) {
  out.add(ChangeFactory.changeOwner(List.of(unit), unitOwner, territory));
}
```

`ChangeFactory.changeOwner(Collection<Unit>, GamePlayer, Territory)` already existed — no new API needed.

## Test plan

- [x] `unitOwnerUpdated_whenExistingUnitChangesOwner` — two-apply scenario: German factory in France on apply 1, Russian owner on apply 2 → unit owner is Russians after second apply
- [x] All existing `WireStateApplierTest` tests still pass (`./gradlew :game-app:ai-sidecar:test --tests "org.triplea.ai.sidecar.wire.WireStateApplierTest"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)