### PR TITLE
feat(ai-sidecar): extend WireStateVerifier — transport, territory, flag drift

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateVerifier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateVerifier.java
@@ -14,8 +14,10 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
@@ -61,9 +63,25 @@ public final class WireStateVerifier {
       final WireState wire,
       final ConcurrentMap<String, UUID> unitIdMap) {
     try {
+      // Build global unit indices for territory-placement and transport-link checks.
+      final Map<UUID, Unit> allUnitsById = new HashMap<>();
+      final Map<UUID, Territory> unitToTerritory = new HashMap<>();
+      for (final Territory t : gameData.getMap().getTerritories()) {
+        for (final Unit u : t.getUnits()) {
+          allUnitsById.put(u.getId(), u);
+          unitToTerritory.put(u.getId(), t);
+        }
+      }
+      // Reverse map: TripleA UUID → wire unit ID, for human-readable transport drift messages.
+      final Map<UUID, String> uuidToWireId = new HashMap<>();
+      for (final Map.Entry<String, UUID> e : unitIdMap.entrySet()) {
+        uuidToWireId.put(e.getValue(), e.getKey());
+      }
+
       int mismatches = 0;
       for (final WireTerritory wt : wire.territories()) {
-        mismatches += verifyTerritory(gameData, wt, unitIdMap);
+        mismatches += verifyTerritory(gameData, wt, unitIdMap,
+            allUnitsById, unitToTerritory, uuidToWireId);
       }
       for (final WirePlayer wp : wire.players()) {
         mismatches += verifyPlayer(gameData, wp);
@@ -89,7 +107,10 @@ public final class WireStateVerifier {
   private static int verifyTerritory(
       final GameData gameData,
       final WireTerritory wt,
-      final ConcurrentMap<String, UUID> unitIdMap) {
+      final ConcurrentMap<String, UUID> unitIdMap,
+      final Map<UUID, Unit> allUnitsById,
+      final Map<UUID, Territory> unitToTerritory,
+      final Map<UUID, String> uuidToWireId) {
     final Territory t = gameData.getMap().getTerritoryOrNull(wt.territoryId());
     if (t == null) {
       return 0;
@@ -135,6 +156,19 @@ public final class WireStateVerifier {
       }
       final Unit unit = findUnitById(t.getUnits(), uuid);
       if (unit == null) {
+        // Unit is known to the id map but not in the expected territory — report where it is.
+        final Territory actual = unitToTerritory.get(uuid);
+        final String actualLocation = actual != null ? actual.getName() : "not-found";
+        LOG.log(
+            Level.WARNING,
+            () ->
+                "apply-drift kind=unit-territory unitId="
+                    + wu.unitId()
+                    + " expected="
+                    + wt.territoryId()
+                    + " actual="
+                    + actualLocation);
+        drift++;
         continue;
       }
 
@@ -189,6 +223,20 @@ public final class WireStateVerifier {
                     + actualUnitOwner);
         drift++;
       }
+
+      // transportedBy — wire says which transport carries this unit; live state must match
+      drift += verifyTransportedBy(wu, unit, unitIdMap, allUnitsById, uuidToWireId,
+          wt.territoryId());
+
+      // combat-phase boolean flags
+      drift += verifyUnitBoolFlag(wu.submerged(), unit.getSubmerged(),
+          "submerged", wt.territoryId(), wu.unitId());
+      drift += verifyUnitBoolFlag(wu.wasInCombat(), unit.getWasInCombat(),
+          "wasInCombat", wt.territoryId(), wu.unitId());
+      drift += verifyUnitBoolFlag(wu.wasLoadedThisTurn(), unit.getWasLoadedThisTurn(),
+          "wasLoadedThisTurn", wt.territoryId(), wu.unitId());
+      drift += verifyUnitBoolFlag(wu.wasUnloadedInCombatPhase(), unit.getWasUnloadedInCombatPhase(),
+          "wasUnloadedInCombatPhase", wt.territoryId(), wu.unitId());
     }
 
     // conquered-this-turn (only checkable if the battle delegate is present)
@@ -210,6 +258,87 @@ public final class WireStateVerifier {
     }
 
     return drift;
+  }
+
+  private static int verifyTransportedBy(
+      final WireUnit wu,
+      final Unit unit,
+      final ConcurrentMap<String, UUID> unitIdMap,
+      final Map<UUID, Unit> allUnitsById,
+      final Map<UUID, String> uuidToWireId,
+      final String territoryId) {
+    final String wireTransportId = wu.transportedBy();
+    final Unit actualTransport = unit.getTransportedBy();
+
+    if (wireTransportId != null) {
+      final UUID transporterUuid = unitIdMap.get(wireTransportId);
+      if (transporterUuid == null) {
+        // Transporter wire ID not yet in idMap — can't verify; skip silently.
+        return 0;
+      }
+      final Unit expectedTransporter = allUnitsById.get(transporterUuid);
+      if (expectedTransporter == null) {
+        return 0;
+      }
+      if (!expectedTransporter.equals(actualTransport)) {
+        final String actualLabel = actualTransport != null
+            ? uuidToWireId.getOrDefault(actualTransport.getId(), "uuid:" + actualTransport.getId())
+            : "null";
+        LOG.log(
+            Level.WARNING,
+            () ->
+                "apply-drift kind=unit-transport-by territory="
+                    + territoryId
+                    + " unitId="
+                    + wu.unitId()
+                    + " expected="
+                    + wireTransportId
+                    + " actual="
+                    + actualLabel);
+        return 1;
+      }
+    } else if (actualTransport != null) {
+      // Wire says no transport, but live unit has one.
+      final String actualLabel =
+          uuidToWireId.getOrDefault(actualTransport.getId(), "uuid:" + actualTransport.getId());
+      LOG.log(
+          Level.WARNING,
+          () ->
+              "apply-drift kind=unit-transport-by territory="
+                  + territoryId
+                  + " unitId="
+                  + wu.unitId()
+                  + " expected=null"
+                  + " actual="
+                  + actualLabel);
+      return 1;
+    }
+    return 0;
+  }
+
+  private static int verifyUnitBoolFlag(
+      final boolean expected,
+      final boolean actual,
+      final String flagName,
+      final String territoryId,
+      final String wireUnitId) {
+    if (expected == actual) {
+      return 0;
+    }
+    LOG.log(
+        Level.WARNING,
+        () ->
+            "apply-drift kind=unit-"
+                + flagName
+                + " territory="
+                + territoryId
+                + " unitId="
+                + wireUnitId
+                + " expected="
+                + expected
+                + " actual="
+                + actual);
+    return 1;
   }
 
   private static int verifyPlayer(final GameData gameData, final WirePlayer wp) {

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateVerifierTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateVerifierTest.java
@@ -341,6 +341,162 @@ class WireStateVerifierTest {
   }
 
   @Test
+  void unitTerritoryDrift_detectedAfterMovingUnitToWrongTerritory() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    final String uid = "u-inf-1";
+    // Wire places the infantry in Germany.
+    final WireState wire =
+        new WireState(
+            List.of(
+                new WireTerritory(
+                    "Germany", "Germans", List.of(new WireUnit(uid, "infantry", 0, 0)))),
+            List.of(),
+            1,
+            "purchase",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, wire, idMap);
+    captured.clear();
+
+    // Move the unit to France to simulate misplacement drift.
+    final Territory germany = gd.getMap().getTerritoryOrThrow("Germany");
+    final Territory france = gd.getMap().getTerritoryOrThrow("France");
+    final Unit unit = germany.getUnits().stream()
+        .filter(u -> u.getId().equals(idMap.get(uid))).findFirst().orElseThrow();
+    gd.performChange(
+        games.strategy.engine.data.changefactory.ChangeFactory.moveUnits(
+            germany, france, List.of(unit)));
+
+    WireStateVerifier.verifyApply(gd, wire, idMap);
+
+    assertThat(warnings())
+        .anyMatch(
+            w ->
+                w.contains("apply-drift")
+                    && w.contains("kind=unit-territory")
+                    && w.contains("unitId=" + uid)
+                    && w.contains("expected=Germany")
+                    && w.contains("actual=France"));
+  }
+
+  @Test
+  void transportedByDrift_detectedAfterClearingLink() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    final WireUnit transport =
+        WireUnit.of("u-trn-1", "transport", 0, 0, 0, "Germans", null, false, false, false, false, 0);
+    final WireUnit infantry =
+        WireUnit.of("u-inf-1", "infantry", 0, 0, 0, "Germans", "u-trn-1", false, false, false, false, 0);
+    final WireState wire =
+        new WireState(
+            List.of(new WireTerritory("112 Sea Zone", "Germans", List.of(transport, infantry))),
+            List.of(),
+            1,
+            "purchase",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, wire, idMap);
+    captured.clear();
+
+    // Clear the transportedBy link to simulate drift.
+    final Territory seaZone = gd.getMap().getTerritoryOrThrow("112 Sea Zone");
+    final UUID infantryUuid = idMap.get("u-inf-1");
+    final Unit infantryUnit = seaZone.getUnits().stream()
+        .filter(u -> u.getId().equals(infantryUuid)).findFirst().orElseThrow();
+    gd.performChange(
+        games.strategy.engine.data.changefactory.ChangeFactory.unitPropertyChange(
+            infantryUnit, null, Unit.PropertyName.TRANSPORTED_BY));
+
+    WireStateVerifier.verifyApply(gd, wire, idMap);
+
+    assertThat(warnings())
+        .anyMatch(
+            w ->
+                w.contains("apply-drift")
+                    && w.contains("kind=unit-transport-by")
+                    && w.contains("unitId=u-inf-1")
+                    && w.contains("expected=u-trn-1")
+                    && w.contains("actual=null"));
+  }
+
+  @Test
+  void submergedFlagDrift_detectedAfterClearingSubmerged() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    final String uid = "u-sub-1";
+    final WireUnit sub =
+        WireUnit.of(uid, "submarine", 0, 0, 0, "Germans", null, true, false, false, false, 0);
+    final WireState wire =
+        new WireState(
+            List.of(new WireTerritory("112 Sea Zone", "Germans", List.of(sub))),
+            List.of(),
+            1,
+            "purchase",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, wire, idMap);
+    captured.clear();
+
+    // Clear submerged flag to simulate drift.
+    final Territory seaZone = gd.getMap().getTerritoryOrThrow("112 Sea Zone");
+    final Unit unit = seaZone.getUnits().stream()
+        .filter(u -> u.getId().equals(idMap.get(uid))).findFirst().orElseThrow();
+    gd.performChange(
+        games.strategy.engine.data.changefactory.ChangeFactory.unitPropertyChange(
+            unit, false, Unit.PropertyName.SUBMERGED));
+
+    WireStateVerifier.verifyApply(gd, wire, idMap);
+
+    assertThat(warnings())
+        .anyMatch(
+            w ->
+                w.contains("apply-drift")
+                    && w.contains("kind=unit-submerged")
+                    && w.contains("unitId=" + uid)
+                    && w.contains("expected=true")
+                    && w.contains("actual=false"));
+  }
+
+  @Test
+  void wasInCombatFlagDrift_detectedAfterClearingWasInCombat() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    final String uid = "u-inf-1";
+    final WireUnit infantry =
+        WireUnit.of(uid, "infantry", 0, 0, 0, "Germans", null, false, true, false, false, 0);
+    final WireState wire =
+        new WireState(
+            List.of(new WireTerritory("Germany", "Germans", List.of(infantry))),
+            List.of(),
+            1,
+            "purchase",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, wire, idMap);
+    captured.clear();
+
+    // Clear wasInCombat to simulate drift.
+    final Territory germany = gd.getMap().getTerritoryOrThrow("Germany");
+    final Unit unit = germany.getUnits().stream()
+        .filter(u -> u.getId().equals(idMap.get(uid))).findFirst().orElseThrow();
+    gd.performChange(
+        games.strategy.engine.data.changefactory.ChangeFactory.unitPropertyChange(
+            unit, false, Unit.PropertyName.WAS_IN_COMBAT));
+
+    WireStateVerifier.verifyApply(gd, wire, idMap);
+
+    assertThat(warnings())
+        .anyMatch(
+            w ->
+                w.contains("apply-drift")
+                    && w.contains("kind=unit-wasInCombat")
+                    && w.contains("unitId=" + uid)
+                    && w.contains("expected=true")
+                    && w.contains("actual=false"));
+  }
+
+  @Test
   void summaryLine_alwaysEmitted() {
     final GameData gd = fresh();
     final WireState wire =


### PR DESCRIPTION
Closes #43

## New drift categories

### `kind=unit-territory`
Previously, when `findUnitById` returned null (unit not in the expected territory), the code silently `continue`d. Now it searches the global unit→territory index and logs where the unit actually ended up:
```
apply-drift kind=unit-territory unitId=u-inf-1 expected=Germany actual=France
```

### `kind=unit-transport-by`
Compares the wire's `transportedBy` field against the live `Unit.getTransportedBy()` link. Uses the reverse idMap to log human-readable wire IDs; falls back to `uuid:<id>` when the actual transporter isn't in the map:
```
apply-drift kind=unit-transport-by territory=112 Sea Zone unitId=u-inf-1 expected=u-trn-1 actual=null
```

### `kind=unit-<flag>` for boolean combat-phase flags
Covers `submerged`, `wasInCombat`, `wasLoadedThisTurn`, `wasUnloadedInCombatPhase` via a shared `verifyUnitBoolFlag` helper:
```
apply-drift kind=unit-submerged territory=112 Sea Zone unitId=u-sub-1 expected=true actual=false
```

## Also
Global unit indices (`allUnitsById`, `unitToTerritory`, `uuidToWireId`) now built once at the top of `verifyApply` in a single pass, shared across all territory iterations.

## Test plan

- [x] `unitTerritoryDrift_detectedAfterMovingUnitToWrongTerritory`
- [x] `transportedByDrift_detectedAfterClearingLink`
- [x] `submergedFlagDrift_detectedAfterClearingSubmerged`
- [x] `wasInCombatFlagDrift_detectedAfterClearingWasInCombat`
- [x] All 8 existing `WireStateVerifierTest` cases still pass (12 total)

`./gradlew :game-app:ai-sidecar:test --tests "org.triplea.ai.sidecar.wire.WireStateVerifierTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)