### PR TITLE
obs(ai-sidecar): log per-unit wire IDs + air-move kind in AiTraceLogger (#1897)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
@@ -31,23 +31,37 @@ public final class AiTraceLogger {
       final MoveDescription move,
       final boolean isBombing,
       final Map<UUID, String> uuidToWireId) {
-    final String kind =
-        isBombing
-            ? "sbr"
-            : move.getRoute().isLoad() ? "load" : move.getRoute().isUnload() ? "unload" : "move";
+    final Collection<Unit> allUnits = move.getUnits();
+    // Air units dispatched from carriers yield route.isUnload() == true on the TripleA side, but
+    // the bot-worker translates them to plain moveUnit calls (not unloadFromTransport). Label the
+    // sidecar trace as "air-move" so the sidecar → bot-worker correspondence reads cleanly.
+    final boolean allAir =
+        !allUnits.isEmpty() && allUnits.stream().allMatch(u -> u.getUnitAttachment().isAir());
+    final String kind;
+    if (isBombing) {
+      kind = "sbr";
+    } else if (move.getRoute().isLoad()) {
+      kind = "load";
+    } else if (move.getRoute().isUnload()) {
+      kind = allAir ? "air-move" : "unload";
+    } else {
+      kind = "move";
+    }
     final String from = maybeQuote(move.getRoute().getStart().getName());
     final String to = maybeQuote(move.getRoute().getEnd().getName());
-    final String units = unitTypeCounts(move.getUnits());
+    final String unitIds = unitWireIds(allUnits, uuidToWireId);
+    final String types = unitTypeCounts(allUnits);
     final String transportId = resolveTransportId(move, uuidToWireId);
     LOG.log(
         System.Logger.Level.INFO,
-        "[AI-TRACE] side=sidecar nation={0} phase={1} kind={2} from={3} to={4} units=[{5}] transportId={6}",
+        "[AI-TRACE] side=sidecar nation={0} phase={1} kind={2} from={3} to={4} unitIds=[{5}] types=[{6}] transportId={7}",
         nation,
         phase,
         kind,
         from,
         to,
-        units,
+        unitIds,
+        types,
         transportId);
   }
 
@@ -82,6 +96,26 @@ public final class AiTraceLogger {
   }
 
   // --- package-private for tests ---
+
+  /**
+   * Build a comma-separated list of Map Room wire IDs for each unit in the given collection, in
+   * iteration order. Falls back to {@code uuid:<java-uuid>} when a unit is not registered in the
+   * reverse map (should not happen in live dispatch but keeps the log non-empty if it does).
+   */
+  static String unitWireIds(final Collection<Unit> units, final Map<UUID, String> uuidToWireId) {
+    if (units.isEmpty()) {
+      return "";
+    }
+    final StringBuilder sb = new StringBuilder();
+    for (final Unit u : units) {
+      if (sb.length() > 0) {
+        sb.append(',');
+      }
+      final String wireId = uuidToWireId.get(u.getId());
+      sb.append(wireId != null ? wireId : "uuid:" + u.getId());
+    }
+    return sb.toString();
+  }
 
   static String unitTypeCounts(final Collection<Unit> units) {
     final Map<String, Integer> counts = new LinkedHashMap<>();

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceLoggerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceLoggerTest.java
@@ -1,0 +1,81 @@
+package org.triplea.ai.sidecar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Unit tests for {@link AiTraceLogger} helpers. The full {@link AiTraceLogger#logCapturedMove} path
+ * is exercised by integration tests in the executor suites (which construct real {@code
+ * MoveDescription} instances); this file focuses on the pure-helper logic that can be verified
+ * without a full TripleA game engine.
+ */
+class AiTraceLoggerTest {
+
+  private static CanonicalGameData canonical;
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+  }
+
+  @Test
+  void unitWireIds_emptyCollection_returnsEmptyString() {
+    assertThat(AiTraceLogger.unitWireIds(List.of(), new HashMap<>())).isEmpty();
+  }
+
+  @Test
+  void unitWireIds_mappedUnits_emitsCommaSeparatedWireIds() {
+    final var gd = canonical.cloneForSession();
+    final UnitType infantry = gd.getUnitTypeList().getUnitType("infantry").orElseThrow();
+    final var germans = gd.getPlayerList().getPlayerId("Germans");
+    final List<Unit> units = new ArrayList<>();
+    final Map<UUID, String> uuidToWireId = new HashMap<>();
+    for (int i = 0; i < 3; i++) {
+      final Unit u = new Unit(UUID.randomUUID(), infantry, germans, gd);
+      units.add(u);
+      uuidToWireId.put(u.getId(), "u" + (100 + i));
+    }
+
+    assertThat(AiTraceLogger.unitWireIds(units, uuidToWireId)).isEqualTo("u100,u101,u102");
+  }
+
+  @Test
+  void unitWireIds_unmappedUnit_fallsBackToUuidPrefix() {
+    final var gd = canonical.cloneForSession();
+    final UnitType infantry = gd.getUnitTypeList().getUnitType("infantry").orElseThrow();
+    final var germans = gd.getPlayerList().getPlayerId("Germans");
+    final UUID orphanId = UUID.randomUUID();
+    final Unit orphan = new Unit(orphanId, infantry, germans, gd);
+
+    final String result = AiTraceLogger.unitWireIds(List.of(orphan), new HashMap<>());
+
+    assertThat(result).isEqualTo("uuid:" + orphanId);
+  }
+
+  @Test
+  void unitTypeCounts_groupsByType() {
+    final var gd = canonical.cloneForSession();
+    final UnitType infantry = gd.getUnitTypeList().getUnitType("infantry").orElseThrow();
+    final UnitType armour = gd.getUnitTypeList().getUnitType("armour").orElseThrow();
+    final var germans = gd.getPlayerList().getPlayerId("Germans");
+    final List<Unit> units =
+        List.of(
+            new Unit(UUID.randomUUID(), infantry, germans, gd),
+            new Unit(UUID.randomUUID(), infantry, germans, gd),
+            new Unit(UUID.randomUUID(), armour, germans, gd));
+
+    assertThat(AiTraceLogger.unitTypeCounts(units)).isEqualTo("infantry×2,armour×1");
+  }
+}


### PR DESCRIPTION
Refs map-room#1897 — part 1 (sidecar side).

## Summary

Two changes to \`AiTraceLogger.logCapturedMove\`:

1. **Wire IDs on the trace.** Emit \`unitIds=[U74]\` as the primary field using the existing \`uuidToWireId\` reverse map. Keep \`types=[infantry×1]\` as secondary readability.
2. **Air-move label.** When all units on an unload route are air units, emit \`kind=air-move\` instead of \`kind=unload\`. TripleA's \`MoveDescription\` reports \`route.isUnload()==true\` for carrier-launch air moves, but the bot-worker translates them to plain \`moveUnit\` (not \`unloadFromTransport\`). Labeling them \`unload\` made the sidecar → bot-worker trace correlation misleading.

## New trace format

\`\`\`
[AI-TRACE] side=sidecar nation=Japanese phase=noncombat-move kind=load from=Okinawa to="19 Sea Zone" unitIds=[U74] types=[infantry×1] transportId=u167
[AI-TRACE] side=sidecar nation=Japanese phase=noncombat-move kind=air-move from="21 Sea Zone" to=Kwangsi unitIds=[U92] types=[fighter×1] transportId=null
\`\`\`

vs. previously:
\`\`\`
[AI-TRACE] side=sidecar nation=Japanese phase=noncombat-move kind=load from=Okinawa to="19 Sea Zone" units=[infantry×1] transportId=u167
[AI-TRACE] side=sidecar nation=Japanese phase=noncombat-move kind=unload from="21 Sea Zone" to=Kwangsi units=[fighter×1] transportId=null
\`\`\`

## Tests

New \`AiTraceLoggerTest\` covers the \`unitWireIds\` helper:
- empty collection → empty string
- mapped units → comma-separated wire IDs in iteration order
- unmapped units → \`uuid:<java-uuid>\` fallback (defensive)
- \`unitTypeCounts\` still groups by type

Full \`logCapturedMove\` path remains covered by existing executor integration tests (which construct real \`MoveDescription\` instances).

## Acceptance

- [x] Sidecar NCM/CM trace includes \`unitIds=[wireId,...]\` for every logged move
- [x] Aircraft-from-carrier moves log \`kind=air-move\` not \`kind=unload\`
- [x] New unit tests added for \`unitWireIds\` helper
- [x] \`./gradlew :game-app:ai-sidecar:test\` green
- [x] \`./gradlew :game-app:ai-sidecar:compileJava\` clean

## Related

- map-room#1897 — original logging improvement spec
- map-room (separate PR) — bot-worker side: \`→ ack=ok / → ack=rejected reason=...\` follow-up logging on \`dispatchMoveOrderWithAck\`. Depends on nothing here — can land independently.

## Crew

Assigning back to bravo per the issue's close-out instruction.