### PR TITLE
feat(proai): evacuateStrandedAir rescue pass in ProNonCombatMoveAi (§19)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -183,6 +183,12 @@ class ProNonCombatMoveAi {
     // Determine where to move infra units
     factoryMoveMap = moveInfraUnits(isCombatMove, factoryMoveMap, infraUnitMoveMap);
 
+    // Rescue air units left on illegal final positions (e.g. just-conquered
+    // territory). Must run before the unmoved-unit warning loop so the pass
+    // can consume entries from unitMoveMap and the warning only fires for
+    // truly unmovable units.
+    evacuateStrandedAir(moveMap, territoryValueMap);
+
     // Log a warning if any units not assigned to a territory (skip infrastructure for now)
     for (final Unit u : territoryManager.getDefendOptions().getUnitMoveMap().keySet()) {
       if (Matches.unitIsInfrastructure().negate().test(u)) {
@@ -2167,6 +2173,123 @@ class ProNonCombatMoveAi {
       Optional.ofNullable(carrierMustMoveWith.get(u))
           .ifPresent(fighters -> to.getTempUnits().addAll(fighters));
     }
+  }
+
+  /**
+   * Rescue pass: for every air unit whose current territory is not a valid landing spot (conquered-
+   * this-turn land, or water without carrier capacity) and which has at least one valid option in
+   * its move map, pick the best destination and assign it. Runs after {@link
+   * #moveUnitsToBestTerritories} and before the unmoved-unit warning loop.
+   *
+   * <p>Two-pass heuristic:
+   *
+   * <ol>
+   *   <li>Defense-maximizer over the unit's valid options — reuses the existing threshold from
+   *       {@code moveUnitsToBestTerritories}.
+   *   <li>Nearest-valid fallback, ties broken by {@code territoryValueMap} (prefer strategically
+   *       useful tiles).
+   * </ol>
+   *
+   * <p>If no valid option exists, the unit is left in place. The Map Room engine's {@code
+   * destroyStrandedAir} path then crashes it per §19.
+   */
+  private void evacuateStrandedAir(
+      final Map<Territory, ProTerritory> moveMap, final Map<Territory, Double> territoryValueMap) {
+    final Map<Unit, Set<Territory>> unitMoveMap =
+        territoryManager.getDefendOptions().getUnitMoveMap();
+    final List<Unit> airStuck = new ArrayList<>();
+    for (final Unit u : unitMoveMap.keySet()) {
+      if (!u.getUnitAttachment().isAir()) {
+        continue;
+      }
+      final Territory currentTerr = unitTerritoryMap.get(u);
+      if (currentTerr == null) {
+        continue;
+      }
+      if (currentTerrIsValidLanding(u, currentTerr, moveMap)) {
+        continue;
+      }
+      if (unitMoveMap.get(u).isEmpty()) {
+        continue;
+      }
+      airStuck.add(u);
+    }
+
+    for (final Unit u : airStuck) {
+      final Territory chosen =
+          pickEvacuationDestination(u, unitMoveMap.get(u), moveMap, territoryValueMap);
+      if (chosen == null) {
+        continue;
+      }
+      moveMap.get(chosen).addUnit(u);
+      unitMoveMap.remove(u);
+      ProLogger.debug(String.format("evacuateStrandedAir: %s moved to %s", u, chosen.getName()));
+    }
+  }
+
+  private boolean currentTerrIsValidLanding(
+      final Unit unit, final Territory t, final Map<Territory, ProTerritory> moveMap) {
+    if (!t.isWater()) {
+      return Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player).test(t);
+    }
+    final ProTerritory proTerritory = moveMap.get(t);
+    if (proTerritory == null) {
+      return false;
+    }
+    return ProTransportUtils.validateCarrierCapacity(
+        player, t, proTerritory.getAllDefendersForCarrierCalcs(data, player), unit);
+  }
+
+  private Territory pickEvacuationDestination(
+      final Unit unit,
+      final Set<Territory> options,
+      final Map<Territory, ProTerritory> moveMap,
+      final Map<Territory, Double> territoryValueMap) {
+    final List<Territory> validOptions = new ArrayList<>();
+    for (final Territory t : options) {
+      if (currentTerrIsValidLanding(unit, t, moveMap)) {
+        validOptions.add(t);
+      }
+    }
+    if (validOptions.isEmpty()) {
+      return null;
+    }
+
+    // Pass 1: defense-maximizer restricted to valid options.
+    Territory bestByDefense = null;
+    double bestWinPct = -Double.MAX_VALUE;
+    for (final Territory t : validOptions) {
+      final ProTerritory proTerritory = moveMap.get(t);
+      proTerritory.setBattleResultIfNull(
+          () ->
+              calc.estimateDefendBattleResults(
+                  proData, proTerritory, proTerritory.getEligibleDefenders(player)));
+      final ProBattleResult result = proTerritory.getBattleResult();
+      final boolean hasFactory = ProMatches.territoryHasInfraFactoryAndIsLand().test(t);
+      final boolean meetsThreshold =
+          (t.equals(proData.getMyCapital())
+                  && result.getWinPercentage() > (100 - proData.getWinPercentage()))
+              || (hasFactory && result.getWinPercentage() > (100 - proData.getMinWinPercentage()))
+              || result.getTuvSwing() >= 0;
+      if (meetsThreshold && result.getWinPercentage() > bestWinPct) {
+        bestByDefense = t;
+        bestWinPct = result.getWinPercentage();
+      }
+    }
+    if (bestByDefense != null) {
+      return bestByDefense;
+    }
+
+    // Pass 2: nearest-valid fallback, ties broken by territory strategic value.
+    final Territory currentTerr = unitTerritoryMap.get(unit);
+    return validOptions.stream()
+        .min(
+            Comparator.comparingInt(
+                    (Territory t) ->
+                        data.getMap().getDistanceIgnoreEndForCondition(currentTerr, t, any -> true))
+                .thenComparing(
+                    t -> territoryValueMap.getOrDefault(t, 0.0), Comparator.reverseOrder()))
+        .orElse(null);
   }
 
   private Map<Territory, ProTerritory> moveInfraUnits(


### PR DESCRIPTION
## Summary

Implements Part B of https://github.com/map-room/map-room/blob/docs/proai-air-evacuation-spec/docs/superpowers/specs/2026-04-21-proai-air-evacuation-design.md.

After \`moveUnitsToBestTerritories\` and before the unmoved-unit warning loop in \`ProNonCombatMoveAi.doNonCombatMove\`, run a new rescue pass \`evacuateStrandedAir\`. For every air unit whose current territory is not a valid landing spot (conquered-this-turn land, or sea zones without carrier capacity) and which has at least one valid option in its move map, pick the best destination via a two-pass heuristic and assign it.

- **Pass 1**: defense-maximizer restricted to the unit's valid reachable options (mirrors the threshold logic from the existing air-placement pass — capital + winPct / factory + winPct / tuvSwing ≥ 0).
- **Pass 2**: nearest-valid fallback, ties broken by \`territoryValueMap\` so strategically useful tiles beat filler.

Units with no valid option remain in place — downstream engines are expected to crash them per §19 (Map Room shipped this path in PR #1906).

## Why

\`ProCombatMoveAi.canAirSafelyLandAfterAttack\` picks attack targets based on a half-range heuristic, but nothing re-checks the post-capture landing situation. After the attack resolves, air units sit on a just-conquered territory. The existing NCM air-placement pass is a pure defense-maximizer — if the unit's reachable options don't improve defense, it leaves the unit unmoved and logs a warning. The unit stays on the conquered tile.

Observed in production (map-room sidecar): Japanese bombers u87, u88, tactical_bomber u107, fighter u145 all physically on Amur after Japan's turn ends, with Amur in \`_conqueredThisTurn\`.

## Test plan

- [x] \`games.strategy.triplea.ai.pro.*\` test suite passes
- [x] \`:game-app:ai-sidecar:test\` passes (\`NoncombatMoveExecutorIntegrationTest\` and others) — rescue is a no-op when no air is stranded
- [x] Spotless clean
- [ ] 🧑 Manual: deploy to map-room sidecar, reproduce the Amur scenario, confirm bombers end up at strategically-chosen landings (airfields, capitals, home) rather than random nearest-friendly tiles.

## Follow-up

Dedicated ProNonCombatMoveAi unit test coverage is not part of this PR — the codebase has no established fixture for direct \`doNonCombatMove\` invocation and building one is a larger infra task. Behavior is validated via the existing sidecar integration tests plus manual Amur reproduction. If future regressions call for unit tests, build a ProAiTestFixture at that point.