### PR TITLE
fix(ai-sidecar): bomber classifies as isTransport=false (#1908)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/WireMoveDescriptionBuilder.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/WireMoveDescriptionBuilder.java
@@ -69,7 +69,11 @@ public final class WireMoveDescriptionBuilder {
   }
 
   private static WireUnitClassification classify(final Unit u) {
+    // Bombers have transportCapacity > 0 (paratroop XML field) but are air units,
+    // not sea transports. isTransport must be false for air to prevent the translator
+    // from splitting a mixed-air MD into two overlapping moveUnit dispatches (#1908).
     return new WireUnitClassification(
-        u.getUnitAttachment().isAir(), u.getUnitAttachment().getTransportCapacity() > 0);
+        u.getUnitAttachment().isAir(),
+        u.getUnitAttachment().getTransportCapacity() > 0 && !u.getUnitAttachment().isAir());
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/WireMoveDescriptionBuilderTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/WireMoveDescriptionBuilderTest.java
@@ -86,6 +86,36 @@ class WireMoveDescriptionBuilderTest {
     assertThat(result.classifications()).isEmpty();
   }
 
+  @Test
+  void bomberClassifiesAsAirNotTransport() {
+    // Bombers have transportCapacity=2 in Global 1940 XML (paratroop field).
+    // Before the fix, classify() returned {isAir:true, isTransport:true}, causing
+    // the TS translator to split a mixed-air MD into two overlapping moveUnit calls.
+    final Unit bomber = unit("bomber");
+    final Map<UUID, String> wireMap = Map.of(bomber.getId(), "W_bmr");
+    final MoveDescription md =
+        new MoveDescription(List.of(bomber), new Route(germany, sz112), Map.of());
+
+    final WireMoveDescription result = WireMoveDescriptionBuilder.build(md, wireMap);
+
+    assertThat(result.classifications())
+        .containsEntry("W_bmr", new WireUnitClassification(true, false));
+  }
+
+  @Test
+  void seaTransportClassifiesAsTransportNotAir() {
+    final Unit tp = unit("transport");
+    final Map<UUID, String> wireMap = Map.of(tp.getId(), "W_tp");
+    // Route must have distinct start/end territories.
+    final MoveDescription md =
+        new MoveDescription(List.of(tp), new Route(sz112, germany), Map.of());
+
+    final WireMoveDescription result = WireMoveDescriptionBuilder.build(md, wireMap);
+
+    assertThat(result.classifications())
+        .containsEntry("W_tp", new WireUnitClassification(false, true));
+  }
+
   private Unit unit(final String type) {
     return data.getUnitTypeList()
         .getUnitTypeOrThrow(type)


### PR DESCRIPTION
## Problem

In Global 1940 XML, bombers have `transportCapacity=2` (a paratroop field). `WireMoveDescriptionBuilder.classify()` read this as sea-transport capacity, emitting `{isAir: true, isTransport: true}` for bombers.

The TypeScript `translateMoveDescription` then hit **both** the `transportUnits` branch and the `airUnits` branch for the same units, producing two overlapping `moveUnit` dispatches. The second was rejected:

```
units=[u87,u88](2)             → ack=ok
units=[u87,u88,u85,u86,u83](5) → ack=rejected  reason="Unit u87 not in Japan"
```

## Fix

Narrow `isTransport` to non-air units:

```java
return new WireUnitClassification(
    u.getUnitAttachment().isAir(),
    u.getUnitAttachment().getTransportCapacity() > 0 && !u.getUnitAttachment().isAir());
```

## Tests

- `bomberClassifiesAsAirNotTransport` — asserts bomber → `{isAir:true, isTransport:false}`
- `seaTransportClassifiesAsTransportNotAir` — asserts transport still → `{isAir:false, isTransport:true}`

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:test --tests "org.triplea.ai.sidecar.exec.WireMoveDescriptionBuilderTest"` — 5 tests, all pass

Closes #1908