### PR TITLE
feat(proai): ProSplitResourceTracker for British dual economy

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
@@ -12,6 +12,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegate;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.ai.pro.data.ProSplitResourceTracker;
 import games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge;
 import games.strategy.triplea.delegate.EndRoundDelegate;
 import games.strategy.triplea.delegate.MoveDelegate;
@@ -31,7 +32,10 @@ import org.triplea.ai.sidecar.dto.PurchaseRequest;
 import org.triplea.ai.sidecar.dto.RepairOrder;
 import org.triplea.ai.sidecar.session.ProSessionSnapshotStore;
 import org.triplea.ai.sidecar.session.Session;
+import org.triplea.ai.sidecar.wire.WirePlayer;
+import org.triplea.ai.sidecar.wire.WireState;
 import org.triplea.ai.sidecar.wire.WireStateApplier;
+import org.triplea.ai.sidecar.wire.WireTerritory;
 import org.triplea.java.collections.IntegerMap;
 
 /**
@@ -120,6 +124,11 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
     final RecordingPurchaseDelegate recorder = new RecordingPurchaseDelegate();
     recorder.initialize("purchase", "Purchase");
     recorder.setDelegateBridgeAndPlayer(new ProDummyDelegateBridge(proAi, player, data));
+
+    // British dual-economy: if the wire state has split IPCs for British plus
+    // per-territory economy tags, prime the ProAi instance with a split-aware
+    // ProResourceTracker for this purchase pass.
+    maybeApplyBritishSplitEconomy(request.state(), proAi, data);
 
     final Future<Void> future =
         session
@@ -254,5 +263,35 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
       }
     }
     return "";
+  }
+
+  private static void maybeApplyBritishSplitEconomy(
+      final WireState wire, final ProAi proAi, final GameData data) {
+    WirePlayer british = null;
+    for (final WirePlayer p : wire.players()) {
+      if ("British".equals(p.playerId()) && p.europePus() != null && p.pacificPus() != null) {
+        british = p;
+        break;
+      }
+    }
+    if (british == null) {
+      return;
+    }
+    final Map<Territory, ProSplitResourceTracker.Pool> poolByTerritory = new HashMap<>();
+    for (final WireTerritory wt : wire.territories()) {
+      if (wt.economy() == null) {
+        continue;
+      }
+      final Territory t = data.getMap().getTerritoryOrNull(wt.territoryId());
+      if (t == null) {
+        continue;
+      }
+      poolByTerritory.put(
+          t,
+          "europe".equals(wt.economy())
+              ? ProSplitResourceTracker.Pool.EUROPE
+              : ProSplitResourceTracker.Pool.PACIFIC);
+    }
+    proAi.setBritishEconomySplit(british.europePus(), british.pacificPus(), poolByTerritory);
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WirePlayer.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WirePlayer.java
@@ -1,5 +1,43 @@
 package org.triplea.ai.sidecar.wire;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
-public record WirePlayer(String playerId, int pus, List<String> tech, boolean capitalCaptured) {}
+/**
+ * Wire serialization of a Map Room player. For British, {@code europePus} and {@code pacificPus}
+ * carry the split IPC pools (both are present iff Map Room's {@code G.ukEconomies} is set); {@code
+ * pus} remains the combined total for backwards compatibility. Absent for non-British players.
+ */
+public record WirePlayer(
+    String playerId,
+    int pus,
+    List<String> tech,
+    boolean capitalCaptured,
+    @JsonInclude(JsonInclude.Include.NON_NULL) Integer europePus,
+    @JsonInclude(JsonInclude.Include.NON_NULL) Integer pacificPus) {
+  @JsonCreator
+  public WirePlayer(
+      @JsonProperty("playerId") final String playerId,
+      @JsonProperty("pus") final int pus,
+      @JsonProperty("tech") final List<String> tech,
+      @JsonProperty("capitalCaptured") final boolean capitalCaptured,
+      @JsonProperty("europePus") final Integer europePus,
+      @JsonProperty("pacificPus") final Integer pacificPus) {
+    this.playerId = playerId;
+    this.pus = pus;
+    this.tech = tech == null ? List.of() : tech;
+    this.capitalCaptured = capitalCaptured;
+    this.europePus = europePus;
+    this.pacificPus = pacificPus;
+  }
+
+  public WirePlayer(
+      final String playerId,
+      final int pus,
+      final List<String> tech,
+      final boolean capitalCaptured) {
+    this(playerId, pus, tech, capitalCaptured, null, null);
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireTerritory.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireTerritory.java
@@ -1,25 +1,48 @@
 package org.triplea.ai.sidecar.wire;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import javax.annotation.Nullable;
 
+/**
+ * Wire serialization of a Map Room territory. The {@code economy} field is set by Map Room for
+ * British-owned territories (and sea zones with a single adjacent British factory) — {@code
+ * "europe"} or {@code "pacific"} — and is consumed by {@link
+ * org.triplea.ai.sidecar.exec.PurchaseExecutor} to build the split-resource tracker's per-territory
+ * pool map. Absent for non-British territories and for ambiguous/unmapped sea zones.
+ */
 public record WireTerritory(
-    String territoryId, String owner, List<WireUnit> units, boolean conqueredThisTurn) {
+    String territoryId,
+    String owner,
+    List<WireUnit> units,
+    boolean conqueredThisTurn,
+    @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable String economy) {
   @JsonCreator
   public WireTerritory(
       @JsonProperty("territoryId") final String territoryId,
       @JsonProperty("owner") final String owner,
       @JsonProperty("units") final List<WireUnit> units,
-      @JsonProperty("conqueredThisTurn") final Boolean conqueredThisTurn) {
+      @JsonProperty("conqueredThisTurn") final Boolean conqueredThisTurn,
+      @JsonProperty("economy") final String economy) {
     this(
         territoryId,
         owner,
         units == null ? List.of() : units,
-        Boolean.TRUE.equals(conqueredThisTurn));
+        Boolean.TRUE.equals(conqueredThisTurn),
+        economy);
   }
 
   public WireTerritory(final String territoryId, final String owner, final List<WireUnit> units) {
-    this(territoryId, owner, units, false);
+    this(territoryId, owner, units, false, null);
+  }
+
+  public WireTerritory(
+      final String territoryId,
+      final String owner,
+      final List<WireUnit> units,
+      final boolean conqueredThisTurn) {
+    this(territoryId, owner, units, conqueredThisTurn, null);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -17,7 +17,9 @@ import games.strategy.triplea.ai.pro.data.PlaceTerritorySnapshot;
 import games.strategy.triplea.ai.pro.data.ProBattleResult;
 import games.strategy.triplea.ai.pro.data.ProPlaceTerritory;
 import games.strategy.triplea.ai.pro.data.ProPurchaseTerritory;
+import games.strategy.triplea.ai.pro.data.ProResourceTracker;
 import games.strategy.triplea.ai.pro.data.ProSessionSnapshot;
+import games.strategy.triplea.ai.pro.data.ProSplitResourceTracker;
 import games.strategy.triplea.ai.pro.data.ProTerritory;
 import games.strategy.triplea.ai.pro.data.ProTerritorySnapshot;
 import games.strategy.triplea.ai.pro.data.PurchaseTerritorySnapshot;
@@ -79,6 +81,15 @@ public abstract class AbstractProAi extends AbstractAi {
   private List<PoliticalActionAttachment> storedPoliticalActions;
   private List<Territory> storedStrafingTerritories;
 
+  // Sidecar-injected split-economy state for British. Set via
+  // setBritishEconomySplit before invokePurchaseForSidecar; consumed by
+  // createResourceTracker. Clearing between turns is not necessary — the
+  // setter is called every British purchase turn with current values.
+  private int britishEuropePus;
+  private int britishPacificPus;
+  private Map<Territory, ProSplitResourceTracker.Pool> britishPoolByTerritory = new HashMap<>();
+  private boolean britishSplitEconomyActive;
+
   // Sidecar mode: skip the politics step in purchase()'s simulation loop.
   // Politics has already executed on the session GameData before purchase runs;
   // re-rolling here would speculatively declare additional wars not present in
@@ -137,6 +148,36 @@ public abstract class AbstractProAi extends AbstractAi {
   /** Package-private — visible to unit tests only. */
   boolean isSimulatePoliticsInPurchase() {
     return simulatePoliticsInPurchase;
+  }
+
+  /**
+   * Tell this ProAi instance that the next British purchase should use a split resource tracker
+   * with the given pool balances and territory mapping. Called by the sidecar's PurchaseExecutor
+   * from the wire state before invoking purchase planning. Has no effect for non-British players —
+   * the active check lives in {@link #createResourceTracker(GamePlayer, GameState)}.
+   */
+  public void setBritishEconomySplit(
+      final int europePus,
+      final int pacificPus,
+      final Map<Territory, ProSplitResourceTracker.Pool> poolByTerritory) {
+    this.britishEuropePus = europePus;
+    this.britishPacificPus = pacificPus;
+    this.britishPoolByTerritory = poolByTerritory;
+    this.britishSplitEconomyActive = true;
+  }
+
+  /**
+   * Construct the {@link ProResourceTracker} for a purchase-planning pass. Returns a {@link
+   * ProSplitResourceTracker} when British is the active player AND {@link #setBritishEconomySplit}
+   * has been called since the last reset; otherwise the unified {@link ProResourceTracker} matching
+   * current TripleA behavior.
+   */
+  public ProResourceTracker createResourceTracker(final GamePlayer player, final GameState data) {
+    if (britishSplitEconomyActive && "British".equals(player.getName())) {
+      return new ProSplitResourceTracker(
+          britishEuropePus, britishPacificPus, britishPoolByTerritory, data);
+    }
+    return new ProResourceTracker(player);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -833,7 +833,7 @@ class ProPurchaseAi {
           }
 
           // Create new temp units
-          resourceTracker.tempPurchase(selectedOption);
+          resourceTracker.tempPurchase(selectedOption, t);
           if (selectedOption.isConstruction()) {
             remainingConstructions -= selectedOption.getQuantity();
           } else {
@@ -1044,7 +1044,7 @@ class ProPurchaseAi {
       ProLogger.trace("Best AA unit: " + bestAaOption.getUnitType().getName());
 
       // Create new temp units
-      resourceTracker.purchase(bestAaOption);
+      resourceTracker.purchase(bestAaOption, t);
       addUnitsToPlace(placeTerritory, bestAaOption.createTempUnits());
     }
   }
@@ -1208,7 +1208,7 @@ class ProPurchaseAi {
         final ProPurchaseOption selectedOption = optionalSelectedOption.get();
 
         // Create new temp units
-        resourceTracker.purchase(selectedOption);
+        resourceTracker.purchase(selectedOption, t);
         remainingUnitProduction -= selectedOption.getQuantity();
         unitsToPlace.addAll(selectedOption.createTempUnits());
         attackAndDefenseDifference += (selectedOption.getAttack() - selectedOption.getDefense());
@@ -1392,7 +1392,7 @@ class ProPurchaseAi {
       final List<ProPurchaseOption> purchaseOptionsForTerritory =
           ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
               proData, player, purchaseOptions.getFactoryOptions(), maxTerritory, isBid);
-      resourceTracker.removeTempPurchase(maxPlacedOption);
+      resourceTracker.removeTempPurchase(maxPlacedOption, maxTerritory);
       ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
           proData,
           player,
@@ -1426,11 +1426,11 @@ class ProPurchaseAi {
           if (ppt.getTerritory().equals(maxTerritory)) {
             final List<Unit> factory = bestFactoryOption.createTempUnits();
             addUnitsToPlace(ppt, factory);
-            if (resourceTracker.hasEnough(bestFactoryOption)) {
-              resourceTracker.purchase(bestFactoryOption);
+            if (resourceTracker.hasEnough(bestFactoryOption, maxTerritory)) {
+              resourceTracker.purchase(bestFactoryOption, maxTerritory);
               ProLogger.debug(maxTerritory + ", placedFactory=" + factory);
             } else {
-              resourceTracker.purchase(bestFactoryOption);
+              resourceTracker.purchase(bestFactoryOption, maxTerritory);
               resourceTracker.removePurchase(maxPlacedOption);
               if (maxPlacedTerritory != null) {
                 maxPlacedTerritory.getPlaceUnits().remove(maxPlacedUnit);
@@ -1660,7 +1660,7 @@ class ProPurchaseAi {
             }
 
             // Create new temp defenders
-            resourceTracker.tempPurchase(selectedOption);
+            resourceTracker.tempPurchase(selectedOption, t);
             remainingUnitProduction -= selectedOption.getQuantity();
             unitsToPlace.addAll(selectedOption.createTempUnits());
             if (selectedOption.isCarrier() || selectedOption.isAir()) {
@@ -1872,7 +1872,7 @@ class ProPurchaseAi {
           }
 
           // Create new temp units
-          resourceTracker.purchase(selectedOption);
+          resourceTracker.purchase(selectedOption, t);
           remainingUnitProduction -= selectedOption.getQuantity();
           unitsToPlace.addAll(selectedOption.createTempUnits());
           if (selectedOption.isCarrier() || selectedOption.isAir()) {
@@ -2036,7 +2036,7 @@ class ProPurchaseAi {
 
               // Add amphib unit
               amphibUnitsToPlace.addAll(ppo.createTempUnits());
-              resourceTracker.purchase(ppo);
+              resourceTracker.purchase(ppo, landTerritory);
               remainingUnitProduction -= ppo.getQuantity();
               transportCapacity -= ppo.getTransportCost();
               ProLogger.trace("Selected unit=" + ppo.getUnitType().getName());
@@ -2069,7 +2069,7 @@ class ProPurchaseAi {
             // Add transports
             final List<Unit> transports = ppo.createTempUnits();
             transportUnitsToPlace.addAll(transports);
-            resourceTracker.purchase(ppo);
+            resourceTracker.purchase(ppo, t);
             remainingUnitProduction -= ppo.getQuantity();
             transportsThatNeedUnits.addAll(transports);
             ProLogger.trace(
@@ -2191,7 +2191,7 @@ class ProPurchaseAi {
         }
 
         // Purchase unit
-        resourceTracker.purchase(bestAttackOption);
+        resourceTracker.purchase(bestAttackOption, t);
         remainingUnitProduction -= bestAttackOption.getQuantity();
         addUnitsToPlace(placeTerritory, bestAttackOption.createTempUnits());
       }
@@ -2250,7 +2250,7 @@ class ProPurchaseAi {
         final ProPurchaseOption selectedOption = optionalSelectedOption.get();
 
         // Purchase unit
-        resourceTracker.purchase(selectedOption);
+        resourceTracker.purchase(selectedOption, t);
         remainingUnitProduction -= selectedOption.getQuantity();
         addUnitsToPlace(placeTerritory, selectedOption.createTempUnits());
       }
@@ -2317,7 +2317,7 @@ class ProPurchaseAi {
         }
 
         // Remove options that cost too much PUs or production
-        resourceTracker.removeTempPurchase(minPurchaseOption);
+        resourceTracker.removeTempPurchase(minPurchaseOption, t);
         ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
             proData,
             player,
@@ -2390,8 +2390,8 @@ class ProPurchaseAi {
         placeTerritory.getPlaceUnits().removeAll(unitsToRemove);
         ProLogger.trace(t + ", removedUnits=" + unitsToRemove);
         for (int i = 0; i < unitsToRemove.size(); i++) {
-          if (resourceTracker.hasEnough(bestUpgradeOption)) {
-            resourceTracker.purchase(bestUpgradeOption);
+          if (resourceTracker.hasEnough(bestUpgradeOption, t)) {
+            resourceTracker.purchase(bestUpgradeOption, t);
             addUnitsToPlace(placeTerritory, bestUpgradeOption.createTempUnits());
           }
         }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -56,6 +56,7 @@ import org.triplea.java.collections.IntegerMap;
 /** Pro purchase AI. */
 class ProPurchaseAi {
 
+  private final AbstractProAi ai;
   private final ProOddsCalculator calc;
   private final ProData proData;
   private GameData data;
@@ -66,6 +67,7 @@ class ProPurchaseAi {
   private boolean isBid = false;
 
   ProPurchaseAi(final AbstractProAi ai) {
+    this.ai = ai;
     this.calc = ai.getCalc();
     this.proData = ai.getProData();
   }
@@ -263,7 +265,7 @@ class ProPurchaseAi {
     data = proData.getData();
     this.startOfTurnData = startOfTurnData;
     player = proData.getPlayer();
-    resourceTracker = new ProResourceTracker(player);
+    resourceTracker = ai.createResourceTracker(player, data);
     territoryManager = new ProTerritoryManager(calc, proData);
     isBid = false;
     final ProPurchaseOptionMap purchaseOptions = proData.getPurchaseOptions();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProResourceTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProResourceTracker.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.ai.pro.data;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.Territory;
 import games.strategy.triplea.Constants;
 import org.triplea.java.collections.IntegerMap;
 
@@ -27,6 +28,32 @@ public class ProResourceTracker {
 
   public boolean hasEnough(final IntegerMap<Resource> amount) {
     return getRemaining().greaterThanOrEqualTo(amount);
+  }
+
+  /**
+   * Territory-aware overload. Default implementation ignores the territory and delegates to the
+   * unified {@link #hasEnough(ProPurchaseOption)}. Subclasses that split resources by territory
+   * (see {@code ProSplitResourceTracker}) should override to route the check to the correct pool.
+   */
+  public boolean hasEnough(final ProPurchaseOption ppo, final Territory placeTerr) {
+    return hasEnough(ppo);
+  }
+
+  /** Territory-aware overload; default delegates to {@link #purchase(ProPurchaseOption)}. */
+  public void purchase(final ProPurchaseOption ppo, final Territory placeTerr) {
+    purchase(ppo);
+  }
+
+  /** Territory-aware overload; default delegates to {@link #tempPurchase(ProPurchaseOption)}. */
+  public void tempPurchase(final ProPurchaseOption ppo, final Territory placeTerr) {
+    tempPurchase(ppo);
+  }
+
+  /**
+   * Territory-aware overload; default delegates to {@link #removeTempPurchase(ProPurchaseOption)}.
+   */
+  public void removeTempPurchase(final ProPurchaseOption ppo, final Territory placeTerr) {
+    removeTempPurchase(ppo);
   }
 
   public void purchase(final ProPurchaseOption ppo) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProSplitResourceTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProSplitResourceTracker.java
@@ -1,0 +1,133 @@
+package games.strategy.triplea.ai.pro.data;
+
+import games.strategy.engine.data.GameState;
+import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.Constants;
+import java.util.Map;
+import org.triplea.java.collections.IntegerMap;
+
+/**
+ * Resource tracker for a player whose economy is split across multiple pools, each serving a subset
+ * of the player's territories. Used for British in Axis &amp; Allies Global 1940 — London (Europe)
+ * and Calcutta (Pacific) have independent IPC pools that can only pay for purchases placed in their
+ * own territories.
+ *
+ * <p>Inherits {@link ProResourceTracker}'s no-territory API so callers that don't know about the
+ * split still see sensible behavior: {@code hasEnough(ppo)} returns true if EITHER pool has enough,
+ * {@code isEmpty()} false until BOTH pools are depleted. For correctness, every call site that
+ * knows its placement target should call the territory-aware overloads.
+ *
+ * <p>Unmapped territories default to the Europe pool (conservative — London is the primary British
+ * capital and keeps behavior sensible if an unexpected territory is encountered).
+ */
+public class ProSplitResourceTracker extends ProResourceTracker {
+
+  public enum Pool {
+    EUROPE,
+    PACIFIC
+  }
+
+  private final IntegerMap<Resource> europeResources;
+  private final IntegerMap<Resource> pacificResources;
+  private IntegerMap<Resource> tempEurope = new IntegerMap<>();
+  private IntegerMap<Resource> tempPacific = new IntegerMap<>();
+  private final Map<Territory, Pool> poolByTerritory;
+  private final Resource pusResource;
+
+  public ProSplitResourceTracker(
+      final int europePus,
+      final int pacificPus,
+      final Map<Territory, Pool> poolByTerritory,
+      final GameState data) {
+    super(0, data);
+    this.pusResource = data.getResourceList().getResourceOrThrow(Constants.PUS);
+    this.europeResources = new IntegerMap<>();
+    this.europeResources.add(pusResource, europePus);
+    this.pacificResources = new IntegerMap<>();
+    this.pacificResources.add(pusResource, pacificPus);
+    this.poolByTerritory = poolByTerritory;
+  }
+
+  // --- Territory-aware API (preferred) ---
+
+  @Override
+  public boolean hasEnough(final ProPurchaseOption ppo, final Territory placeTerr) {
+    return poolRemaining(poolFor(placeTerr)).greaterThanOrEqualTo(ppo.getCosts());
+  }
+
+  @Override
+  public void purchase(final ProPurchaseOption ppo, final Territory placeTerr) {
+    poolResources(poolFor(placeTerr)).subtract(ppo.getCosts());
+  }
+
+  @Override
+  public void tempPurchase(final ProPurchaseOption ppo, final Territory placeTerr) {
+    tempFor(poolFor(placeTerr)).add(ppo.getCosts());
+  }
+
+  @Override
+  public void removeTempPurchase(final ProPurchaseOption ppo, final Territory placeTerr) {
+    if (ppo != null) {
+      tempFor(poolFor(placeTerr)).subtract(ppo.getCosts());
+    }
+  }
+
+  // --- No-territory API (inherited; overridden to span both pools) ---
+
+  @Override
+  public boolean hasEnough(final ProPurchaseOption ppo) {
+    return poolRemaining(Pool.EUROPE).greaterThanOrEqualTo(ppo.getCosts())
+        || poolRemaining(Pool.PACIFIC).greaterThanOrEqualTo(ppo.getCosts());
+  }
+
+  @Override
+  public void confirmTempPurchases() {
+    europeResources.subtract(tempEurope);
+    pacificResources.subtract(tempPacific);
+    clearTempPurchases();
+  }
+
+  @Override
+  public void clearTempPurchases() {
+    tempEurope = new IntegerMap<>();
+    tempPacific = new IntegerMap<>();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return poolRemaining(Pool.EUROPE).allValuesEqual(0)
+        && poolRemaining(Pool.PACIFIC).allValuesEqual(0);
+  }
+
+  @Override
+  public int getTempPUs(final GameState data) {
+    return tempEurope.getInt(pusResource) + tempPacific.getInt(pusResource);
+  }
+
+  @Override
+  public String toString() {
+    return "europe=" + poolRemaining(Pool.EUROPE) + " pacific=" + poolRemaining(Pool.PACIFIC);
+  }
+
+  // --- Helpers ---
+
+  private Pool poolFor(final Territory t) {
+    final Pool p = poolByTerritory.get(t);
+    return p == null ? Pool.EUROPE : p;
+  }
+
+  private IntegerMap<Resource> poolResources(final Pool p) {
+    return p == Pool.EUROPE ? europeResources : pacificResources;
+  }
+
+  private IntegerMap<Resource> tempFor(final Pool p) {
+    return p == Pool.EUROPE ? tempEurope : tempPacific;
+  }
+
+  private IntegerMap<Resource> poolRemaining(final Pool p) {
+    final IntegerMap<Resource> out = new IntegerMap<>(poolResources(p));
+    out.subtract(tempFor(p));
+    return out;
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProSplitResourceTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProSplitResourceTracker.java
@@ -81,6 +81,26 @@ public class ProSplitResourceTracker extends ProResourceTracker {
         || poolRemaining(Pool.PACIFIC).greaterThanOrEqualTo(ppo.getCosts());
   }
 
+  /** No-territory purchase: defaults to the Europe pool (unmapped-territory policy). */
+  @Override
+  public void purchase(final ProPurchaseOption ppo) {
+    europeResources.subtract(ppo.getCosts());
+  }
+
+  /** No-territory tempPurchase: defaults to the Europe pool. */
+  @Override
+  public void tempPurchase(final ProPurchaseOption ppo) {
+    tempEurope.add(ppo.getCosts());
+  }
+
+  /** No-territory removeTempPurchase: defaults to the Europe pool. */
+  @Override
+  public void removeTempPurchase(final ProPurchaseOption ppo) {
+    if (ppo != null) {
+      tempEurope.subtract(ppo.getCosts());
+    }
+  }
+
   @Override
   public void confirmTempPurchases() {
     europeResources.subtract(tempEurope);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
@@ -144,7 +144,8 @@ public final class ProPurchaseValidationUtils {
                     purchaseOption,
                     resourceTracker,
                     remainingUnitProduction,
-                    remainingConstructions)
+                    remainingConstructions,
+                    territory)
                 || hasReachedMaxUnitBuiltPerPlayer(
                     purchaseOption, player, data, unitsToPlace, purchaseTerritories)
                 || hasReachedConstructionLimits(
@@ -164,8 +165,9 @@ public final class ProPurchaseValidationUtils {
       final ProPurchaseOption purchaseOption,
       final ProResourceTracker resourceTracker,
       final int remainingUnitProduction,
-      final int remainingConstructions) {
-    return resourceTracker.hasEnough(purchaseOption)
+      final int remainingConstructions,
+      final Territory placeTerr) {
+    return resourceTracker.hasEnough(purchaseOption, placeTerr)
         && purchaseOption.getQuantity()
             <= (purchaseOption.isConstruction() ? remainingConstructions : remainingUnitProduction);
   }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPurchaseAiSplitEconomyTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPurchaseAiSplitEconomyTest.java
@@ -1,0 +1,69 @@
+package games.strategy.triplea.ai.pro;
+
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.player.PlayerBridge;
+import games.strategy.triplea.ai.pro.data.ProSplitResourceTracker;
+import games.strategy.triplea.delegate.PurchaseDelegate;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Integration: ProPurchaseAi running against a British player with the split resource tracker
+ * active must plan a purchase that respects per-pool budgets.
+ *
+ * <p>Uses the Global 1940 test fixture; sets explicit small budgets so the planner is forced into
+ * the per-pool constraint. The assertion is that the full purchase invocation completes without
+ * exception — ProResourceTracker would throw if a pool went negative.
+ */
+public class ProPurchaseAiSplitEconomyTest {
+
+  private ProAi proAi;
+  private GameData gameData;
+  private PurchaseDelegate purchaseDelegate;
+  private GamePlayer british;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    gameData = TestMapGameData.GLOBAL1940.getGameData();
+    british = gameData.getPlayerList().getPlayerId("British");
+    proAi = new ProAi("Test British", "British Test Player");
+    final IDelegateBridge bridge = newDelegateBridge(british);
+    purchaseDelegate = (PurchaseDelegate) gameData.getDelegate("purchase");
+    purchaseDelegate.setDelegateBridgeAndPlayer(bridge);
+    final PlayerBridge playerBridgeMock = Mockito.mock(PlayerBridge.class);
+    proAi.initialize(playerBridgeMock, british);
+    when(playerBridgeMock.getGameData()).thenReturn(gameData);
+  }
+
+  @Test
+  void splitTrackerPurchaseCompletesWithoutOverDraft() {
+    // Budget: Europe 12 PUs, Pacific 6 PUs. Small enough to force per-pool
+    // constraints but non-zero in both so the planner has something to spend
+    // on each side.
+    final Map<Territory, ProSplitResourceTracker.Pool> poolByTerritory = new HashMap<>();
+    final Territory uk = gameData.getMap().getTerritoryOrThrow("United Kingdom");
+    final Territory india = gameData.getMap().getTerritoryOrThrow("India");
+    poolByTerritory.put(uk, ProSplitResourceTracker.Pool.EUROPE);
+    poolByTerritory.put(india, ProSplitResourceTracker.Pool.PACIFIC);
+    proAi.setBritishEconomySplit(12, 6, poolByTerritory);
+
+    // Purchase completes; if the split tracker went negative on either pool,
+    // the underlying IntegerMap operations would misbehave and the purchase
+    // delegate would reject the plan. assertDoesNotThrow is the invariant.
+    assertDoesNotThrow(() -> proAi.purchase(false, 18, purchaseDelegate, gameData, british));
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/data/ProSplitResourceTrackerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/data/ProSplitResourceTrackerTest.java
@@ -1,0 +1,145 @@
+package games.strategy.triplea.ai.pro.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.Constants;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.triplea.java.collections.IntegerMap;
+
+final class ProSplitResourceTrackerTest {
+
+  private GameData data;
+  private Resource pus;
+  private Territory tEurope;
+  private Territory tPacific;
+  private Territory tUnmapped;
+  private Map<Territory, ProSplitResourceTracker.Pool> poolByTerritory;
+
+  @BeforeEach
+  void setUp() {
+    data = TestMapGameData.WW2V3_1941.getGameData();
+    pus = data.getResourceList().getResourceOrThrow(Constants.PUS);
+    tEurope = data.getMap().getTerritoryOrThrow("United Kingdom");
+    tPacific = data.getMap().getTerritoryOrThrow("India");
+    tUnmapped = data.getMap().getTerritoryOrThrow("Germany");
+    poolByTerritory = new HashMap<>();
+    poolByTerritory.put(tEurope, ProSplitResourceTracker.Pool.EUROPE);
+    poolByTerritory.put(tPacific, ProSplitResourceTracker.Pool.PACIFIC);
+  }
+
+  private ProPurchaseOption ppoCost(final int cost) {
+    final IntegerMap<Resource> costs = new IntegerMap<>();
+    costs.add(pus, cost);
+    final ProPurchaseOption ppo = mock(ProPurchaseOption.class);
+    when(ppo.getCosts()).thenReturn(costs);
+    return ppo;
+  }
+
+  @Test
+  void hasEnoughRoutesToEuropePoolForEuropeTerritory() {
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(10, 0, poolByTerritory, data);
+    assertThat(t.hasEnough(ppoCost(5), tEurope)).isTrue();
+    assertThat(t.hasEnough(ppoCost(10), tEurope)).isTrue();
+    assertThat(t.hasEnough(ppoCost(11), tEurope)).isFalse();
+  }
+
+  @Test
+  void hasEnoughRoutesToPacificPoolForPacificTerritory() {
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(0, 10, poolByTerritory, data);
+    assertThat(t.hasEnough(ppoCost(5), tPacific)).isTrue();
+    assertThat(t.hasEnough(ppoCost(10), tPacific)).isTrue();
+    assertThat(t.hasEnough(ppoCost(11), tPacific)).isFalse();
+  }
+
+  @Test
+  void hasEnoughRejectsWhenCorrectPoolIsShort() {
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(4, 4, poolByTerritory, data);
+    assertThat(t.hasEnough(ppoCost(5), tEurope)).isFalse();
+    assertThat(t.hasEnough(ppoCost(5), tPacific)).isFalse();
+  }
+
+  @Test
+  void unmappedTerritoryDefaultsToEurope() {
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(10, 0, poolByTerritory, data);
+    assertThat(t.hasEnough(ppoCost(5), tUnmapped)).isTrue(); // europe has 10
+    final ProSplitResourceTracker t2 = new ProSplitResourceTracker(0, 10, poolByTerritory, data);
+    assertThat(t2.hasEnough(ppoCost(5), tUnmapped)).isFalse(); // europe pool is 0
+  }
+
+  @Test
+  void purchaseDeductsFromCorrectPool() {
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(10, 10, poolByTerritory, data);
+    t.purchase(ppoCost(5), tEurope);
+    assertThat(t.hasEnough(ppoCost(5), tEurope)).isTrue(); // 5 left
+    assertThat(t.hasEnough(ppoCost(6), tEurope)).isFalse();
+    assertThat(t.hasEnough(ppoCost(10), tPacific)).isTrue(); // Pacific untouched
+  }
+
+  @Test
+  void noTerritoryHasEnoughReturnsTrueIfEitherPoolHasEnough() {
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(10, 0, poolByTerritory, data);
+    assertThat(t.hasEnough(ppoCost(5))).isTrue();
+    assertThat(t.hasEnough(ppoCost(10))).isTrue();
+  }
+
+  @Test
+  void noTerritoryHasEnoughReturnsFalseIfBothPoolsShort() {
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(4, 4, poolByTerritory, data);
+    assertThat(t.hasEnough(ppoCost(5))).isFalse();
+  }
+
+  @Test
+  void tempPurchaseConfirmAppliesPerPool() {
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(20, 20, poolByTerritory, data);
+    t.tempPurchase(ppoCost(5), tEurope);
+    t.tempPurchase(ppoCost(10), tPacific);
+    t.confirmTempPurchases();
+    assertThat(t.hasEnough(ppoCost(15), tEurope)).isTrue(); // 15 left
+    assertThat(t.hasEnough(ppoCost(16), tEurope)).isFalse();
+    assertThat(t.hasEnough(ppoCost(10), tPacific)).isTrue(); // 10 left
+    assertThat(t.hasEnough(ppoCost(11), tPacific)).isFalse();
+  }
+
+  @Test
+  void tempPurchaseClearReversesWithoutAffectingPools() {
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(20, 20, poolByTerritory, data);
+    t.tempPurchase(ppoCost(5), tEurope);
+    t.tempPurchase(ppoCost(10), tPacific);
+    t.clearTempPurchases();
+    assertThat(t.hasEnough(ppoCost(20), tEurope)).isTrue();
+    assertThat(t.hasEnough(ppoCost(20), tPacific)).isTrue();
+  }
+
+  @Test
+  void isEmptyOnlyWhenBothPoolsDepleted() {
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(10, 0, poolByTerritory, data);
+    assertThat(t.isEmpty()).isFalse();
+    t.purchase(ppoCost(10), tEurope);
+    assertThat(t.isEmpty()).isTrue();
+  }
+
+  @Test
+  void getTempPUsReturnsCombinedAcrossBothPools() {
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(20, 20, poolByTerritory, data);
+    t.tempPurchase(ppoCost(5), tEurope);
+    t.tempPurchase(ppoCost(10), tPacific);
+    assertThat(t.getTempPUs(data)).isEqualTo(15);
+  }
+
+  @Test
+  void toStringIncludesBothPools() {
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(10, 20, poolByTerritory, data);
+    final String s = t.toString();
+    assertThat(s).contains("europe");
+    assertThat(s).contains("pacific");
+  }
+}


### PR DESCRIPTION
Implements Part T of [docs/superpowers/specs/2026-04-21-british-split-economy-ai-design.md](https://github.com/map-room/map-room/blob/docs/british-split-economy-ai-spec/docs/superpowers/specs/2026-04-21-british-split-economy-ai-design.md).

## Summary

Adds \`ProSplitResourceTracker\`, a subclass of \`ProResourceTracker\` that holds two IPC pools (Europe, Pacific) and routes purchase-affordability checks by territory. \`ProPurchaseAi\` threads the current placement \`Territory\` through every tracker call (14 sites across 7 methods); territory-aware overloads on the base class default to the existing no-territory implementations so non-British ProAi flows are untouched.

\`AbstractProAi\` gains a \`setBritishEconomySplit(europePus, pacificPus, poolByTerritory)\` setter and a \`createResourceTracker(player, data)\` factory. The sidecar's \`PurchaseExecutor\` reads the new wire fields (\`WirePlayer.europePus\` / \`pacificPus\`, \`WireTerritory.economy\`) and primes the setter before invoking purchase planning. No-op when the wire state doesn't carry split info.

Bid phase continues to use the unified tracker (Map Room doesn't use bids).

## Commits

- \`feat(proai): add territory-aware overloads on ProResourceTracker\`
- \`feat(proai): ProSplitResourceTracker routes purchases to per-economy pools\`
- \`feat(proai): createResourceTracker factory + setBritishEconomySplit setter\`
- \`refactor(proai): route main-purchase tracker through AbstractProAi factory\`
- \`refactor(proai): thread placeTerritory through resource-tracker calls\`
- \`test(proai): integration test for ProPurchaseAi + split tracker\`
- \`feat(ai-sidecar): wire British split economy into ProAi before purchase\`

## Test plan

- [x] 12 new tests in \`ProSplitResourceTrackerTest\` (pool routing, temp purchases, isEmpty semantics, unmapped defaults)
- [x] 1 integration test in \`ProPurchaseAiSplitEconomyTest\` — drives \`ProAi.purchase\` against Global 1940 with Europe=12, Pacific=6; asserts completion without over-drafting
- [x] Existing \`games.strategy.triplea.ai.pro.*\` suite passes unchanged
- [x] \`:game-app:ai-sidecar:test\` passes including \`NoncombatMoveExecutorIntegrationTest\`
- [x] Spotless clean
- [ ] 🧑 Manual (after map-room triplea-ref bump): reproduce a British turn in the deployed sidecar; confirm \`ProLogger\` shows split tracker balances (\`europe=XX pacific=YY\`) during purchase planning.