### PR TITLE
ci: publish ai-sidecar Docker image to ghcr.io on push to main

### DIFF
--- a/.github/workflows/publish-ai-sidecar.yml
+++ b/.github/workflows/publish-ai-sidecar.yml
@@ -1,0 +1,29 @@
+name: Publish AI Sidecar Docker Image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/map-room/ai-sidecar:latest
+            ghcr.io/map-room/ai-sidecar:${{ github.sha }}


### PR DESCRIPTION
Adds workflow to publish ghcr.io/map-room/ai-sidecar:latest on push to main.

Closes #50