### PR TITLE
obs: thread matchID into sidecar [AI-TRACE] lines via per-thread context

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
@@ -10,15 +10,52 @@ import java.util.UUID;
 /**
  * Emits single-line structured AI-TRACE log entries for sidecar executor decisions.
  *
- * <p>Format: {@code [AI-TRACE] side=sidecar nation=X phase=Y key=value ...} Arrays use {@code
- * [a,b,c]} notation; unit counts use {@code type×N} notation; territory names containing spaces are
- * double-quoted.
+ * <p>Format: {@code [AI-TRACE] matchID=<id> side=sidecar nation=X phase=Y key=value ...} Arrays use
+ * {@code [a,b,c]} notation; unit counts use {@code type×N} notation; territory names containing
+ * spaces are double-quoted.
+ *
+ * <p>The {@code matchID} tag is sourced from {@link #setMatchId(String)}, which the request
+ * boundary in {@code DecisionHandler} sets before dispatching an executor and clears in a finally
+ * block. The system uses a per-thread context (functionally an MDC slot for {@code
+ * System.Logger}-based code) — every executor call site already runs on the HTTP request thread, so
+ * a {@link ThreadLocal} carries the matchID through the executor stack without having to thread it
+ * through every method signature.
+ *
+ * <p>If no matchID is set when an emit happens (e.g. tests, or a background path that never went
+ * through {@code DecisionHandler}), the line is tagged {@code matchID=unknown} so the Loki query
+ * {@code {matchID=~"unknown|..."} } still surfaces those lines for triage.
  */
 public final class AiTraceLogger {
 
   private static final System.Logger LOG = System.getLogger(AiTraceLogger.class.getName());
+  private static final String UNKNOWN_MATCH_ID = "unknown";
+  private static final ThreadLocal<String> MATCH_ID = new ThreadLocal<>();
 
   private AiTraceLogger() {}
+
+  /**
+   * Bind the matchID for the current thread. Call at the request boundary (e.g. start of {@code
+   * DecisionHandler.handle}). Pair with {@link #clearMatchId()} in a finally block so a thread-pool
+   * worker doesn't leak a stale matchID into the next request.
+   */
+  public static void setMatchId(final String matchId) {
+    MATCH_ID.set(matchId);
+  }
+
+  /** Clear the per-thread matchID. Always call from a finally block. */
+  public static void clearMatchId() {
+    MATCH_ID.remove();
+  }
+
+  /**
+   * Read the per-thread matchID, falling back to {@code "unknown"} when no boundary set one. Public
+   * so request-boundary tests can assert that {@code DecisionHandler} binds and clears the matchID
+   * around executor dispatch.
+   */
+  public static String currentMatchId() {
+    final String v = MATCH_ID.get();
+    return v == null ? UNKNOWN_MATCH_ID : v;
+  }
 
   /**
    * Log a captured move from CombatMoveExecutor or NoncombatMoveExecutor.
@@ -54,7 +91,8 @@ public final class AiTraceLogger {
     final String transportId = resolveTransportId(move, uuidToWireId);
     LOG.log(
         System.Logger.Level.INFO,
-        "[AI-TRACE] side=sidecar nation={0} phase={1} kind={2} from={3} to={4} unitIds=[{5}] types=[{6}] transportId={7}",
+        "[AI-TRACE] matchID={0} side=sidecar nation={1} phase={2} kind={3} from={4} to={5} unitIds=[{6}] types=[{7}] transportId={8}",
+        currentMatchId(),
         nation,
         phase,
         kind,
@@ -69,7 +107,8 @@ public final class AiTraceLogger {
   public static void logPurchaseOrder(final String nation, final String unitType, final int count) {
     LOG.log(
         System.Logger.Level.INFO,
-        "[AI-TRACE] side=sidecar nation={0} phase=purchase units=[{1}×{2}]",
+        "[AI-TRACE] matchID={0} side=sidecar nation={1} phase=purchase units=[{2}×{3}]",
+        currentMatchId(),
         nation,
         unitType,
         count);
@@ -80,7 +119,8 @@ public final class AiTraceLogger {
       final String nation, final String territory, final Collection<String> unitTypes) {
     LOG.log(
         System.Logger.Level.INFO,
-        "[AI-TRACE] side=sidecar nation={0} phase=place territory={1} units=[{2}]",
+        "[AI-TRACE] matchID={0} side=sidecar nation={1} phase=place territory={2} units=[{3}]",
+        currentMatchId(),
         nation,
         maybeQuote(territory),
         stringTypeCounts(unitTypes));
@@ -90,7 +130,8 @@ public final class AiTraceLogger {
   public static void logWarDeclaration(final String nation, final String target) {
     LOG.log(
         System.Logger.Level.INFO,
-        "[AI-TRACE] side=sidecar nation={0} phase=politics target={1}",
+        "[AI-TRACE] matchID={0} side=sidecar nation={1} phase=politics target={2}",
+        currentMatchId(),
         nation,
         target);
   }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import org.triplea.ai.sidecar.AiTraceLogger;
 import org.triplea.ai.sidecar.dto.CombatMovePlan;
 import org.triplea.ai.sidecar.dto.CombatMoveRequest;
 import org.triplea.ai.sidecar.dto.DecisionPlan;
@@ -277,6 +278,12 @@ public final class DecisionHandler implements HttpHandler {
       return;
     }
 
+    // Bind the matchID for this request thread so AiTraceLogger emits include
+    // matchID=<id> on every per-order line. Required for the Loki/Promtail design
+    // (#1968): {matchID="X"} queries must surface every per-order trace for the
+    // match. Clear in finally so a thread-pool worker doesn't leak a stale matchID
+    // into the next request.
+    AiTraceLogger.setMatchId(session.get().key().gameId());
     try {
       switch (request) {
         case SelectCasualtiesRequest sc -> {
@@ -340,6 +347,8 @@ public final class DecisionHandler implements HttpHandler {
     } catch (final RuntimeException e) {
       LOG.log(System.Logger.Level.ERROR, "Decision handler internal error", e);
       writeJson(exchange, 500, JsonBodies.errorBody("internal"));
+    } finally {
+      AiTraceLogger.clearMatchId();
     }
   }
 

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceLoggerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceLoggerTest.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
@@ -77,5 +78,55 @@ class AiTraceLoggerTest {
             new Unit(UUID.randomUUID(), armour, germans, gd));
 
     assertThat(AiTraceLogger.unitTypeCounts(units)).isEqualTo("infantry×2,armour×1");
+  }
+
+  // ---------------------------------------------------------------------------
+  // matchID context (#2004)
+  //
+  // The ThreadLocal-based matchID context backs every per-order [AI-TRACE] line
+  // emitted by sidecar executors. The integration assertion (matchID actually
+  // appears in the log line) is exercised by the executor suites; here we cover
+  // the per-thread isolation, fallback, and clear semantics that DecisionHandler
+  // relies on for safe thread-pool reuse.
+  // ---------------------------------------------------------------------------
+
+  @AfterEach
+  void clearMatchIdContext() {
+    AiTraceLogger.clearMatchId();
+  }
+
+  @Test
+  void currentMatchId_unset_returnsUnknown() {
+    AiTraceLogger.clearMatchId();
+    assertThat(AiTraceLogger.currentMatchId()).isEqualTo("unknown");
+  }
+
+  @Test
+  void setAndClearMatchId_roundTrip() {
+    AiTraceLogger.setMatchId("match-abc-123");
+    assertThat(AiTraceLogger.currentMatchId()).isEqualTo("match-abc-123");
+    AiTraceLogger.clearMatchId();
+    assertThat(AiTraceLogger.currentMatchId()).isEqualTo("unknown");
+  }
+
+  @Test
+  void matchId_isolatedAcrossThreads() throws Exception {
+    AiTraceLogger.setMatchId("main-thread-match");
+
+    final java.util.concurrent.atomic.AtomicReference<String> seenInWorker =
+        new java.util.concurrent.atomic.AtomicReference<>();
+    final Thread worker =
+        new Thread(
+            () -> {
+              // Worker has no inherited matchID — must see "unknown".
+              seenInWorker.set(AiTraceLogger.currentMatchId());
+              AiTraceLogger.setMatchId("worker-thread-match");
+            });
+    worker.start();
+    worker.join();
+
+    assertThat(seenInWorker.get()).isEqualTo("unknown");
+    // Main thread context was never touched by worker's setMatchId — still its own value.
+    assertThat(AiTraceLogger.currentMatchId()).isEqualTo("main-thread-match");
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.AiTraceLogger;
 import org.triplea.ai.sidecar.CanonicalGameData;
 import org.triplea.ai.sidecar.dto.PurchasePlan;
 import org.triplea.ai.sidecar.dto.RetreatPlan;
@@ -286,6 +287,71 @@ class DecisionHandlerTest {
             "POST", "/session/" + s.sessionId() + "/decision", offensiveBody("tech"));
     h.handle(ex);
     assertEquals(400, ex.responseCode());
+  }
+
+  // ---------------------------------------------------------------------
+  // matchID context (#2004) — DecisionHandler must bind the session's gameId
+  // into AiTraceLogger for the duration of the dispatch, then clear it.
+  // ---------------------------------------------------------------------
+
+  @Test
+  void matchIdIsBoundDuringDispatchAndClearedAfter() throws Exception {
+    final SessionRegistry registry = newRegistry();
+    final Session s = newSession(registry); // SessionKey gameId = "g-1"
+    final AtomicReference<String> seenInExecutor = new AtomicReference<>();
+    final DecisionHandler h =
+        handler(
+            registry,
+            (session, req) -> {
+              seenInExecutor.set(AiTraceLogger.currentMatchId());
+              return new SelectCasualtiesPlan(List.of(), List.of());
+            },
+            (session, req) -> {
+              throw new AssertionError();
+            },
+            (session, req) -> {
+              throw new AssertionError();
+            });
+
+    AiTraceLogger.clearMatchId();
+    final FakeHttpExchange ex =
+        new FakeHttpExchange(
+            "POST", "/session/" + s.sessionId() + "/decision", SELECT_CASUALTIES_BODY);
+    h.handle(ex);
+
+    // During dispatch the executor saw the session's matchID.
+    assertEquals("g-1", seenInExecutor.get());
+    // After dispatch the per-thread context is cleared so a thread-pool
+    // worker reused for the next request doesn't leak the previous matchID.
+    assertEquals("unknown", AiTraceLogger.currentMatchId());
+  }
+
+  @Test
+  void matchIdIsClearedEvenWhenExecutorThrows() throws Exception {
+    final SessionRegistry registry = newRegistry();
+    final Session s = newSession(registry);
+    final DecisionHandler h =
+        handler(
+            registry,
+            (session, req) -> {
+              throw new IllegalArgumentException("simulated bad-request");
+            },
+            (session, req) -> {
+              throw new AssertionError();
+            },
+            (session, req) -> {
+              throw new AssertionError();
+            });
+
+    AiTraceLogger.clearMatchId();
+    final FakeHttpExchange ex =
+        new FakeHttpExchange(
+            "POST", "/session/" + s.sessionId() + "/decision", SELECT_CASUALTIES_BODY);
+    h.handle(ex);
+
+    assertEquals(400, ex.responseCode());
+    // finally block must clear the matchID even when the executor throws.
+    assertEquals("unknown", AiTraceLogger.currentMatchId());
   }
 
   @Test


### PR DESCRIPTION
Refs map-room#2004 — Java/sidecar half of the matchID-tagging prereq for the Loki/Promtail design (map-room#1968). The TS half lands in [map-room#2006](https://github.com/map-room/map-room/pull/2006).

## Summary

`{matchID=\"X\"}` Loki queries can only return per-match log lines if every line carries `matchID=`. Today the sidecar's `AiTraceLogger` emits per-order traces without it; this PR adds the tag.

## Approach

A static `ThreadLocal<String>` in `AiTraceLogger` acts as an MDC slot for `System.Logger`-based code (the sidecar uses JDK's `System.Logger`, not SLF4J directly — so we don't get MDC for free). `DecisionHandler` binds the session's `gameId` into the slot at the start of dispatch and clears it in a `finally` block — so a thread-pool worker reused for the next request never leaks a stale matchID.

### Why `ThreadLocal` works for `System.Logger`-based code

Every `AiTraceLogger.*` call site is reached from an `executor.execute()` invoked from `DecisionHandler.handle()` on the HTTP request thread. The per-session `offensiveExecutor.submit(...)` call inside the executors runs ProAi planning on a worker thread, but the resulting `AiTraceLogger.*` calls happen **after** `future.get()` returns — back on the request thread. Verified by grep:

- `CombatMoveExecutor.java:106 .submit(...)` → log calls at `135, 145` (after `future.get()`)
- `NoncombatMoveExecutor.java:102 .submit(...)` → log call at `135` (after)
- `PoliticsExecutor.java:93 .submit(...)` → log call at `125` (after)
- `PurchaseExecutor.java:138 .submit(...)` → log call at `181` (after)
- `PlaceExecutor.java:109 .submit(...)` → log call at `148` (after)

So a single `ThreadLocal` set in `DecisionHandler` reaches every emit. Adding SLF4J just for MDC would be unnecessary churn.

## Format change

Prepended `matchID={0}` to every `System.Logger.log(...)` template and shifted the existing positional placeholders by one. Lines now look like:

```
[AI-TRACE] matchID=<id> side=sidecar nation=Germans phase=combat-move kind=move from=Germany to=Poland unitIds=[u1,u2] types=[infantry×2] transportId=null
[AI-TRACE] matchID=<id> side=sidecar nation=Germans phase=purchase units=[infantry×3]
[AI-TRACE] matchID=<id> side=sidecar nation=Germans phase=place territory=Germany units=[infantry×3]
[AI-TRACE] matchID=<id> side=sidecar nation=Germans phase=politics target=British
```

When no matchID is set (tests, non-DecisionHandler paths), the line is tagged `matchID=unknown` so a Loki query like `{matchID=~\"unknown|.+\"}` still surfaces it for triage.

## Grep evidence

```
$ grep -n '\[AI-TRACE\]' game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
13: * <p>Format: {@code [AI-TRACE] matchID=<id> side=sidecar nation=X phase=Y key=value ...} Arrays
93:        \"[AI-TRACE] matchID={0} side=sidecar nation={1} phase={2} kind={3} from={4} to={5} unitIds=[{6}] types=[{7}] transportId={8}\",
109:       \"[AI-TRACE] matchID={0} side=sidecar nation={1} phase=purchase units=[{2}×{3}]\",
121:       \"[AI-TRACE] matchID={0} side=sidecar nation={1} phase=place territory={2} units=[{3}]\",
132:       \"[AI-TRACE] matchID={0} side=sidecar nation={1} phase=politics target={2}\",
```

Every emit template carries matchID. ✓

## Test plan

- [x] `AiTraceLoggerTest`: per-thread isolation (worker thread does not inherit main thread's matchID); `set`/`clear` round-trip; fallback to `\"unknown\"` when unset.
- [x] `DecisionHandlerTest`: matchID is bound to the session's `gameId` during dispatch and observable from inside the executor stub; cleared after dispatch **even when the executor throws** (verifies the `finally` block).
- [ ] 🧑 Manual: CI runs `./gradlew :game-app:ai-sidecar:test` (no JDK installed in my dev env to run locally — verified by reading code + targeted unit tests above).
- [ ] 🧑 Manual: end-to-end against a live sidecar — `docker compose logs ai-sidecar | grep '\[AI-TRACE\]' | head` shows `matchID=<id>` on every line, and the matchID matches the bot-worker `dir=dispatch` line for the same move.

## Coordination

The TS PR ([map-room#2006](https://github.com/map-room/map-room/pull/2006)) and this one are independent (different repos, different services) and can be reviewed/merged in either order. Once both land, Loki/Promtail (#1968) can be designed/built on top.