### PR TITLE
feat(sidecar): SessionReaper + 404 lifecycle logs (#2046)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
@@ -254,6 +254,10 @@ public final class DecisionHandler implements HttpHandler {
     }
     final Optional<Session> session = registry.get(match.get().sessionId());
     if (session.isEmpty()) {
+      LOG.log(
+          System.Logger.Level.WARNING,
+          "[sidecar] session not found matchID={0} endpoint=decision",
+          match.get().sessionId());
       writeJson(exchange, 404, JsonBodies.errorBody("unknown-session"));
       return;
     }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/SessionLifecycleHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/SessionLifecycleHandler.java
@@ -11,6 +11,10 @@ import org.triplea.ai.sidecar.session.SessionRegistry;
 import org.triplea.ai.sidecar.wire.SessionUpdateRequest;
 
 public final class SessionLifecycleHandler implements HttpHandler {
+
+  private static final System.Logger LOG =
+      System.getLogger(SessionLifecycleHandler.class.getName());
+
   private final SessionRegistry registry;
 
   public SessionLifecycleHandler(final SessionRegistry registry) {
@@ -43,6 +47,10 @@ public final class SessionLifecycleHandler implements HttpHandler {
   private void handleDelete(final HttpExchange exchange, final String sessionId)
       throws IOException {
     if (!registry.delete(sessionId)) {
+      LOG.log(
+          System.Logger.Level.WARNING,
+          "[sidecar] session not found matchID={0} endpoint=delete",
+          sessionId);
       writeJson(exchange, 404, JsonBodies.errorBody("not-found", "unknown session"));
       return;
     }
@@ -54,6 +62,10 @@ public final class SessionLifecycleHandler implements HttpHandler {
       throws IOException {
     final Optional<Session> session = registry.get(sessionId);
     if (session.isEmpty()) {
+      LOG.log(
+          System.Logger.Level.WARNING,
+          "[sidecar] session not found matchID={0} endpoint=update",
+          sessionId);
       writeJson(exchange, 404, JsonBodies.errorBody("not-found", "unknown session"));
       return;
     }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionReaper.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionReaper.java
@@ -73,6 +73,12 @@ public final class SessionReaper {
     }
 
     for (final SessionKey key : toDelete) {
+      final long idleSec =
+          registry.getUpdatedAt(key).map(updatedAt -> (now - updatedAt) / 1000).orElse(-1L);
+      LOG.log(
+          System.Logger.Level.INFO,
+          "[sidecar] session reaped matchID={0} idleSeconds={1} caller=reaper",
+          new Object[] {key.gameId(), idleSec});
       registry.deleteByKey(key);
     }
 

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionRegistry.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionRegistry.java
@@ -113,6 +113,10 @@ public final class SessionRegistry {
     return Optional.ofNullable(byId.get(sessionId));
   }
 
+  public Optional<Long> getUpdatedAt(final SessionKey key) {
+    return Optional.ofNullable(updatedAtMap.get(key));
+  }
+
   public synchronized boolean delete(final String sessionId) {
     final Session removed = byId.remove(sessionId);
     if (removed == null) {


### PR DESCRIPTION
Closes map-room/map-room#2046

## Context

Foxtrot's investigation #2043 had to read code to refute the H3 reaper hypothesis. This PR adds structured log lines so future investigations can grep logs instead.

## Changes

**SessionReaper** — one `INFO` log per reaped session:
```
[sidecar] session reaped matchID=<gameId> idleSeconds=<N> caller=reaper
```
Requires `SessionRegistry.getUpdatedAt(key)` (also added) so the reaper can compute actual idle time rather than approximating from the threshold.

**SessionLifecycleHandler** (update + delete endpoints) and **DecisionHandler** (decision endpoint) — one `WARN` log when a session lookup returns nothing:
```
[sidecar] session not found matchID=<sessionId> endpoint=<update|delete|decision>
```
All log lines include `matchID=` for grep correlation across endpoints and reaper cycles.

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:check` — BUILD SUCCESSFUL, all 56 tasks pass
- [x] Existing `SessionReaperTest` covers the reap path; existing `SessionLifecycleHandlerTest` covers the 404 paths — both pass with new log lines in place