### PR TITLE
fix(sidecar): tolerate unknown fields in SessionManifest (closes map-room/map-room#2050)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionManifest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionManifest.java
@@ -1,6 +1,7 @@
 package org.triplea.ai.sidecar.session;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -8,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * data/sessions/{gameId}/{nation}.json} on creation and update. Re-read on startup to rehydrate the
  * in-memory session registry.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class SessionManifest {
   private final String sessionId;
   private final String gameId;

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionStore.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionStore.java
@@ -89,11 +89,15 @@ public final class SessionStore {
       return result;
     }
     try {
-      // Only read files at exactly depth 2 (dataDir/{gameId}/{nation}.json).
-      // The snapshots/ subdirectory (written by ProSessionSnapshotStore) is at depth 1
-      // and its files are a different schema — skip them by constraining the walk depth.
+      // Read files at exactly depth 2: dataDir/{gameId}/{nation}.json.
+      // Exclude the snapshots/ subtree — its files land at the same depth but use a different
+      // schema (ProSessionSnapshot). Previously Jackson's UnrecognizedPropertyException filtered
+      // them implicitly; we now exclude them explicitly so @JsonIgnoreProperties on SessionManifest
+      // cannot cause snapshot files to be silently parsed as manifests with null fields.
+      final Path snapshotsDir = dataDir.resolve("snapshots");
       Files.walk(dataDir, 2)
           .filter(p -> p.getNameCount() == dataDir.getNameCount() + 2)
+          .filter(p -> !p.startsWith(snapshotsDir))
           .filter(p -> p.toString().endsWith(".json") && !p.toString().endsWith(".tmp"))
           .forEach(
               p -> {

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionManifestTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/SessionManifestTest.java
@@ -1,0 +1,40 @@
+package org.triplea.ai.sidecar.session;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class SessionManifestTest {
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void toleratesUnknownFieldsOnDeserialization() throws Exception {
+    // JSON written by an older sidecar version that included combatMoveMap and other fields
+    // not present in the current SessionManifest schema.
+    String json =
+        """
+        {
+          "sessionId": "sess-1",
+          "gameId":    "game-abc",
+          "nation":    "Germans",
+          "seed":      42,
+          "createdAt": 1000,
+          "updatedAt": 2000,
+          "combatMoveMap": {"Germany": ["tank", "infantry"]},
+          "legacyField": "ignored"
+        }
+        """;
+
+    SessionManifest manifest =
+        assertDoesNotThrow(() -> mapper.readValue(json, SessionManifest.class));
+
+    assertEquals("sess-1", manifest.sessionId());
+    assertEquals("game-abc", manifest.gameId());
+    assertEquals("Germans", manifest.nation());
+    assertEquals(42L, manifest.seed());
+    assertEquals(1000L, manifest.createdAt());
+    assertEquals(2000L, manifest.updatedAt());
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a 4th bot-stall mechanism surfaced in map-room/map-room#2043 (not caught by foxtrot's code-only investigation because it only manifests on live sidecar restart with stale on-disk manifests).

**Root cause:** The sidecar's `SessionManifest` didn't have `@JsonIgnoreProperties(ignoreUnknown = true)`. A manifest written by an older schema version (which included `combatMoveMap`) causes Jackson to throw `UnrecognizedPropertyException` on restart. `SessionStore.loadAll()` catches and logs the exception, skipping the file — meaning that bot's session is silently lost. When the player resumes, there's no `ProAi` session for the match → bot can't plan → stalls (Mode A recovery eventually kicks in at 120s, now 5s after map-room/map-room#2044).

## Changes

**`SessionManifest.java`** — add `@JsonIgnoreProperties(ignoreUnknown = true)`. Jackson now silently skips unknown fields. The 6 known fields are preserved correctly; stale fields like `combatMoveMap` are ignored.

**`SessionStore.java`** — fix a latent bug exposed by the annotation. Snapshot files at `data/sessions/snapshots/{file}.json` are depth 2 from `dataDir` — the same depth as manifest files. Previously Jackson's `UnrecognizedPropertyException` filtered them implicitly (they have a completely different schema). With `@JsonIgnoreProperties`, snapshot files would silently parse as manifests with all-null fields, causing a NPE in `SessionRegistry.rehydrate()` on `byId.containsKey(m.sessionId())`. Fixed by explicitly excluding the `snapshots/` subtree in `loadAll()`.

**`SessionManifestTest.java`** — new unit test: feeds a JSON blob with extra fields beyond the 6 known (including `combatMoveMap`) to `ObjectMapper.readValue`; verifies no exception is thrown and all 6 known fields are populated correctly.

## Test plan

- [x] `SessionManifestTest.toleratesUnknownFieldsOnDeserialization()` passes — parses JSON with extra `combatMoveMap` + `legacyField` without throwing, all 6 known fields correct.
- [x] `Phase2DefensiveDecisionsIntegrationTest` passes — the SessionStore snapshot-exclusion fix prevents the NPE that occurred when snapshot files at depth 2 were silently parsed as manifests with null sessionId.
- [x] Full `./gradlew :game-app:ai-sidecar:test` green (5m run).
- [x] `spotlessCheck` clean.
- [x] Checkstyle warnings are all pre-existing (not in changed files).
- [ ] 🧑 Manual: restart a live sidecar with stale on-disk manifests (containing `combatMoveMap`) and confirm no `UnrecognizedPropertyException` warning and the session is loaded.

## References

- map-room/map-room#2050 — issue this fixes
- map-room/map-room#2043 — bot-stall research (surfaced session-loss as stall mechanism)
- map-room/map-room#2044 — graceful lease release (Mode A recovery 120s→5s); this PR closes the session-loss gap that made recovery necessary
- bravo's map-room/map-room#1994 — same shape problem (TS snapshot schema drift), different layer