### PR TITLE
obs(ai-sidecar): structured casualty-decision rationale logs (#2101)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
@@ -3,8 +3,10 @@ package org.triplea.ai.sidecar;
 import games.strategy.engine.data.MoveDescription;
 import games.strategy.engine.data.Unit;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -136,7 +138,73 @@ public final class AiTraceLogger {
         target);
   }
 
+  /**
+   * Log the rationale for a casualty-selection decision (#2101).
+   *
+   * <p>Triagers chasing AI-stuck bugs (the #2057 / #2065 / #2066 class) need to see what the AI was
+   * choosing between, what it picked, and whether it diverged from the client-supplied default.
+   * ProAi's deeper reasoning (TUL ratio, cost math) lives inside {@code
+   * AbstractProAi.selectCasualties} and would require its own instrumentation to surface — out of
+   * scope for v1. The {@code reason} captured here is a coarse summary: {@code default-applied}
+   * when ProAi accepted the client's default casualty set verbatim, otherwise {@code
+   * overridden-from-default}. With {@code consideredIds} / {@code pickedIds} / {@code defaultIds}
+   * the triager can manually reconstruct what changed.
+   *
+   * @param uuidToWireId reverse map (Java UUID → Map Room wire ID) for projecting Unit references
+   *     back onto the wire identity space the bug-reporter sees.
+   */
+  public static void logCasualtyDecision(
+      final String nation,
+      final String battleId,
+      final String territory,
+      final int hitCount,
+      final Collection<Unit> considered,
+      final Collection<Unit> defaultCasualties,
+      final Collection<Unit> picked,
+      final Map<UUID, String> uuidToWireId) {
+    LOG.log(
+        System.Logger.Level.INFO,
+        "[AI-TRACE] matchID={0} side=sidecar nation={1} phase=battle kind=select-casualties"
+            + " battleId={2} territory={3} hitCount={4}"
+            + " consideredIds=[{5}] consideredTypes=[{6}]"
+            + " pickedIds=[{7}] pickedTypes=[{8}]"
+            + " defaultIds=[{9}] reason={10}",
+        currentMatchId(),
+        nation,
+        battleId,
+        maybeQuote(territory),
+        hitCount,
+        unitWireIds(considered, uuidToWireId),
+        unitTypeCounts(considered),
+        unitWireIds(picked, uuidToWireId),
+        unitTypeCounts(picked),
+        unitWireIds(defaultCasualties, uuidToWireId),
+        casualtyReason(picked, defaultCasualties));
+  }
+
   // --- package-private for tests ---
+
+  /**
+   * Coarse rationale tag for {@link #logCasualtyDecision}: {@code default-applied} when the AI's
+   * pick is the same UUID set the client proposed as the default, else {@code
+   * overridden-from-default}. Set comparison (not list comparison) — ProAi may reorder.
+   */
+  static String casualtyReason(
+      final Collection<Unit> picked, final Collection<Unit> defaultCasualties) {
+    if (picked.size() != defaultCasualties.size()) {
+      return "overridden-from-default";
+    }
+    final Set<UUID> defaultIds = new HashSet<>(defaultCasualties.size());
+    for (final Unit u : defaultCasualties) {
+      defaultIds.add(u.getId());
+    }
+    for (final Unit u : picked) {
+      if (!defaultIds.contains(u.getId())) {
+        return "overridden-from-default";
+      }
+    }
+    return "default-applied";
+  }
 
   /**
    * Build a comma-separated list of Map Room wire IDs for each unit in the given collection, in

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/SelectCasualtiesExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/SelectCasualtiesExecutor.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
+import org.triplea.ai.sidecar.AiTraceLogger;
 import org.triplea.ai.sidecar.dto.SelectCasualtiesPlan;
 import org.triplea.ai.sidecar.dto.SelectCasualtiesRequest;
 import org.triplea.ai.sidecar.session.Session;
@@ -127,6 +128,20 @@ public final class SelectCasualtiesExecutor
     }
 
     final Map<UUID, String> reverseIdMap = reverseIdMap(idMap);
+
+    // Decision-rationale trace (#2101). Emitted before wire-id projection so it captures the
+    // raw ProAi outputs alongside the inputs the AI considered. Cheap (one log line per call)
+    // and bounded — there's exactly one casualty decision per assignCasualties dispatch.
+    AiTraceLogger.logCasualtyDecision(
+        defender.getName(),
+        b.battleId(),
+        b.territory(),
+        b.hitCount(),
+        selectFrom,
+        defaultCasualties.getKilled(),
+        details.getKilled(),
+        reverseIdMap);
+
     final List<String> killedIds = new ArrayList<>(details.getKilled().size());
     for (final Unit u : details.getKilled()) {
       killedIds.add(mapRoomIdOf(u, reverseIdMap));

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceLoggerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceLoggerTest.java
@@ -10,6 +10,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -128,5 +133,138 @@ class AiTraceLoggerTest {
     assertThat(seenInWorker.get()).isEqualTo("unknown");
     // Main thread context was never touched by worker's setMatchId — still its own value.
     assertThat(AiTraceLogger.currentMatchId()).isEqualTo("main-thread-match");
+  }
+
+  // ---------------------------------------------------------------------------
+  // casualty-decision rationale (#2101)
+  //
+  // logCasualtyDecision is the v1 lever for AI-stuck triage. Tests cover:
+  //   - the coarse reason-tag computation (default-applied vs overridden)
+  //   - the full emitted line shape, captured via a JUL handler attached to
+  //     the underlying AiTraceLogger logger (System.Logger delegates to JUL).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void casualtyReason_pickedEqualsDefault_returnsDefaultApplied() {
+    final var gd = canonical.cloneForSession();
+    final UnitType infantry = gd.getUnitTypeList().getUnitType("infantry").orElseThrow();
+    final var germans = gd.getPlayerList().getPlayerId("Germans");
+    final Unit u1 = new Unit(UUID.randomUUID(), infantry, germans, gd);
+    final Unit u2 = new Unit(UUID.randomUUID(), infantry, germans, gd);
+
+    // Same set, same order.
+    assertThat(AiTraceLogger.casualtyReason(List.of(u1, u2), List.of(u1, u2)))
+        .isEqualTo("default-applied");
+    // Same set, reordered (ProAi may reorder; we compare by UUID set).
+    assertThat(AiTraceLogger.casualtyReason(List.of(u2, u1), List.of(u1, u2)))
+        .isEqualTo("default-applied");
+  }
+
+  @Test
+  void casualtyReason_pickedDiffersFromDefault_returnsOverridden() {
+    final var gd = canonical.cloneForSession();
+    final UnitType infantry = gd.getUnitTypeList().getUnitType("infantry").orElseThrow();
+    final UnitType armour = gd.getUnitTypeList().getUnitType("armour").orElseThrow();
+    final var germans = gd.getPlayerList().getPlayerId("Germans");
+    final Unit inf = new Unit(UUID.randomUUID(), infantry, germans, gd);
+    final Unit tank = new Unit(UUID.randomUUID(), armour, germans, gd);
+
+    // Different unit picked.
+    assertThat(AiTraceLogger.casualtyReason(List.of(tank), List.of(inf)))
+        .isEqualTo("overridden-from-default");
+    // Different size.
+    assertThat(AiTraceLogger.casualtyReason(List.of(inf, tank), List.of(inf)))
+        .isEqualTo("overridden-from-default");
+  }
+
+  @Test
+  void logCasualtyDecision_emitsLineWithExpectedKeysAndMatchId() {
+    final var gd = canonical.cloneForSession();
+    final UnitType infantry = gd.getUnitTypeList().getUnitType("infantry").orElseThrow();
+    final UnitType armour = gd.getUnitTypeList().getUnitType("armour").orElseThrow();
+    final var germans = gd.getPlayerList().getPlayerId("Germans");
+    final Unit inf1 = new Unit(UUID.randomUUID(), infantry, germans, gd);
+    final Unit inf2 = new Unit(UUID.randomUUID(), infantry, germans, gd);
+    final Unit tank = new Unit(UUID.randomUUID(), armour, germans, gd);
+    final Map<UUID, String> uuidToWireId = new HashMap<>();
+    uuidToWireId.put(inf1.getId(), "u-inf-1");
+    uuidToWireId.put(inf2.getId(), "u-inf-2");
+    uuidToWireId.put(tank.getId(), "u-tank-1");
+
+    AiTraceLogger.setMatchId("match-cas-001");
+    final CapturingHandler capture = attachHandler();
+    try {
+      AiTraceLogger.logCasualtyDecision(
+          /* nation */ "Germans",
+          /* battleId */ "b-france-1",
+          /* territory */ "Western Europe",
+          /* hitCount */ 2,
+          /* considered */ List.of(inf1, inf2, tank),
+          /* defaultCasualties */ List.of(inf1, inf2),
+          /* picked */ List.of(inf1, tank),
+          uuidToWireId);
+    } finally {
+      detachHandler(capture);
+    }
+
+    assertThat(capture.formatted())
+        .anySatisfy(
+            line ->
+                assertThat(line)
+                    .startsWith("[AI-TRACE] matchID=match-cas-001 side=sidecar nation=Germans")
+                    .contains("phase=battle kind=select-casualties")
+                    .contains("battleId=b-france-1")
+                    .contains("territory=\"Western Europe\"")
+                    .contains("hitCount=2")
+                    .contains("consideredIds=[u-inf-1,u-inf-2,u-tank-1]")
+                    .contains("consideredTypes=[infantry×2,armour×1]")
+                    .contains("pickedIds=[u-inf-1,u-tank-1]")
+                    .contains("pickedTypes=[infantry×1,armour×1]")
+                    .contains("defaultIds=[u-inf-1,u-inf-2]")
+                    .contains("reason=overridden-from-default"));
+  }
+
+  private static CapturingHandler attachHandler() {
+    final Logger jul = Logger.getLogger(AiTraceLogger.class.getName());
+    final CapturingHandler h = new CapturingHandler();
+    h.setLevel(Level.ALL);
+    jul.setLevel(Level.ALL);
+    jul.addHandler(h);
+    jul.setUseParentHandlers(false);
+    return h;
+  }
+
+  private static void detachHandler(final CapturingHandler h) {
+    Logger.getLogger(AiTraceLogger.class.getName()).removeHandler(h);
+  }
+
+  /**
+   * JUL handler that captures every {@link LogRecord} so tests can assert on the formatted message.
+   * System.Logger delegates to JUL by default in JDK, so attaching here intercepts {@code LOG.log}
+   * calls in {@link AiTraceLogger}.
+   */
+  private static final class CapturingHandler extends Handler {
+    private final List<LogRecord> records = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void publish(final LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() throws SecurityException {}
+
+    List<String> formatted() {
+      return records.stream()
+          .map(
+              r ->
+                  r.getParameters() == null
+                      ? r.getMessage()
+                      : java.text.MessageFormat.format(r.getMessage(), r.getParameters()))
+          .toList();
+    }
   }
 }


### PR DESCRIPTION
Refs map-room/map-room#2101 — first scope (casualty-decision). Follow-up issues filed for the other branches called out in #2101: retreat-decision (map-room/map-room#2103), scramble-selection (map-room/map-room#2104), SBR interceptor-selection (map-room/map-room#2105).

## Why

For AI-stuck bugs in the #2057 / #2065 / #2066 class, the existing INFO-level [AI-TRACE] lines show that the AI reached \`assignCasualties\` but not *why* it picked the units it picked. Triagers chasing one of those reports today have a Grafana matchID + window scoped link from #2026, but the lines for the relevant 30-120s window can only confirm the AI dispatched a casualty selection — they have no signal on whether the AI picked the same casualties the client proposed by default, picked something different, or what alternatives were on the table.

#2101 §1 lists casualty-selection first; #2057/#2065/#2066 already mapped the surface; that's the first scope here.

## What this PR adds

\`SelectCasualtiesExecutor.execute\` emits one structured rationale line per call, after \`ProAi.selectCasualties\` returns:

\`\`\`
[AI-TRACE] matchID=X side=sidecar nation=Germans phase=battle kind=select-casualties battleId=Y territory=\"Western Europe\" hitCount=2 consideredIds=[u1,u2,u3] consideredTypes=[infantry×2,armour×1] pickedIds=[u1,u3] pickedTypes=[infantry×1,armour×1] defaultIds=[u1,u2] reason=overridden-from-default
\`\`\`

Format follows the existing structural key=value pattern from #1844 / #1845 — same redaction safety story applies. matchID is read from the per-thread context PR #56 already established; no new threading work needed.

### Reason tag (intentionally coarse at v1)

- \`default-applied\` when ProAi accepted the client-supplied default casualty set verbatim (UUID set comparison; ProAi may reorder).
- \`overridden-from-default\` when the AI's pick differs in any unit.

That's the minimum viable signal. Deeper rationale — TUL ratio, cost math, attacker-vs-defender posture — lives inside \`AbstractProAi.selectCasualties\` itself and would require its own instrumentation pass to expose. Out of scope for v1; the considered / picked / default lists give the triager enough to see *what* changed and reason about *why* manually.

## Test plan

- [x] \`./gradlew :game-app:ai-sidecar:test\` — full suite green
- [x] Three new \`AiTraceLoggerTest\` cases:
  - \`casualtyReason_pickedEqualsDefault_returnsDefaultApplied\` — matching pick + reordered match
  - \`casualtyReason_pickedDiffersFromDefault_returnsOverridden\` — different unit + different size
  - \`logCasualtyDecision_emitsLineWithExpectedKeysAndMatchId\` — JUL-handler capture verifying the full line shape (every key, types, matchID prefix). Test installs a JUL Handler on the underlying logger since System.Logger delegates to JUL by default in JDK.
- [x] \`spotlessCheck\` + \`checkstyleMain\` + \`checkstyleTest\` clean (the 4 checkstyle warnings reported are all in pre-existing test files unrelated to this PR)
- [x] Existing \`SelectCasualtiesExecutorTest\` (4 cases including the multi-hit battleship and default-size-mismatch regression) still passes — confirms the integration call from the executor doesn't disturb the live ProAi path.
- [ ] 🧑 Manual: Replay #2057's matchID (\`LEjYQgC3WMr\`) against a sidecar with this build and confirm the rationale line appears in the Grafana Explore window for that match. Per the #2057 attached state.json, the German bot was at \`attackerCasualtySelection\` (1 surface hit, France battle) — the rationale line should show \`considered=[the units in France]\`, \`picked=[the unit ProAi chose]\`, \`default=[the client's autoDefenseCasualties]\`, and \`reason=...\`. If the line is missing, the call site or matchID threading regressed.

## Sample line (from the test capture)

The test asserts a real emitted line containing:
\`\`\`
[AI-TRACE] matchID=match-cas-001 side=sidecar nation=Germans phase=battle kind=select-casualties battleId=b-france-1 territory=\"Western Europe\" hitCount=2 consideredIds=[u-inf-1,u-inf-2,u-tank-1] consideredTypes=[infantry×2,armour×1] pickedIds=[u-inf-1,u-tank-1] pickedTypes=[infantry×1,armour×1] defaultIds=[u-inf-1,u-inf-2] reason=overridden-from-default
\`\`\`

## Out of scope (filed as separate follow-ups)

- Retreat-decision rationale → map-room/map-room#2103
- Scramble-selection rationale → map-room/map-room#2104
- SBR interceptor-selection rationale → map-room/map-room#2105

Each gets its own focused PR per #2101's recommendation.

## Related

- map-room/map-room#2101 — tracking issue
- map-room/map-room#2057 / #2065 / #2066 — the AI-stuck bugs that motivated this
- map-room/map-room#1844 / #1845 — AI-TRACE structural format
- map-room/map-room#2026 — bug-report Grafana enrichment (the link triagers click)
- map-room/triplea#56 — matchID per-thread context (reused here unchanged)