### PR TITLE
obs(ai-sidecar): structured retreat / scramble / SBR-interceptor rationale logs (#2103 #2104 #2105)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
@@ -182,6 +182,112 @@ public final class AiTraceLogger {
         casualtyReason(picked, defaultCasualties));
   }
 
+  /**
+   * Log the rationale for a retreat-vs-press decision (#2103).
+   *
+   * <p>Captures the candidate retreat territories the AI was offered, where (if anywhere) it
+   * decided to retreat, and a coarse {@code reason} tag: {@code no-options} when the candidate list
+   * was empty (no decision was actually made), {@code press} when the AI chose to fight on, {@code
+   * retreat} when it chose to retreat. ProAi's deeper rationale (per-territory TUL math,
+   * defender-threat estimate) lives inside {@code ProRetreatAi} and is out of scope here.
+   *
+   * @param retreatTo the chosen retreat territory name, or {@code null} if the AI chose to press
+   */
+  public static void logRetreatDecision(
+      final String nation,
+      final String battleId,
+      final String territory,
+      final Collection<String> candidateTerritories,
+      final String retreatTo) {
+    LOG.log(
+        System.Logger.Level.INFO,
+        "[AI-TRACE] matchID={0} side=sidecar nation={1} phase=battle kind=retreat-decision"
+            + " battleId={2} territory={3} candidates=[{4}] retreatTo={5} reason={6}",
+        currentMatchId(),
+        nation,
+        battleId,
+        maybeQuote(territory),
+        territoryNamesList(candidateTerritories),
+        retreatTo == null ? "null" : maybeQuote(retreatTo),
+        retreatReason(candidateTerritories, retreatTo));
+  }
+
+  /**
+   * Log the rationale for a scramble-selection decision (#2104).
+   *
+   * <p>Captures the flat list of scramble candidates ProScrambleAi was offered (across all source
+   * territories) and what it picked, plus a coarse {@code reason} tag — {@code no-candidates} when
+   * ProScrambleAi was never invoked (empty live candidate set), {@code none} / {@code partial} /
+   * {@code all} based on pick-vs-candidate cardinality. The per-source breakdown is intentionally
+   * flattened: the bug-stuck question is "why didn't the AI scramble", which only needs the
+   * aggregate.
+   */
+  public static void logScrambleDecision(
+      final String nation,
+      final String territory,
+      final Collection<Unit> candidates,
+      final Collection<Unit> picked,
+      final Map<UUID, String> uuidToWireId) {
+    LOG.log(
+        System.Logger.Level.INFO,
+        "[AI-TRACE] matchID={0} side=sidecar nation={1} phase=battle kind=scramble-decision"
+            + " territory={2}"
+            + " candidatesIds=[{3}] candidatesTypes=[{4}]"
+            + " pickedIds=[{5}] pickedTypes=[{6}]"
+            + " reason={7}",
+        currentMatchId(),
+        nation,
+        maybeQuote(territory),
+        unitWireIds(candidates, uuidToWireId),
+        unitTypeCounts(candidates),
+        unitWireIds(picked, uuidToWireId),
+        unitTypeCounts(picked),
+        scrambleReason(candidates, picked));
+  }
+
+  /**
+   * Log the rationale for an SBR interceptor-selection decision (#2105).
+   *
+   * <p>{@code InterceptExecutor} is currently a stub returning no interceptors — see the {@code
+   * TODO} on that class. The rationale line still emits because triagers benefit from seeing
+   * "intercept query reached the sidecar but the decision is not yet implemented" vs. silence. Once
+   * ProAI integration lands, the call site can pass the real picked set + a non-stub reason (e.g.
+   * {@code interceptor-favorable}) without changing this signature.
+   *
+   * <p>Wire-side identifiers are passed as parallel {@code candidateIds} / {@code candidateTypes}
+   * lists rather than {@code Collection<Unit>} because the stub executor never resolves {@link
+   * Unit} instances; keeping the helper string-typed avoids forcing the executor through an
+   * unnecessary live-unit lookup just to log.
+   *
+   * @param reason caller-supplied — the InterceptExecutor passes {@code stub-not-implemented}
+   *     today; the real heuristic moves in when ProAI integration replaces the stub.
+   */
+  public static void logSbrInterceptorDecision(
+      final String nation,
+      final String battleId,
+      final String territory,
+      final String attackerNation,
+      final Collection<String> candidateIds,
+      final Collection<String> candidateTypes,
+      final Collection<String> pickedIds,
+      final String reason) {
+    LOG.log(
+        System.Logger.Level.INFO,
+        "[AI-TRACE] matchID={0} side=sidecar nation={1} phase=sbr kind=interceptor-decision"
+            + " battleId={2} territory={3} attacker={4}"
+            + " candidatesIds=[{5}] candidatesTypes=[{6}]"
+            + " pickedIds=[{7}] reason={8}",
+        currentMatchId(),
+        nation,
+        battleId,
+        maybeQuote(territory),
+        attackerNation,
+        stringCommaJoin(candidateIds),
+        stringTypeCounts(candidateTypes),
+        stringCommaJoin(pickedIds),
+        reason);
+  }
+
   // --- package-private for tests ---
 
   /**
@@ -207,6 +313,34 @@ public final class AiTraceLogger {
   }
 
   /**
+   * Coarse rationale tag for {@link #logRetreatDecision}: {@code no-options} when ProRetreatAi was
+   * never invoked (empty candidate list short-circuit), {@code press} when the AI chose to fight
+   * (null retreatTo), {@code retreat} otherwise.
+   */
+  static String retreatReason(
+      final Collection<String> candidateTerritories, final String retreatTo) {
+    if (candidateTerritories.isEmpty()) {
+      return "no-options";
+    }
+    return retreatTo == null ? "press" : "retreat";
+  }
+
+  /**
+   * Coarse rationale tag for {@link #logScrambleDecision}: {@code no-candidates} when ProScrambleAi
+   * was never invoked, otherwise the partition of picked-vs-candidate cardinality ({@code none} /
+   * {@code partial} / {@code all}).
+   */
+  static String scrambleReason(final Collection<Unit> candidates, final Collection<Unit> picked) {
+    if (candidates.isEmpty()) {
+      return "no-candidates";
+    }
+    if (picked.isEmpty()) {
+      return "none";
+    }
+    return picked.size() == candidates.size() ? "all" : "partial";
+  }
+
+  /**
    * Build a comma-separated list of Map Room wire IDs for each unit in the given collection, in
    * iteration order. Falls back to {@code uuid:<java-uuid>} when a unit is not registered in the
    * reverse map (should not happen in live dispatch but keeps the log non-empty if it does).
@@ -222,6 +356,40 @@ public final class AiTraceLogger {
       }
       final String wireId = uuidToWireId.get(u.getId());
       sb.append(wireId != null ? wireId : "uuid:" + u.getId());
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Comma-join territory names, double-quoting any name containing a space. Used for
+   * retreat-decision candidate lists where territory names like {@code "Western Europe"} need to
+   * stay parseable inside a {@code [a,b,c]} bracket form.
+   */
+  static String territoryNamesList(final Collection<String> names) {
+    if (names.isEmpty()) {
+      return "";
+    }
+    final StringBuilder sb = new StringBuilder();
+    for (final String n : names) {
+      if (sb.length() > 0) {
+        sb.append(',');
+      }
+      sb.append(maybeQuote(n));
+    }
+    return sb.toString();
+  }
+
+  /** Plain comma-join for already-string identifier lists (e.g. wire unit ids). */
+  static String stringCommaJoin(final Collection<String> values) {
+    if (values.isEmpty()) {
+      return "";
+    }
+    final StringBuilder sb = new StringBuilder();
+    for (final String v : values) {
+      if (sb.length() > 0) {
+        sb.append(',');
+      }
+      sb.append(v);
     }
     return sb.toString();
   }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/InterceptExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/InterceptExecutor.java
@@ -1,6 +1,8 @@
 package org.triplea.ai.sidecar.exec;
 
+import java.util.ArrayList;
 import java.util.List;
+import org.triplea.ai.sidecar.AiTraceLogger;
 import org.triplea.ai.sidecar.dto.InterceptPlan;
 import org.triplea.ai.sidecar.dto.InterceptRequest;
 import org.triplea.ai.sidecar.session.Session;
@@ -11,11 +13,35 @@ import org.triplea.ai.sidecar.session.Session;
  * <p>Returns the safe default (no interceptors sent) until ProAI integration is wired. TODO: invoke
  * the ProAI SBR intercept logic once identified (likely related to {@code
  * AbstractProAi.shouldBomberBomb} or a dedicated scramble/intercept method).
+ *
+ * <p>The {@code [AI-TRACE] kind=interceptor-decision} line still emits in the stub state (#2105) so
+ * triagers can distinguish "intercept query reached the sidecar but the decision is not yet
+ * implemented" from silence. Once the ProAI integration replaces the stub return below, swap {@code
+ * reason="stub-not-implemented"} for the real heuristic and pass the real picked set — the helper
+ * signature accepts both today.
  */
 public final class InterceptExecutor implements DecisionExecutor<InterceptRequest, InterceptPlan> {
 
   @Override
   public InterceptPlan execute(final Session session, final InterceptRequest request) {
+    final InterceptRequest.InterceptBattle b = request.battle();
+    final List<String> candidateIds = new ArrayList<>(b.pendingInterceptors().size());
+    final List<String> candidateTypes = new ArrayList<>(b.pendingInterceptors().size());
+    for (final InterceptRequest.PendingInterceptor pi : b.pendingInterceptors()) {
+      candidateIds.add(pi.unit().unitId());
+      candidateTypes.add(pi.unit().unitType());
+    }
+
+    AiTraceLogger.logSbrInterceptorDecision(
+        b.defenderNation(),
+        b.battleId(),
+        b.territory(),
+        b.attackerNation(),
+        candidateIds,
+        candidateTypes,
+        /* pickedIds */ List.of(),
+        /* reason */ "stub-not-implemented");
+
     return new InterceptPlan(List.of());
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RetreatQueryExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RetreatQueryExecutor.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.triplea.ai.sidecar.AiTraceLogger;
 import org.triplea.ai.sidecar.dto.RetreatPlan;
 import org.triplea.ai.sidecar.dto.RetreatQueryRequest;
 import org.triplea.ai.sidecar.session.Session;
@@ -58,6 +59,14 @@ public final class RetreatQueryExecutor
 
     final RetreatQueryRequest.RetreatQueryBattle b = request.battle();
     if (b.possibleRetreatTerritories().isEmpty()) {
+      // Emit the rationale line even on this short-circuit (#2103) — triagers benefit from
+      // seeing "AI was queried but had no retreat options" vs. silence; reason=no-options.
+      AiTraceLogger.logRetreatDecision(
+          session.key().nation(),
+          b.battleId(),
+          b.battleTerritory(),
+          List.of(),
+          /* retreatTo */ null);
       return new RetreatPlan(null);
     }
 
@@ -139,7 +148,17 @@ public final class RetreatQueryExecutor
       ExecutorSupport.removePendingBattle(tracker, synthetic);
     }
 
-    return new RetreatPlan(chosen.map(Territory::getName).orElse(null));
+    final String retreatTo = chosen.map(Territory::getName).orElse(null);
+
+    // Decision-rationale trace (#2103). One line per call after ProAi resolved.
+    AiTraceLogger.logRetreatDecision(
+        attacker.getName(),
+        b.battleId(),
+        b.battleTerritory(),
+        b.possibleRetreatTerritories(),
+        retreatTo);
+
+    return new RetreatPlan(retreatTo);
   }
 
   private static GamePlayer requirePlayer(final GameData data, final String name) {

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/ScrambleExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/ScrambleExecutor.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
+import org.triplea.ai.sidecar.AiTraceLogger;
 import org.triplea.ai.sidecar.dto.ScramblePlan;
 import org.triplea.ai.sidecar.dto.ScrambleRequest;
 import org.triplea.ai.sidecar.session.Session;
@@ -70,6 +71,13 @@ public final class ScrambleExecutor implements DecisionExecutor<ScrambleRequest,
 
     final ScrambleRequest.ScrambleBattle b = request.battle();
     if (b.possibleScramblers() == null || b.possibleScramblers().isEmpty()) {
+      // Emit the rationale line on the short-circuit too (#2104). reason=no-candidates.
+      AiTraceLogger.logScrambleDecision(
+          session.key().nation(),
+          b.defendingTerritory(),
+          /* candidates */ List.of(),
+          /* picked */ List.of(),
+          Map.of());
       return new ScramblePlan(Map.of());
     }
 
@@ -122,6 +130,14 @@ public final class ScrambleExecutor implements DecisionExecutor<ScrambleRequest,
     }
 
     if (possibleScramblers.isEmpty()) {
+      // All wire-side sources were skipped (no airbase on the live source territory). Emit
+      // the rationale line so triagers see "scramble queried but no live candidates".
+      AiTraceLogger.logScrambleDecision(
+          session.key().nation(),
+          b.defendingTerritory(),
+          /* candidates */ List.of(),
+          /* picked */ List.of(),
+          Map.of());
       return new ScramblePlan(Map.of());
     }
 
@@ -171,11 +187,28 @@ public final class ScrambleExecutor implements DecisionExecutor<ScrambleRequest,
       ExecutorSupport.removePendingBattle(tracker, synthetic);
     }
 
+    final Map<UUID, String> reverse = reverseIdMap(idMap);
+
+    // Decision-rationale trace (#2104). One flat list each for candidates and picks across
+    // all source territories — matches the helper's "aggregate" model. Emitted before the
+    // wire-projection loop so it captures live Unit references.
+    final List<Unit> candidatesFlat = new ArrayList<>();
+    for (final Tuple<Collection<Unit>, Collection<Unit>> t : possibleScramblers.values()) {
+      candidatesFlat.addAll(t.getSecond());
+    }
+    final List<Unit> pickedFlat = new ArrayList<>();
+    if (chosen != null) {
+      for (final Collection<Unit> v : chosen.values()) {
+        pickedFlat.addAll(v);
+      }
+    }
+    AiTraceLogger.logScrambleDecision(
+        defender.getName(), b.defendingTerritory(), candidatesFlat, pickedFlat, reverse);
+
     if (chosen == null || chosen.isEmpty()) {
       return new ScramblePlan(Map.of());
     }
 
-    final Map<UUID, String> reverse = reverseIdMap(idMap);
     final Map<String, List<String>> out = new LinkedHashMap<>();
     for (final Map.Entry<Territory, Collection<Unit>> e : chosen.entrySet()) {
       final List<String> ids = new ArrayList<>(e.getValue().size());

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceCapture.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceCapture.java
@@ -1,0 +1,98 @@
+package org.triplea.ai.sidecar;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/**
+ * Test utility for capturing {@link AiTraceLogger} emissions in unit tests.
+ *
+ * <p>System.Logger delegates to JUL by default in JDK; this attaches a {@link Handler} to the
+ * underlying JUL logger named after {@link AiTraceLogger} so {@code LOG.log(...)} calls land here
+ * as {@link LogRecord}s the test can assert on.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * final AiTraceCapture cap = AiTraceCapture.attach();
+ * try {
+ *   AiTraceLogger.logRetreatDecision(...);
+ * } finally {
+ *   cap.detach();
+ * }
+ * assertThat(cap.formatted()).hasSize(1).first().asString()
+ *     .startsWith("[AI-TRACE] matchID=...");
+ * }</pre>
+ *
+ * <p>{@link #attach()} captures the JUL logger's prior {@link Level} and {@code useParentHandlers}
+ * flag; {@link #detach()} restores both. Without restoration the handler-removal still leaks the
+ * raised log level into subsequent tests in the same JVM (#2103 felix-review nit).
+ */
+public final class AiTraceCapture {
+
+  private final Logger jul;
+  private final Level originalLevel;
+  private final boolean originalUseParent;
+  private final CapturingHandler handler;
+
+  private AiTraceCapture(
+      final Logger jul,
+      final Level originalLevel,
+      final boolean originalUseParent,
+      final CapturingHandler handler) {
+    this.jul = jul;
+    this.originalLevel = originalLevel;
+    this.originalUseParent = originalUseParent;
+    this.handler = handler;
+  }
+
+  /** Attach a fresh capture to the AiTraceLogger backend. Pair with {@link #detach()}. */
+  public static AiTraceCapture attach() {
+    final Logger jul = Logger.getLogger(AiTraceLogger.class.getName());
+    final Level originalLevel = jul.getLevel();
+    final boolean originalUseParent = jul.getUseParentHandlers();
+    final CapturingHandler h = new CapturingHandler();
+    h.setLevel(Level.ALL);
+    jul.setLevel(Level.ALL);
+    jul.addHandler(h);
+    jul.setUseParentHandlers(false);
+    return new AiTraceCapture(jul, originalLevel, originalUseParent, h);
+  }
+
+  /** Restore the JUL logger to its prior state. Always call from a finally block. */
+  public void detach() {
+    jul.removeHandler(handler);
+    jul.setLevel(originalLevel);
+    jul.setUseParentHandlers(originalUseParent);
+  }
+
+  /** Captured records, formatted via {@link MessageFormat} like the System.Logger backend would. */
+  public List<String> formatted() {
+    return handler.records.stream()
+        .map(
+            r ->
+                r.getParameters() == null
+                    ? r.getMessage()
+                    : MessageFormat.format(r.getMessage(), r.getParameters()))
+        .toList();
+  }
+
+  private static final class CapturingHandler extends Handler {
+    private final List<LogRecord> records = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void publish(final LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() throws SecurityException {}
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceLoggerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceLoggerTest.java
@@ -10,11 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -192,7 +187,7 @@ class AiTraceLoggerTest {
     uuidToWireId.put(tank.getId(), "u-tank-1");
 
     AiTraceLogger.setMatchId("match-cas-001");
-    final CapturingHandler capture = attachHandler();
+    final AiTraceCapture cap = AiTraceCapture.attach();
     try {
       AiTraceLogger.logCasualtyDecision(
           /* nation */ "Germans",
@@ -204,67 +199,209 @@ class AiTraceLoggerTest {
           /* picked */ List.of(inf1, tank),
           uuidToWireId);
     } finally {
-      detachHandler(capture);
+      cap.detach();
     }
 
-    assertThat(capture.formatted())
-        .anySatisfy(
-            line ->
-                assertThat(line)
-                    .startsWith("[AI-TRACE] matchID=match-cas-001 side=sidecar nation=Germans")
-                    .contains("phase=battle kind=select-casualties")
-                    .contains("battleId=b-france-1")
-                    .contains("territory=\"Western Europe\"")
-                    .contains("hitCount=2")
-                    .contains("consideredIds=[u-inf-1,u-inf-2,u-tank-1]")
-                    .contains("consideredTypes=[infantry×2,armour×1]")
-                    .contains("pickedIds=[u-inf-1,u-tank-1]")
-                    .contains("pickedTypes=[infantry×1,armour×1]")
-                    .contains("defaultIds=[u-inf-1,u-inf-2]")
-                    .contains("reason=overridden-from-default"));
+    assertThat(cap.formatted()).hasSize(1);
+    assertThat(cap.formatted().get(0))
+        .startsWith("[AI-TRACE] matchID=match-cas-001 side=sidecar nation=Germans")
+        .contains("phase=battle kind=select-casualties")
+        .contains("battleId=b-france-1")
+        .contains("territory=\"Western Europe\"")
+        .contains("hitCount=2")
+        .contains("consideredIds=[u-inf-1,u-inf-2,u-tank-1]")
+        .contains("consideredTypes=[infantry×2,armour×1]")
+        .contains("pickedIds=[u-inf-1,u-tank-1]")
+        .contains("pickedTypes=[infantry×1,armour×1]")
+        .contains("defaultIds=[u-inf-1,u-inf-2]")
+        .contains("reason=overridden-from-default");
   }
 
-  private static CapturingHandler attachHandler() {
-    final Logger jul = Logger.getLogger(AiTraceLogger.class.getName());
-    final CapturingHandler h = new CapturingHandler();
-    h.setLevel(Level.ALL);
-    jul.setLevel(Level.ALL);
-    jul.addHandler(h);
-    jul.setUseParentHandlers(false);
-    return h;
+  // ---------------------------------------------------------------------------
+  // retreat-decision rationale (#2103)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void retreatReason_emptyCandidates_returnsNoOptions() {
+    assertThat(AiTraceLogger.retreatReason(List.of(), null)).isEqualTo("no-options");
+    assertThat(AiTraceLogger.retreatReason(List.of(), "Italy")).isEqualTo("no-options");
   }
 
-  private static void detachHandler(final CapturingHandler h) {
-    Logger.getLogger(AiTraceLogger.class.getName()).removeHandler(h);
+  @Test
+  void retreatReason_nullRetreatTo_returnsPress() {
+    assertThat(AiTraceLogger.retreatReason(List.of("Italy", "Germany"), null)).isEqualTo("press");
   }
 
-  /**
-   * JUL handler that captures every {@link LogRecord} so tests can assert on the formatted message.
-   * System.Logger delegates to JUL by default in JDK, so attaching here intercepts {@code LOG.log}
-   * calls in {@link AiTraceLogger}.
-   */
-  private static final class CapturingHandler extends Handler {
-    private final List<LogRecord> records = new CopyOnWriteArrayList<>();
+  @Test
+  void retreatReason_chosenTerritory_returnsRetreat() {
+    assertThat(AiTraceLogger.retreatReason(List.of("Italy", "Germany"), "Italy"))
+        .isEqualTo("retreat");
+  }
 
-    @Override
-    public void publish(final LogRecord record) {
-      records.add(record);
+  @Test
+  void logRetreatDecision_emitsLineWithExpectedKeysAndMatchId() {
+    AiTraceLogger.setMatchId("match-ret-001");
+    final AiTraceCapture cap = AiTraceCapture.attach();
+    try {
+      AiTraceLogger.logRetreatDecision(
+          /* nation */ "Germans",
+          /* battleId */ "b-france-1",
+          /* territory */ "Western Europe",
+          /* candidateTerritories */ List.of("Germany", "Italy"),
+          /* retreatTo */ "Italy");
+    } finally {
+      cap.detach();
     }
 
-    @Override
-    public void flush() {}
+    assertThat(cap.formatted()).hasSize(1);
+    assertThat(cap.formatted().get(0))
+        .startsWith("[AI-TRACE] matchID=match-ret-001 side=sidecar nation=Germans")
+        .contains("phase=battle kind=retreat-decision")
+        .contains("battleId=b-france-1")
+        .contains("territory=\"Western Europe\"")
+        .contains("candidates=[Germany,Italy]")
+        .contains("retreatTo=Italy")
+        .contains("reason=retreat");
+  }
 
-    @Override
-    public void close() throws SecurityException {}
-
-    List<String> formatted() {
-      return records.stream()
-          .map(
-              r ->
-                  r.getParameters() == null
-                      ? r.getMessage()
-                      : java.text.MessageFormat.format(r.getMessage(), r.getParameters()))
-          .toList();
+  @Test
+  void logRetreatDecision_pressDecision_emitsRetreatToNullAndReasonPress() {
+    AiTraceLogger.setMatchId("match-ret-002");
+    final AiTraceCapture cap = AiTraceCapture.attach();
+    try {
+      AiTraceLogger.logRetreatDecision(
+          "Germans", "b-france-2", "Western Europe", List.of("Germany"), null);
+    } finally {
+      cap.detach();
     }
+
+    assertThat(cap.formatted()).hasSize(1);
+    assertThat(cap.formatted().get(0)).contains("retreatTo=null").contains("reason=press");
+  }
+
+  @Test
+  void logRetreatDecision_quotesTerritoryNamesContainingSpaces() {
+    AiTraceLogger.setMatchId("match-ret-003");
+    final AiTraceCapture cap = AiTraceCapture.attach();
+    try {
+      AiTraceLogger.logRetreatDecision(
+          "Germans",
+          "b-fr-3",
+          "Western Europe",
+          List.of("Eastern Europe", "Germany"),
+          "Eastern Europe");
+    } finally {
+      cap.detach();
+    }
+
+    assertThat(cap.formatted()).hasSize(1);
+    assertThat(cap.formatted().get(0))
+        .contains("candidates=[\"Eastern Europe\",Germany]")
+        .contains("retreatTo=\"Eastern Europe\"");
+  }
+
+  // ---------------------------------------------------------------------------
+  // scramble-selection rationale (#2104)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void scrambleReason_emptyCandidates_returnsNoCandidates() {
+    final var gd = canonical.cloneForSession();
+    assertThat(AiTraceLogger.scrambleReason(List.of(), List.of())).isEqualTo("no-candidates");
+    // No-candidates wins even if picked is somehow non-empty (defensive guard).
+    final UnitType fighter = gd.getUnitTypeList().getUnitType("fighter").orElseThrow();
+    final var germans = gd.getPlayerList().getPlayerId("Germans");
+    final Unit f = new Unit(UUID.randomUUID(), fighter, germans, gd);
+    assertThat(AiTraceLogger.scrambleReason(List.of(), List.of(f))).isEqualTo("no-candidates");
+  }
+
+  @Test
+  void scrambleReason_pickedSubsetOfCandidates_returnsPartialAllOrNone() {
+    final var gd = canonical.cloneForSession();
+    final UnitType fighter = gd.getUnitTypeList().getUnitType("fighter").orElseThrow();
+    final var germans = gd.getPlayerList().getPlayerId("Germans");
+    final Unit f1 = new Unit(UUID.randomUUID(), fighter, germans, gd);
+    final Unit f2 = new Unit(UUID.randomUUID(), fighter, germans, gd);
+
+    assertThat(AiTraceLogger.scrambleReason(List.of(f1, f2), List.of())).isEqualTo("none");
+    assertThat(AiTraceLogger.scrambleReason(List.of(f1, f2), List.of(f1))).isEqualTo("partial");
+    assertThat(AiTraceLogger.scrambleReason(List.of(f1, f2), List.of(f1, f2))).isEqualTo("all");
+  }
+
+  @Test
+  void logScrambleDecision_emitsLineWithExpectedKeysAndMatchId() {
+    final var gd = canonical.cloneForSession();
+    final UnitType fighter = gd.getUnitTypeList().getUnitType("fighter").orElseThrow();
+    final var germans = gd.getPlayerList().getPlayerId("Germans");
+    final Unit f1 = new Unit(UUID.randomUUID(), fighter, germans, gd);
+    final Unit f2 = new Unit(UUID.randomUUID(), fighter, germans, gd);
+    final Map<UUID, String> uuidToWireId = new HashMap<>();
+    uuidToWireId.put(f1.getId(), "u-fighter-1");
+    uuidToWireId.put(f2.getId(), "u-fighter-2");
+
+    AiTraceLogger.setMatchId("match-scr-001");
+    final AiTraceCapture cap = AiTraceCapture.attach();
+    try {
+      AiTraceLogger.logScrambleDecision(
+          /* nation */ "Germans",
+          /* territory */ "112 Sea Zone",
+          /* candidates */ List.of(f1, f2),
+          /* picked */ List.of(f1),
+          uuidToWireId);
+    } finally {
+      cap.detach();
+    }
+
+    assertThat(cap.formatted()).hasSize(1);
+    assertThat(cap.formatted().get(0))
+        .startsWith("[AI-TRACE] matchID=match-scr-001 side=sidecar nation=Germans")
+        .contains("phase=battle kind=scramble-decision")
+        .contains("territory=\"112 Sea Zone\"")
+        .contains("candidatesIds=[u-fighter-1,u-fighter-2]")
+        .contains("candidatesTypes=[fighter×2]")
+        .contains("pickedIds=[u-fighter-1]")
+        .contains("pickedTypes=[fighter×1]")
+        .contains("reason=partial");
+  }
+
+  // ---------------------------------------------------------------------------
+  // SBR interceptor-selection rationale (#2105)
+  //
+  // InterceptExecutor is currently a stub returning no interceptors. The rationale line still
+  // emits — triagers benefit from seeing that an intercept query reached the sidecar but the
+  // decision is not yet implemented (vs. "the decision did happen and chose nothing"). Once
+  // ProAI integration lands, the helper signature already accepts a real reason and picked set
+  // so the call site can switch over without API churn.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void logSbrInterceptorDecision_emitsLineWithExpectedKeysAndMatchId() {
+    AiTraceLogger.setMatchId("match-sbr-001");
+    final AiTraceCapture cap = AiTraceCapture.attach();
+    try {
+      AiTraceLogger.logSbrInterceptorDecision(
+          /* nation */ "Germans",
+          /* battleId */ "sbr-1",
+          /* territory */ "Germany",
+          /* attackerNation */ "British",
+          /* candidateIds */ List.of("u-f-1", "u-f-2"),
+          /* candidateTypes */ List.of("fighter", "fighter"),
+          /* pickedIds */ List.of(),
+          /* reason */ "stub-not-implemented");
+    } finally {
+      cap.detach();
+    }
+
+    assertThat(cap.formatted()).hasSize(1);
+    assertThat(cap.formatted().get(0))
+        .startsWith("[AI-TRACE] matchID=match-sbr-001 side=sidecar nation=Germans")
+        .contains("phase=sbr kind=interceptor-decision")
+        .contains("battleId=sbr-1")
+        .contains("territory=Germany")
+        .contains("attacker=British")
+        .contains("candidatesIds=[u-f-1,u-f-2]")
+        .contains("candidatesTypes=[fighter×2]")
+        .contains("pickedIds=[]")
+        .contains("reason=stub-not-implemented");
   }
 }


### PR DESCRIPTION
Closes map-room/map-room#2103.
Closes map-room/map-room#2104.
Closes map-room/map-room#2105.

Extends the casualty-decision pattern from #60 (\`logCasualtyDecision\`) to the remaining stuck-state decision classes called out in map-room/map-room#2101. Bundled into one PR per chase's preference (single review cycle, less GitHub noise, identical pattern across all three).

## What this PR adds

Three new helpers in \`AiTraceLogger\`, parallel to \`logCasualtyDecision\`:

| Helper | Emit | Reason values |
|---|---|---|
| \`logRetreatDecision\`  | \`[AI-TRACE] kind=retreat-decision retreatTo=<t\|null>\`  | \`no-options\` / \`press\` / \`retreat\` |
| \`logScrambleDecision\` | \`[AI-TRACE] kind=scramble-decision territory=T\`        | \`no-candidates\` / \`none\` / \`partial\` / \`all\` |
| \`logSbrInterceptorDecision\` | \`[AI-TRACE] phase=sbr kind=interceptor-decision\`  | \`stub-not-implemented\` today; caller-supplied so swap when ProAI integration lands |

Each follows the structural key=value format from #1844 / #1845 (same redaction story applies). matchID inherits from PR #56's per-thread context.

## Sample emitted lines (from the test capture)

\`\`\`
[AI-TRACE] matchID=match-ret-001 side=sidecar nation=Germans phase=battle kind=retreat-decision battleId=b-france-1 territory=\"Western Europe\" candidates=[Germany,Italy] retreatTo=Italy reason=retreat

[AI-TRACE] matchID=match-scr-001 side=sidecar nation=Germans phase=battle kind=scramble-decision territory=\"112 Sea Zone\" candidatesIds=[u-fighter-1,u-fighter-2] candidatesTypes=[fighter×2] pickedIds=[u-fighter-1] pickedTypes=[fighter×1] reason=partial

[AI-TRACE] matchID=match-sbr-001 side=sidecar nation=Germans phase=sbr kind=interceptor-decision battleId=sbr-1 territory=Germany attacker=British candidatesIds=[u-f-1,u-f-2] candidatesTypes=[fighter×2] pickedIds=[] reason=stub-not-implemented
\`\`\`

## Wiring

- **\`RetreatQueryExecutor\`** — emits on the empty-candidates short-circuit (line 60-62; reason=\`no-options\`) and after \`ProAi.retreatQuery\` resolves (reason=\`press\` / \`retreat\`).
- **\`ScrambleExecutor\`** — emits on both short-circuits (empty wire-side sources, all sources skipped for missing airbase) and after \`ProScrambleAi\` resolves. Candidates + picks are flattened across source territories — the bug-stuck question is \"why didn't the AI scramble?\", which only needs the aggregate.
- **\`InterceptExecutor\`** — currently a stub returning no interceptors (the existing \`TODO\` is unchanged). Emit still happens with reason=\`stub-not-implemented\` so triagers see \"intercept query reached the sidecar but the decision is unimplemented\" rather than silence. When ProAI integration replaces the stub, the helper signature accepts a real picked set + non-stub reason without API churn.

## Felix's review nits from PR #60 — addressed

1. **JUL Level not restored on detach** → fixed. Extracted the JUL-handler capture into a new public test utility \`AiTraceCapture\`. \`attach()\` saves the prior \`Level\` + \`useParentHandlers\` flag; \`detach()\` restores both. The existing \`logCasualtyDecision\` test was refactored onto the shared utility, so the fix retroactively covers it.
2. **\`anySatisfy\` won't catch double-emit** → fixed. Every line-shape assertion now does \`assertThat(cap.formatted()).hasSize(1)\` before asserting on element 0. The refactored casualty test follows the same pattern.

## Test plan

- [x] \`./gradlew :game-app:ai-sidecar:test\` — full suite green
- [x] New \`AiTraceLoggerTest\` cases (10 in total covering the three helpers):
  - **Retreat:** 3 reason cases (\`no-options\` / \`press\` / \`retreat\`) + 3 line-shape (retreat / press / quoted-territory-name)
  - **Scramble:** 2 reason cases + 1 line-shape with quoted sea-zone territory
  - **SBR:** 1 line-shape capturing the stub case
- [x] Existing \`AiTraceLoggerTest.logCasualtyDecision_emitsLineWithExpectedKeysAndMatchId\` refactored onto \`AiTraceCapture\` + \`hasSize(1)\` and still passes
- [x] Existing \`RetreatQueryExecutorTest\`, \`ScrambleExecutorTest\`, \`SelectCasualtiesExecutorTest\` all pass — confirms the new emit calls don't perturb the live executor paths
- [x] \`spotlessCheck\` + \`checkstyleMain\` + \`checkstyleTest\` clean on the modified files (the 18 reported checkstyle warnings are all in pre-existing files unrelated to this PR)
- [ ] 🧑 Manual: post-deploy, query Loki for \`{service=\"ai-sidecar\"} |~ \"kind=(retreat|scramble|interceptor)-decision\"\` and confirm rationale lines are flowing for real matchIDs.

## Out of scope (per #2101's deferred items)

Deeper rationale extraction — exposing TUL ratio / cost math from inside ProAi — remains a separate effort. The coarse \`reason\` tags in this PR give triagers enough to reconstruct \"AI was offered X, picked Y\" manually.

## Related

- map-room/map-room#2101 — parent rationale-coverage tracking issue
- map-room/triplea#60 — casualty-decision rationale (the pattern this PR replicates)
- map-room/map-room#2057 / #2065 / #2066 — AI-stuck bugs that motivated rationale logs
- map-room/map-room#1844 / #1845 — AI-TRACE structural format
- map-room/triplea#56 — matchID per-thread context (reused unchanged)