### PR TITLE
obs(ai-sidecar): suppress JDK HttpServer FINE healthcheck noise (#2111)

### DIFF
--- a/game-app/ai-sidecar/src/main/resources/logging.properties
+++ b/game-app/ai-sidecar/src/main/resources/logging.properties
@@ -10,3 +10,11 @@ java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
 # Compact single-line format: timestamp level logger - message
 java.util.logging.SimpleFormatter.format = %1$tFT%1$tT %4$s %3$s - %5$s%6$s%n
+
+# Suppress JDK HttpServer access logs (GET /health, no-request-line, etc.)
+# at FINE-level. The root logger is raised to FINE when SIDECAR_LOG_LEVEL=FINE,
+# which lets com.sun.net.httpserver emit ~8K healthcheck lines/day with no
+# debugging value (#2111). Per-logger entries set here survive the programmatic
+# root-level override in SidecarMain.initializeLogging(), so this stays INFO
+# regardless of SIDECAR_LOG_LEVEL — only ProAI rationale logs get the bump.
+com.sun.net.httpserver.level = INFO


### PR DESCRIPTION
Closes map-room/map-room#2111

## Problem

Deploy PR #24 bumped `SIDECAR_LOG_LEVEL` to `FINE` in production so ProAI planning logs would appear in Loki for AI-decision-stuck bug triage. The desired signal landed, but `com.sun.net.httpserver` also emits at FINE — including access log lines for every healthcheck probe (every 30s):

```
FINE com.sun.net.httpserver - GET /health HTTP/1.1 [200  OK] ()
FINE com.sun.net.httpserver - Exchange request line: GET /health HTTP/1.1
FINE com.sun.net.httpserver - no request line: closing
```

~6 lines/probe × 2 probes/min × 1440 min/day = **~8,640 lines/day** of pure noise. Dilutes the ProAI signal we actually care about.

## Fix — Option A (JUL config)

One line added to `game-app/ai-sidecar/src/main/resources/logging.properties`:

```properties
com.sun.net.httpserver.level = INFO
```

**Why this works:** `SidecarMain.initializeLogging()` calls `LogManager.readConfiguration(is)` to load the properties file, then programmatically overrides the root logger to FINE via `root.setLevel(FINE)`. Per-logger entries loaded from the properties file set an **explicit level** on a named logger — this is not inherited from the root, and the subsequent `root.setLevel()` call only updates the root logger's own level. The `com.sun.net.httpserver` logger retains its INFO floor regardless of `SIDECAR_LOG_LEVEL`.

**Option B (Promtail drop filter) was not chosen** — it would add a service-specific noise filter to the shared Promtail config, masking future HttpServer logs we might actually want, and adding deploy-repo maintenance burden for a problem that lives in the sidecar.

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:spotlessCheck` — BUILD SUCCESSFUL
- [ ] 🧑 Manual: After ai-sidecar rebuild + redeploy — query Loki `{container="ai-sidecar"} |~ "GET /health"` over a 5-min window → zero rows
- [ ] 🧑 Manual: Verify FINE-level ProAI rationale logs are still emitted (check for `[ProAI]`-prefixed lines in Grafana Explore for an active AI match)
- [ ] 🧑 Manual: Loki ingest rate for `ai-sidecar` drops by ~8K lines/day vs post-#24 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)