### PR TITLE
fix(proai): make ConcurrentBattleCalculator per-instance, not static

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
@@ -1,18 +1,19 @@
 package games.strategy.triplea.ai.pro;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.framework.GameShutdownRegistry;
 import games.strategy.triplea.odds.calculator.ConcurrentBattleCalculator;
 
 public class ProAi extends AbstractProAi {
-  // Odds calculator
-  private static final ConcurrentBattleCalculator concurrentCalc = new ConcurrentBattleCalculator();
+  private final ConcurrentBattleCalculator concurrentCalc;
 
   public ProAi(final String name, final String playerLabel) {
-    super(name, concurrentCalc, new ProData(), playerLabel);
-    // cuncurrentCalc is static so that it can be shared across all ProAi instances
-    // at the end of a game, it needs to be cleared up
-    GameShutdownRegistry.registerShutdownAction(() -> concurrentCalc.setGameData(null));
+    this(name, playerLabel, new ConcurrentBattleCalculator());
+  }
+
+  private ProAi(
+      final String name, final String playerLabel, final ConcurrentBattleCalculator calc) {
+    super(name, calc, new ProData(), playerLabel);
+    this.concurrentCalc = calc;
   }
 
   @Override

--- a/game-app/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
+++ b/game-app/smoke-testing/src/test/java/games/strategy/engine/data/AiGameTest.java
@@ -58,8 +58,6 @@ public class AiGameTest {
         "Expecting first round game to not be over so early: " + getResourceSummary(game.getData()),
         game.isGameOver(),
         is(false));
-    // Need to call stopGame() to ensure ProAI resets its static ConcurrentBattleCalculator, else
-    // the next test will use the wrong GameData for simulation.
     game.stopGame();
   }
 


### PR DESCRIPTION
## Problem

`ProAi` held `ConcurrentBattleCalculator` as a `static final` field — a single instance shared across **all** ProAi instances in the JVM. `ConcurrentBattleCalculator` is stateful: it owns a worker pool, an `isDataSet` flag, and two mutexes (`mutexSetGameData`, `mutexCalcIsRunning`).

In the multi-tenant ai-sidecar (one `ProAi` per session, multiple concurrent sessions per deployed instance), two sessions calling `setGameData(differentGameData)` concurrently clobber each other's worker pool and cancel each other's odds calculations mid-flight. The worst observable case: degenerate AI decisions when two users run concurrent single-player matches.

Closes #3

## Fix

Refactor to per-`ProAi` instance ownership using constructor delegation (required because Java prohibits referencing instance fields in `super()` calls):

```java
// Before
private static final ConcurrentBattleCalculator concurrentCalc = new ConcurrentBattleCalculator();

// After
private final ConcurrentBattleCalculator concurrentCalc;

public ProAi(String name, String playerLabel) {
  this(name, playerLabel, new ConcurrentBattleCalculator());
}

private ProAi(String name, String playerLabel, ConcurrentBattleCalculator calc) {
  super(name, calc, new ProData(), playerLabel);
  this.concurrentCalc = calc;
}
```

Also removes the `@Deprecated` `GameShutdownRegistry` hook — it existed solely to clean up the static singleton. Per-instance cleanup is already handled by `stopGame()` (`cancel()` + `setGameData(null)`).

## Test cleanup

Removes the now-inaccurate comment in `AiGameTest.testFirstRoundTenTimes()` that explained why `stopGame()` was required to reset the static calculator between `@RepeatedTest` iterations. The `stopGame()` call itself is retained — it's still good practice for resource cleanup.

## Verification

- Two non-ProAi callers (`LanchesterDebugAction`, `BattleCalculatorPanel`) each construct their own `ConcurrentBattleCalculator` instances and are unaffected.
- `./gradlew :game-app:ai-sidecar:test :game-app:game-core:test` passes (BUILD SUCCESSFUL, 52 tasks).