### PR TITLE
fix(sidecar): skip stale transport.unloaded entries where unloadedTo is null (#2162)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -356,6 +356,14 @@ public final class WireStateApplier {
         allUnitsById.put(u.getId(), u);
       }
     }
+    // Defense-in-depth: index wire units by Map Room id so we can check unloadedTo on cargo units
+    // when building a transport's unloaded list (#2162 — stale cross-nation transport state).
+    final Map<String, WireUnit> wireUnitById = new HashMap<>();
+    for (final WireTerritory wt : wire.territories()) {
+      for (final WireUnit wu : wt.units()) {
+        wireUnitById.put(wu.unitId(), wu);
+      }
+    }
 
     for (final WireTerritory wt : wire.territories()) {
       final Territory t = gameData.getMap().getTerritoryOrNull(wt.territoryId());
@@ -431,6 +439,15 @@ public final class WireStateApplier {
         if (wu.unloaded() != null && !wu.unloaded().isEmpty()) {
           final List<Unit> unloadedUnits = new ArrayList<>();
           for (final String unloadedId : wu.unloaded()) {
+            // Skip cargo units whose wire state has no unloadedTo — this indicates stale
+            // cross-nation transport state (#2162): the transport belongs to one nation but
+            // the cargo belongs to another, so only the cargo's unloadedTo was cleared at
+            // phase start while the transport's unloaded list was not. Propagating it to
+            // Java would cause an NPE in TransportTracker.isTransportUnloadRestricted*.
+            final WireUnit cargoWu = wireUnitById.get(unloadedId);
+            if (cargoWu == null || cargoWu.unloadedTo() == null) {
+              continue;
+            }
             final UUID unloadedUuid = unitIdMap.get(unloadedId);
             if (unloadedUuid != null) {
               final Unit unloadedUnit = allUnitsById.get(unloadedUuid);

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
@@ -746,21 +746,55 @@ class WireStateApplierTest {
 
     final WireUnit transport =
         WireUnit.of(
-            "u-trn-1", "transport", 0, 0, 0, "Germans", null,
-            false, false, false, false, 0, false, false, null,
-            List.of("u-inf-1"), null, false);
+            "u-trn-1",
+            "transport",
+            0,
+            0,
+            0,
+            "Germans",
+            null,
+            false,
+            false,
+            false,
+            false,
+            0,
+            false,
+            false,
+            null,
+            List.of("u-inf-1"),
+            null,
+            false);
     final WireUnit infantry =
         WireUnit.of(
-            "u-inf-1", "infantry", 0, 0, 0, "Germans", null,
-            false, false, false, true, 0, false, false, null,
-            null, "Germany", false);
+            "u-inf-1",
+            "infantry",
+            0,
+            0,
+            0,
+            "Germans",
+            null,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+            false,
+            null,
+            null,
+            "Germany",
+            false);
 
     final WireState wire =
         new WireState(
             List.of(
                 new WireTerritory("112 Sea Zone", "Germans", List.of(transport)),
                 new WireTerritory("Germany", "Germans", List.of(infantry))),
-            List.of(), 1, "combatMove", "Germans", List.of());
+            List.of(),
+            1,
+            "combatMove",
+            "Germans",
+            List.of());
 
     WireStateApplier.apply(gd, wire, idMap);
 
@@ -796,21 +830,55 @@ class WireStateApplierTest {
 
     final WireUnit transport =
         WireUnit.of(
-            "u-trn-1", "transport", 0, 0, 0, "Germans", null,
-            false, false, false, false, 0, false, false, null,
-            List.of("u-inf-1"), null, false);
+            "u-trn-1",
+            "transport",
+            0,
+            0,
+            0,
+            "Germans",
+            null,
+            false,
+            false,
+            false,
+            false,
+            0,
+            false,
+            false,
+            null,
+            List.of("u-inf-1"),
+            null,
+            false);
     final WireUnit infantry =
         WireUnit.of(
-            "u-inf-1", "infantry", 0, 0, 0, "Germans", null,
-            false, false, false, false, 0, false, false, null,
-            null, null, false); // unloadedTo = null — stale cross-nation state
+            "u-inf-1",
+            "infantry",
+            0,
+            0,
+            0,
+            "Germans",
+            null,
+            false,
+            false,
+            false,
+            false,
+            0,
+            false,
+            false,
+            null,
+            null,
+            null,
+            false); // unloadedTo = null — stale cross-nation state
 
     final WireState wire =
         new WireState(
             List.of(
                 new WireTerritory("112 Sea Zone", "Germans", List.of(transport)),
                 new WireTerritory("Germany", "Germans", List.of(infantry))),
-            List.of(), 1, "combatMove", "Germans", List.of());
+            List.of(),
+            1,
+            "combatMove",
+            "Germans",
+            List.of());
 
     WireStateApplier.apply(gd, wire, freshIdMap());
 

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
@@ -1,11 +1,13 @@
 package org.triplea.ai.sidecar.wire;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.settings.ClientSetting;
 import java.util.List;
 import java.util.Map;
@@ -730,5 +732,104 @@ class WireStateApplierTest {
     WireStateApplier.apply(gd, wire, freshIdMap());
     assertThat(gd.getPlayerList().getPlayerId("Germans").getTechAttachment().getHeavyBomber())
         .isTrue();
+  }
+
+  // ---------- transport unloaded / unloadedTo round-trip (#2162) ----------
+
+  @Test
+  void transportUnloaded_consistentState_setsUnloadedOnTransportAndUnloadedToOnCargo() {
+    // Consistent wire state: transport.unloaded = [infantry], infantry.unloadedTo = "Germany".
+    // After apply, the Java transport must have the infantry in its unloaded collection and the
+    // infantry must have the Germany territory as its unloadedTo.
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+
+    final WireUnit transport =
+        WireUnit.of(
+            "u-trn-1", "transport", 0, 0, 0, "Germans", null,
+            false, false, false, false, 0, false, false, null,
+            List.of("u-inf-1"), null, false);
+    final WireUnit infantry =
+        WireUnit.of(
+            "u-inf-1", "infantry", 0, 0, 0, "Germans", null,
+            false, false, false, true, 0, false, false, null,
+            null, "Germany", false);
+
+    final WireState wire =
+        new WireState(
+            List.of(
+                new WireTerritory("112 Sea Zone", "Germans", List.of(transport)),
+                new WireTerritory("Germany", "Germans", List.of(infantry))),
+            List.of(), 1, "combatMove", "Germans", List.of());
+
+    WireStateApplier.apply(gd, wire, idMap);
+
+    final Territory seaZone = gd.getMap().getTerritoryOrNull("112 Sea Zone");
+    assertThat(seaZone).isNotNull();
+    final Unit transportUnit =
+        seaZone.getUnits().stream()
+            .filter(u -> u.getId().equals(idMap.get("u-trn-1")))
+            .findFirst()
+            .orElseThrow();
+    final Territory germanyTerr = gd.getMap().getTerritoryOrNull("Germany");
+    assertThat(germanyTerr).isNotNull();
+    final Unit infantryUnit =
+        germanyTerr.getUnits().stream()
+            .filter(u -> u.getId().equals(idMap.get("u-inf-1")))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(transportUnit.getUnloaded()).containsExactly(infantryUnit);
+    assertThat(infantryUnit.getUnloadedTo()).isNotNull();
+    assertThat(infantryUnit.getUnloadedTo().getName()).isEqualTo("Germany");
+  }
+
+  @Test
+  void transportUnloaded_nullUnloadedToOnCargo_staleEntrySkipped_preventsNpe() {
+    // Defense-in-depth for #2162. Wire state is inconsistent: transport.unloaded = [infantry]
+    // but infantry.unloadedTo = null. This arises when a foreign-owned transport retains its
+    // unloaded list from a prior nation's combat-move phase while the cargo unit's unloadedTo
+    // was cleared because the cargo belongs to the active player. The applier must skip the
+    // stale entry so transport.getUnloaded() is empty, preventing an NPE in
+    // TransportTracker.isTransportUnloadRestrictedToAnotherTerritory.
+    final GameData gd = fresh();
+
+    final WireUnit transport =
+        WireUnit.of(
+            "u-trn-1", "transport", 0, 0, 0, "Germans", null,
+            false, false, false, false, 0, false, false, null,
+            List.of("u-inf-1"), null, false);
+    final WireUnit infantry =
+        WireUnit.of(
+            "u-inf-1", "infantry", 0, 0, 0, "Germans", null,
+            false, false, false, false, 0, false, false, null,
+            null, null, false); // unloadedTo = null — stale cross-nation state
+
+    final WireState wire =
+        new WireState(
+            List.of(
+                new WireTerritory("112 Sea Zone", "Germans", List.of(transport)),
+                new WireTerritory("Germany", "Germans", List.of(infantry))),
+            List.of(), 1, "combatMove", "Germans", List.of());
+
+    WireStateApplier.apply(gd, wire, freshIdMap());
+
+    final Territory seaZone = gd.getMap().getTerritoryOrNull("112 Sea Zone");
+    assertThat(seaZone).isNotNull();
+    final Unit transportUnit =
+        seaZone.getUnits().stream()
+            .filter(u -> u.getType().getName().equals("transport"))
+            .findFirst()
+            .orElseThrow();
+
+    // Stale entry skipped — transport has no unloaded units
+    assertThat(transportUnit.getUnloaded()).isEmpty();
+
+    // Regression: no NPE when TransportTracker interrogates this transport
+    assertThatCode(
+            () ->
+                TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(
+                    transportUnit, seaZone))
+        .doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
## Context

Companion fix for map-room/map-room#2164 (NPE in `TransportTracker.isTransportUnloadRestrictedToAnotherTerritory`).

**Root cause** is in the TS engine (fixed in the companion PR): `game-def.ts` only cleared `unit.unloaded`/`unit.unloadedTo` for the active player's units, leaving foreign-owned transports with stale `unloaded` lists that referenced cargo units whose `unloadedTo` was already cleared.

## This PR: Defense-in-depth

`WireStateApplier.applyUnitProperties` now builds a `wireUnitById` index over all wire units and **skips any cargo entry** from a transport's `unloaded` list where the cargo unit's `unloadedTo` is `null` in the wire state.

This prevents `TransportTracker.isTransportUnloadRestrictedToAnotherTerritory` from receiving a unit with `null getUnloadedTo()` even if a future inconsistency escapes the TS-side primary fix.

## Test Plan

- [x] `WireStateApplierTest` — new test: consistent wire state (`transport.unloaded = [inf]`, `inf.unloadedTo = "Germany"`) round-trips correctly
- [x] `WireStateApplierTest` — new test: inconsistent wire state (`transport.unloaded = [inf]`, `inf.unloadedTo = null`) → `transport.getUnloaded()` empty + `assertThatCode(...).doesNotThrowAnyException()`
- [x] All sidecar tests pass (`./gradlew :game-app:ai-sidecar:test`)