### PR TITLE
fix(sidecar): apply Chinese production frontier from wire state (#2174)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WirePlayer.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WirePlayer.java
@@ -9,6 +9,13 @@ import java.util.List;
  * Wire serialization of a Map Room player. For British, {@code europePus} and {@code pacificPus}
  * carry the split IPC pools (both are present iff Map Room's {@code G.ukEconomies} is set); {@code
  * pus} remains the combined total for backwards compatibility. Absent for non-British players.
+ *
+ * <p>For the Chinese player, {@code productionFrontier} names the TripleA {@link
+ * games.strategy.engine.data.ProductionFrontier} that should be set before running ProPurchaseAi.
+ * Either {@code "productionChinese_Burma_Road_Open"} (Infantry + Artillery) or {@code
+ * "productionChinese_Burma_Road_Closed"} (Infantry only). Absent for all other players. The
+ * canonical GameData defaults to the Open frontier; without this field the sidecar cannot know the
+ * road is closed and always allows Artillery (see map-room#2174).
  */
 public record WirePlayer(
     String playerId,
@@ -16,7 +23,8 @@ public record WirePlayer(
     List<String> tech,
     boolean capitalCaptured,
     @JsonInclude(JsonInclude.Include.NON_NULL) Integer europePus,
-    @JsonInclude(JsonInclude.Include.NON_NULL) Integer pacificPus) {
+    @JsonInclude(JsonInclude.Include.NON_NULL) Integer pacificPus,
+    @JsonInclude(JsonInclude.Include.NON_NULL) String productionFrontier) {
   @JsonCreator
   public WirePlayer(
       @JsonProperty("playerId") final String playerId,
@@ -24,13 +32,15 @@ public record WirePlayer(
       @JsonProperty("tech") final List<String> tech,
       @JsonProperty("capitalCaptured") final boolean capitalCaptured,
       @JsonProperty("europePus") final Integer europePus,
-      @JsonProperty("pacificPus") final Integer pacificPus) {
+      @JsonProperty("pacificPus") final Integer pacificPus,
+      @JsonProperty("productionFrontier") final String productionFrontier) {
     this.playerId = playerId;
     this.pus = pus;
     this.tech = tech == null ? List.of() : tech;
     this.capitalCaptured = capitalCaptured;
     this.europePus = europePus;
     this.pacificPus = pacificPus;
+    this.productionFrontier = productionFrontier;
   }
 
   public WirePlayer(
@@ -38,6 +48,16 @@ public record WirePlayer(
       final int pus,
       final List<String> tech,
       final boolean capitalCaptured) {
-    this(playerId, pus, tech, capitalCaptured, null, null);
+    this(playerId, pus, tech, capitalCaptured, null, null, null);
+  }
+
+  public WirePlayer(
+      final String playerId,
+      final int pus,
+      final List<String> tech,
+      final boolean capitalCaptured,
+      final Integer europePus,
+      final Integer pacificPus) {
+    this(playerId, pus, tech, capitalCaptured, europePus, pacificPus, null);
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -523,6 +523,20 @@ public final class WireStateApplier {
     // lookups rather than a boolean flag on the player. It is accepted on the wire for Map
     // Room's own bookkeeping but is currently a no-op on the Java side. Revisit if a specific
     // executor needs it.
+
+    // China's production frontier must be set explicitly because the canonical GameData defaults to
+    // productionChinese_Burma_Road_Open and the sidecar never fires TripleA's trigger system that
+    // would switch it. Without this, ProPurchaseAi always sees Artillery as available even when the
+    // Burma Road is closed (#2174).
+    if (wp.productionFrontier() != null) {
+      final var frontier =
+          gameData.getProductionFrontierList().getProductionFrontier(wp.productionFrontier());
+      if (frontier == null) {
+        throw new IllegalArgumentException(
+            "Unknown productionFrontier in WireState: " + wp.productionFrontier());
+      }
+      player.setProductionFrontier(frontier);
+    }
   }
 
   private static GamePlayer resolvePlayer(final GameData gameData, final String name) {

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
@@ -900,4 +900,89 @@ class WireStateApplierTest {
                     transportUnit, seaZone))
         .doesNotThrowAnyException();
   }
+
+  // ---------- China production frontier (#2174) ----------
+
+  @Test
+  void appliesProductionFrontierClosedForChinese() {
+    final GameData gd = fresh();
+    // Default canonical XML sets Chinese to productionChinese_Burma_Road_Open.
+    assertThat(gd.getPlayerList().getPlayerId("Chinese").getProductionFrontier().getName())
+        .isEqualTo("productionChinese_Burma_Road_Open");
+
+    final WireState wire =
+        new WireState(
+            List.of(),
+            List.of(
+                new WirePlayer(
+                    "Chinese",
+                    0,
+                    List.of(),
+                    false,
+                    null,
+                    null,
+                    "productionChinese_Burma_Road_Closed")),
+            1,
+            "purchase",
+            "Chinese",
+            List.of());
+    WireStateApplier.apply(gd, wire, freshIdMap());
+
+    assertThat(gd.getPlayerList().getPlayerId("Chinese").getProductionFrontier().getName())
+        .isEqualTo("productionChinese_Burma_Road_Closed");
+  }
+
+  @Test
+  void productionFrontierNullLeavesChineseFrontierUnchanged() {
+    final GameData gd = fresh();
+    final String originalFrontier =
+        gd.getPlayerList().getPlayerId("Chinese").getProductionFrontier().getName();
+
+    final WireState wire =
+        new WireState(
+            List.of(),
+            List.of(new WirePlayer("Chinese", 0, List.of(), false)),
+            1,
+            "purchase",
+            "Chinese",
+            List.of());
+    WireStateApplier.apply(gd, wire, freshIdMap());
+
+    assertThat(gd.getPlayerList().getPlayerId("Chinese").getProductionFrontier().getName())
+        .isEqualTo(originalFrontier);
+  }
+
+  @Test
+  void appliesProductionFrontierOpenForChinese() {
+    final GameData gd = fresh();
+    // Manually force Closed first so we can verify Open restores it.
+    gd.getPlayerList()
+        .getPlayerId("Chinese")
+        .setProductionFrontier(
+            gd.getProductionFrontierList()
+                .getProductionFrontier("productionChinese_Burma_Road_Closed"));
+    assertThat(gd.getPlayerList().getPlayerId("Chinese").getProductionFrontier().getName())
+        .isEqualTo("productionChinese_Burma_Road_Closed");
+
+    final WireState wire =
+        new WireState(
+            List.of(),
+            List.of(
+                new WirePlayer(
+                    "Chinese",
+                    0,
+                    List.of(),
+                    false,
+                    null,
+                    null,
+                    "productionChinese_Burma_Road_Open")),
+            1,
+            "purchase",
+            "Chinese",
+            List.of());
+    WireStateApplier.apply(gd, wire, freshIdMap());
+
+    assertThat(gd.getPlayerList().getPlayerId("Chinese").getProductionFrontier().getName())
+        .isEqualTo("productionChinese_Burma_Road_Open");
+  }
 }


### PR DESCRIPTION
## Summary

- `WirePlayer` gains an optional `productionFrontier` field (Java + Jackson)
- `WireStateApplier.applyPlayer()` calls `GamePlayer.setProductionFrontier()` when the field is present
- 3 new tests in `WireStateApplierTest`: Closed applies, Open restores, null is a no-op

## Root cause

TripleA's Global 1940 XML defines two Chinese production frontiers:
- `productionChinese_Burma_Road_Open` (Infantry + Artillery)
- `productionChinese_Burma_Road_Closed` (Infantry only)

The XML starts China on the **Open** frontier. In a live game, triggers fire at turn start to switch between them based on territory ownership. The sidecar's `WireStateApplier` correctly hydrates territory ownership but never runs the trigger system — so the frontier was stuck on Open and `ProPurchaseAi` always had access to Artillery.

## Fix

The TS side already has `isBurmaRoadOpen(G)` and knows the correct frontier name. We project it onto the wire (`WirePlayer.productionFrontier`) and apply it in `WireStateApplier.applyPlayer()` before `PurchaseExecutor` calls `ProAi.invokePurchaseForSidecar`.

Companion TS PR: map-room/map-room#2175

## Test plan

- [x] `WireStateApplierTest.appliesProductionFrontierClosedForChinese` — verifies frontier switches from Open to Closed
- [x] `WireStateApplierTest.appliesProductionFrontierOpenForChinese` — verifies frontier can be restored to Open
- [x] `WireStateApplierTest.productionFrontierNullLeavesChineseFrontierUnchanged` — null is a no-op (backward compat)
- [x] `./gradlew :game-app:ai-sidecar:test` — full sidecar test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)