### PR TITLE
feat(sidecar): wire InterceptExecutor through ProAi TUV-swing analysis

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/InterceptExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/InterceptExecutor.java
@@ -174,8 +174,7 @@ public final class InterceptExecutor implements DecisionExecutor<InterceptReques
     for (final Unit u : sorted) {
       chosen.add(u);
       current = calc.calculateBattleResults(proData, territory, bombers, chosen, List.of());
-      if (current.getTuvSwing() <= 0
-          && current.getWinPercentage() < (100 - minWinPct)) {
+      if (current.getTuvSwing() <= 0 && current.getWinPercentage() < (100 - minWinPct)) {
         break;
       }
     }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/InterceptExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/InterceptExecutor.java
@@ -1,35 +1,199 @@
 package org.triplea.ai.sidecar.exec;
 
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.ProBattleResult;
+import games.strategy.triplea.ai.pro.util.ProBattleUtils;
+import games.strategy.triplea.ai.pro.util.ProOddsCalculator;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
 import org.triplea.ai.sidecar.AiTraceLogger;
 import org.triplea.ai.sidecar.dto.InterceptPlan;
 import org.triplea.ai.sidecar.dto.InterceptRequest;
 import org.triplea.ai.sidecar.session.Session;
+import org.triplea.ai.sidecar.wire.WireStateApplier;
 
 /**
- * Stub executor for the {@code intercept} decision kind.
+ * Executes an {@code intercept} decision by choosing which pending interceptors to commit to an SBR
+ * air battle using ProAi's TUV-swing analysis.
  *
- * <p>Returns the safe default (no interceptors sent) until ProAI integration is wired. TODO: invoke
- * the ProAI SBR intercept logic once identified (likely related to {@code
- * AbstractProAi.shouldBomberBomb} or a dedicated scramble/intercept method).
+ * <p>The approach parallels {@link ScrambleExecutor} (which uses {@code ProScrambleAi}) but is
+ * self-contained because TripleA's {@code AbstractProAi} does not override {@code
+ * selectUnitsQuery()} — there is no existing ProAi entry point for SBR interception. Instead, this
+ * executor drives {@link ProOddsCalculator} directly:
  *
- * <p>The {@code [AI-TRACE] kind=interceptor-decision} line still emits in the stub state (#2105) so
- * triagers can distinguish "intercept query reached the sidecar but the decision is not yet
- * implemented" from silence. Once the ProAI integration replaces the stub return below, swap {@code
- * reason="stub-not-implemented"} for the real heuristic and pass the real picked set — the helper
- * signature accepts both today.
+ * <ol>
+ *   <li>Simulate the air battle with <em>no</em> interceptors (baseline TUV swing).
+ *   <li>Simulate with <em>all</em> interceptors. If the outcome is no better than baseline, skip.
+ *   <li>Add interceptors one at a time (strongest first) until the defender is winning comfortably
+ *       or we run out of candidates. Return the minimum set that achieves a good outcome.
+ * </ol>
+ *
+ * <h2>Why the simulation uses land-battle combat values</h2>
+ *
+ * <p>{@code ProOddsCalculator.calculateBattleResults} calls TripleA's standard battle simulator,
+ * which uses regular attack/defense values (e.g. bomber att=4, fighter def=4), not the air-battle
+ * reduced values (bomber att=1, fighter def=2) that the actual SBR intercept uses. The TUV
+ * comparison is still directionally correct: fighters dominate bombers under both value sets, so
+ * the analysis reliably identifies when interception is worthwhile.
+ *
+ * <h2>Baseline ProBattleResult sentinel</h2>
+ *
+ * <p>With no interceptors the territory is land attacked only by air units; {@code
+ * ProOddsCalculator} short-circuits and returns {@code ProBattleResult(tuvSwing=-1)} — a sentinel
+ * meaning "no real combat, attacker gains nothing". Any simulation with fighters present produces a
+ * more-negative TUV swing (defender kills expensive bombers), so the comparison reliably detects
+ * improvement.
  */
 public final class InterceptExecutor implements DecisionExecutor<InterceptRequest, InterceptPlan> {
 
   @Override
   public InterceptPlan execute(final Session session, final InterceptRequest request) {
+    final GameData data = session.gameData();
+    final ConcurrentMap<String, UUID> idMap = session.unitIdMap();
+
+    WireStateApplier.apply(data, request.state(), idMap);
+
     final InterceptRequest.InterceptBattle b = request.battle();
+
+    // Build candidate ID lists for trace logging (always emitted, even on short-circuit).
     final List<String> candidateIds = new ArrayList<>(b.pendingInterceptors().size());
     final List<String> candidateTypes = new ArrayList<>(b.pendingInterceptors().size());
     for (final InterceptRequest.PendingInterceptor pi : b.pendingInterceptors()) {
       candidateIds.add(pi.unit().unitId());
       candidateTypes.add(pi.unit().unitType());
+    }
+
+    if (b.pendingInterceptors().isEmpty()) {
+      AiTraceLogger.logSbrInterceptorDecision(
+          b.defenderNation(),
+          b.battleId(),
+          b.territory(),
+          b.attackerNation(),
+          List.of(),
+          List.of(),
+          List.of(),
+          "no-candidates");
+      return new InterceptPlan(List.of());
+    }
+
+    final Territory territory = requireTerritory(data, b.territory());
+
+    // Collect attacker's bombers from the live territory after wire-state application.
+    final GamePlayer attacker = requirePlayer(data, b.attackerNation());
+    final List<Unit> bombers = new ArrayList<>();
+    for (final Unit u : territory.getUnits()) {
+      if (attacker.equals(u.getOwner())) {
+        bombers.add(u);
+      }
+    }
+
+    if (bombers.isEmpty()) {
+      AiTraceLogger.logSbrInterceptorDecision(
+          b.defenderNation(),
+          b.battleId(),
+          b.territory(),
+          b.attackerNation(),
+          candidateIds,
+          candidateTypes,
+          List.of(),
+          "no-bombers-in-territory");
+      return new InterceptPlan(List.of());
+    }
+
+    // Resolve wire interceptors to live Unit objects on their source territories.
+    final List<Unit> candidates = resolveCandidates(data, idMap, b.pendingInterceptors());
+
+    if (candidates.isEmpty()) {
+      AiTraceLogger.logSbrInterceptorDecision(
+          b.defenderNation(),
+          b.battleId(),
+          b.territory(),
+          b.attackerNation(),
+          candidateIds,
+          candidateTypes,
+          List.of(),
+          "no-live-candidates");
+      return new InterceptPlan(List.of());
+    }
+
+    final GamePlayer defender = requirePlayer(data, session.key().nation());
+    ExecutorSupport.ensureProAiInitialized(session, defender);
+    ExecutorSupport.ensureBattleDelegate(data);
+    // Re-bind ProData to the live session GameData. AbstractProAi.scrambleUnitsQuery() calls
+    // initializeData() implicitly, but here we call ProOddsCalculator directly, so we must
+    // trigger the same re-bind to avoid proData.getData() returning null or a stale copy.
+    session.proAi().reinitializeProDataForSidecar();
+
+    final ProOddsCalculator calc = session.proAi().getCalc();
+    final ProData proData = session.proAi().getProData();
+
+    // Baseline: no interceptors. ProOddsCalculator returns ProBattleResult(tuvSwing=-1) for
+    // all-air attacker vs no defenders on a land territory.
+    final ProBattleResult baseline =
+        calc.calculateBattleResults(proData, territory, bombers, List.of(), List.of());
+
+    // Check if any interception helps at all (all interceptors vs none).
+    final ProBattleResult allResult =
+        calc.calculateBattleResults(proData, territory, bombers, candidates, List.of());
+
+    if (allResult.getTuvSwing() >= baseline.getTuvSwing()) {
+      AiTraceLogger.logSbrInterceptorDecision(
+          b.defenderNation(),
+          b.battleId(),
+          b.territory(),
+          b.attackerNation(),
+          candidateIds,
+          candidateTypes,
+          List.of(),
+          "intercept-not-favorable");
+      return new InterceptPlan(List.of());
+    }
+
+    // Add interceptors one at a time (strongest first), stopping when the defense is already
+    // winning comfortably — matching ProScrambleAi's greedy-until-sufficient termination.
+    final List<Unit> sorted = new ArrayList<>(candidates);
+    sorted.sort(
+        Comparator.comparingDouble(
+                (Unit u) ->
+                    ProBattleUtils.estimateStrength(territory, List.of(u), List.of(), false))
+            .reversed());
+
+    final double minWinPct = proData.getMinWinPercentage();
+    final List<Unit> chosen = new ArrayList<>();
+    ProBattleResult current = baseline;
+    for (final Unit u : sorted) {
+      chosen.add(u);
+      current = calc.calculateBattleResults(proData, territory, bombers, chosen, List.of());
+      if (current.getTuvSwing() <= 0
+          && current.getWinPercentage() < (100 - minWinPct)) {
+        break;
+      }
+    }
+
+    // If the incremental result is still no better than baseline, fall back to all interceptors
+    // (we already confirmed allResult < baseline above, so this is always better than none).
+    if (current.getTuvSwing() >= baseline.getTuvSwing()) {
+      chosen.clear();
+      chosen.addAll(candidates);
+    }
+
+    final Map<UUID, String> reverse = reverseIdMap(idMap);
+    final List<String> pickedIds = new ArrayList<>(chosen.size());
+    for (final Unit u : chosen) {
+      final String mrId = reverse.get(u.getId());
+      if (mrId != null) {
+        pickedIds.add(mrId);
+      }
     }
 
     AiTraceLogger.logSbrInterceptorDecision(
@@ -39,9 +203,56 @@ public final class InterceptExecutor implements DecisionExecutor<InterceptReques
         b.attackerNation(),
         candidateIds,
         candidateTypes,
-        /* pickedIds */ List.of(),
-        /* reason */ "stub-not-implemented");
+        pickedIds,
+        "tuv-swing");
+    return new InterceptPlan(pickedIds);
+  }
 
-    return new InterceptPlan(List.of());
+  private static Territory requireTerritory(final GameData data, final String name) {
+    final Territory t = data.getMap().getTerritoryOrNull(name);
+    if (t == null) {
+      throw new IllegalArgumentException("Unknown territory in InterceptRequest: " + name);
+    }
+    return t;
+  }
+
+  private static GamePlayer requirePlayer(final GameData data, final String name) {
+    final GamePlayer p = data.getPlayerList().getPlayerId(name);
+    if (p == null) {
+      throw new IllegalArgumentException("Unknown player in InterceptRequest: " + name);
+    }
+    return p;
+  }
+
+  private static List<Unit> resolveCandidates(
+      final GameData data,
+      final ConcurrentMap<String, UUID> idMap,
+      final Collection<InterceptRequest.PendingInterceptor> pendingInterceptors) {
+    final List<Unit> out = new ArrayList<>();
+    for (final InterceptRequest.PendingInterceptor pi : pendingInterceptors) {
+      final UUID uuid = idMap.get(pi.unit().unitId());
+      if (uuid == null) {
+        continue;
+      }
+      final Territory source = data.getMap().getTerritoryOrNull(pi.fromTerritory());
+      if (source == null) {
+        continue;
+      }
+      for (final Unit u : source.getUnits()) {
+        if (u.getId().equals(uuid)) {
+          out.add(u);
+          break;
+        }
+      }
+    }
+    return out;
+  }
+
+  private static Map<UUID, String> reverseIdMap(final ConcurrentMap<String, UUID> idMap) {
+    final Map<UUID, String> out = new HashMap<>(idMap.size());
+    for (final Map.Entry<String, UUID> e : idMap.entrySet()) {
+      out.put(e.getValue(), e.getKey());
+    }
+    return out;
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/InterceptExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/InterceptExecutorTest.java
@@ -1,0 +1,226 @@
+package org.triplea.ai.sidecar.exec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.dto.InterceptPlan;
+import org.triplea.ai.sidecar.dto.InterceptRequest;
+import org.triplea.ai.sidecar.dto.InterceptRequest.PendingInterceptor;
+import org.triplea.ai.sidecar.session.Session;
+import org.triplea.ai.sidecar.session.SessionKey;
+import org.triplea.ai.sidecar.wire.WireState;
+import org.triplea.ai.sidecar.wire.WireTerritory;
+import org.triplea.ai.sidecar.wire.WireUnit;
+
+class InterceptExecutorTest {
+
+  private static CanonicalGameData canonical;
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+  }
+
+  private Session freshSession(final String nation) {
+    final GameData data = canonical.cloneForSession();
+    final ProAi proAi = new ProAi("sidecar-test-" + nation, nation);
+    return new Session(
+        "s-test-" + UUID.randomUUID(),
+        new SessionKey("g1", nation),
+        42L,
+        proAi,
+        data,
+        new ConcurrentHashMap<>(),
+        Executors.newSingleThreadExecutor());
+  }
+
+  // -------------------------------------------------------------------------
+  // Test 1: No pending interceptors → immediate empty plan, no ProAi call.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void emptyPendingInterceptors_returnsEmptyPlan() {
+    final Session session = freshSession("Germans");
+
+    final WireState wire =
+        new WireState(
+            List.of(
+                new WireTerritory(
+                    "Western Germany",
+                    "Germans",
+                    List.of(new WireUnit("u-usa-bmr-1", "bomber", 0, 0, 0, "Americans")))),
+            List.of(),
+            1,
+            "combat",
+            "Americans",
+            List.of());
+
+    final InterceptRequest req =
+        new InterceptRequest(
+            wire,
+            new InterceptRequest.InterceptBattle(
+                "battle-1",
+                "Western Germany",
+                "Americans",
+                "Germans",
+                List.of() /* no pending interceptors */));
+
+    final InterceptPlan plan = new InterceptExecutor().execute(session, req);
+    assertThat(plan).isNotNull();
+    assertThat(plan.interceptorIds()).isEmpty();
+  }
+
+  // -------------------------------------------------------------------------
+  // Test 2: Bombers in territory + fighters as candidates → plan contains only
+  //   valid fighter IDs from the candidate set.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void bombersPresent_fightersAsInterceptors_planContainsValidIds() {
+    final Session session = freshSession("Germans");
+
+    final WireState wire =
+        new WireState(
+            List.of(
+                // Western Germany: German-owned territory with two American bombers
+                new WireTerritory(
+                    "Western Germany",
+                    "Germans",
+                    List.of(
+                        new WireUnit("u-usa-bmr-1", "bomber", 0, 0, 0, "Americans"),
+                        new WireUnit("u-usa-bmr-2", "bomber", 0, 0, 0, "Americans"))),
+                // Germany: source territory with two German fighters available to intercept
+                new WireTerritory(
+                    "Germany",
+                    "Germans",
+                    List.of(
+                        new WireUnit("u-ger-ftr-1", "fighter", 0, 0),
+                        new WireUnit("u-ger-ftr-2", "fighter", 0, 0)))),
+            List.of(),
+            1,
+            "combat",
+            "Americans",
+            List.of());
+
+    final InterceptRequest req =
+        new InterceptRequest(
+            wire,
+            new InterceptRequest.InterceptBattle(
+                "battle-2",
+                "Western Germany",
+                "Americans",
+                "Germans",
+                List.of(
+                    new PendingInterceptor("Germany", new WireUnit("u-ger-ftr-1", "fighter", 0, 0)),
+                    new PendingInterceptor(
+                        "Germany", new WireUnit("u-ger-ftr-2", "fighter", 0, 0)))));
+
+    final InterceptPlan plan = new InterceptExecutor().execute(session, req);
+    assertThat(plan).isNotNull();
+    assertThat(plan.interceptorIds())
+        .allMatch(id -> id.equals("u-ger-ftr-1") || id.equals("u-ger-ftr-2"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Test 3: Unit-ID round-trip — any IDs emitted in the plan must have been
+  //   registered in the session id map and be a subset of the candidate IDs.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void unitIdRoundTrip_pickedIdsAreSubsetOfCandidates() {
+    final Session session = freshSession("Germans");
+
+    final WireState wire =
+        new WireState(
+            List.of(
+                new WireTerritory(
+                    "Western Germany",
+                    "Germans",
+                    List.of(new WireUnit("u-usa-bmr-RT", "bomber", 0, 0, 0, "Americans"))),
+                new WireTerritory(
+                    "Germany",
+                    "Germans",
+                    List.of(
+                        new WireUnit("u-ger-ftr-RT1", "fighter", 0, 0),
+                        new WireUnit("u-ger-ftr-RT2", "fighter", 0, 0)))),
+            List.of(),
+            1,
+            "combat",
+            "Americans",
+            List.of());
+
+    final InterceptRequest req =
+        new InterceptRequest(
+            wire,
+            new InterceptRequest.InterceptBattle(
+                "battle-rt",
+                "Western Germany",
+                "Americans",
+                "Germans",
+                List.of(
+                    new PendingInterceptor(
+                        "Germany", new WireUnit("u-ger-ftr-RT1", "fighter", 0, 0)),
+                    new PendingInterceptor(
+                        "Germany", new WireUnit("u-ger-ftr-RT2", "fighter", 0, 0)))));
+
+    final InterceptPlan plan = new InterceptExecutor().execute(session, req);
+
+    // All wire IDs were registered in the session map after WireStateApplier ran.
+    assertThat(session.unitIdMap()).containsKeys("u-usa-bmr-RT", "u-ger-ftr-RT1", "u-ger-ftr-RT2");
+
+    // Any IDs the plan emits must be strings we sent in (not UUID.toString()).
+    assertThat(plan.interceptorIds())
+        .allMatch(id -> id.equals("u-ger-ftr-RT1") || id.equals("u-ger-ftr-RT2"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Test 4: No attacker units in the territory → empty plan (no-bombers
+  //   short-circuit fires before calling ProAi).
+  // -------------------------------------------------------------------------
+
+  @Test
+  void noBombersInTerritory_returnsEmptyPlan() {
+    final Session session = freshSession("Germans");
+
+    // Territory has only German units — no American bombers visible in wire.
+    final WireState wire =
+        new WireState(
+            List.of(
+                new WireTerritory(
+                    "Western Germany",
+                    "Germans",
+                    List.of(new WireUnit("u-ger-inf-1", "infantry", 0, 0)))),
+            List.of(),
+            1,
+            "combat",
+            "Americans",
+            List.of());
+
+    final InterceptRequest req =
+        new InterceptRequest(
+            wire,
+            new InterceptRequest.InterceptBattle(
+                "battle-nobombers",
+                "Western Germany",
+                "Americans",
+                "Germans",
+                List.of(
+                    new PendingInterceptor(
+                        "Germany", new WireUnit("u-ger-ftr-nb", "fighter", 0, 0)))));
+
+    final InterceptPlan plan = new InterceptExecutor().execute(session, req);
+    assertThat(plan).isNotNull();
+    assertThat(plan.interceptorIds()).isEmpty();
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/InterceptExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/InterceptExecutorTest.java
@@ -128,6 +128,10 @@ class InterceptExecutorTest {
 
     final InterceptPlan plan = new InterceptExecutor().execute(session, req);
     assertThat(plan).isNotNull();
+    // Acceptance criterion: at least one interceptor must be sent when bombers are
+    // present and fighters are available. Two bombers vs two fighters always favours
+    // interception in TUV terms (fighters are cheaper and have higher combat values).
+    assertThat(plan.interceptorIds()).isNotEmpty();
     assertThat(plan.interceptorIds())
         .allMatch(id -> id.equals("u-ger-ftr-1") || id.equals("u-ger-ftr-2"));
   }
@@ -135,6 +139,7 @@ class InterceptExecutorTest {
   // -------------------------------------------------------------------------
   // Test 3: Unit-ID round-trip — any IDs emitted in the plan must have been
   //   registered in the session id map and be a subset of the candidate IDs.
+  //   Also verifies the acceptance criterion: at least one interceptor is sent.
   // -------------------------------------------------------------------------
 
   @Test
@@ -178,6 +183,9 @@ class InterceptExecutorTest {
 
     // All wire IDs were registered in the session map after WireStateApplier ran.
     assertThat(session.unitIdMap()).containsKeys("u-usa-bmr-RT", "u-ger-ftr-RT1", "u-ger-ftr-RT2");
+
+    // Acceptance criterion: at least one interceptor must be sent (real-state assertion).
+    assertThat(plan.interceptorIds()).isNotEmpty();
 
     // Any IDs the plan emits must be strings we sent in (not UUID.toString()).
     assertThat(plan.interceptorIds())


### PR DESCRIPTION
Closes map-room/map-room#2177

## Summary

- Replaces the `InterceptExecutor` stub (always returned no interceptors) with a real TUV-swing analysis using `ProOddsCalculator`
- `AbstractProAi` has no `selectUnitsQuery` override — so there is no existing ProAi entry point for SBR interception. The executor drives `ProOddsCalculator` directly, paralleling how `ProScrambleAi` works for normal scramble decisions
- Algorithm: (1) baseline with no interceptors → `ProBattleResult(tuvSwing=-1)` sentinel; (2) all interceptors → full simulation; (3) if interception helps, add fighters one at a time (strongest first) until the defense is winning comfortably or candidates exhausted
- Calls `reinitializeProDataForSidecar()` to ensure `proData.getData()` points at the live session `GameData` (same reason PoliticsExecutor does)

## Test plan

- [x] `InterceptExecutorTest` — 4 cases: empty candidates short-circuit, bombers + fighters → valid IDs in plan, unit ID round-trip, no bombers → empty plan
- [x] Full `ai-sidecar` test suite passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)