### PR TITLE
fix(ai): storedFactoryMoveMap null after empty-snapshot restore + persist snapshots to data dir (map-room#2191)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
@@ -44,6 +44,8 @@ import org.triplea.ai.sidecar.wire.WireStateApplier;
 public final class NoncombatMoveExecutor
     implements DecisionExecutor<NoncombatMoveRequest, NoncombatMovePlan> {
 
+  private static final System.Logger LOG = System.getLogger(NoncombatMoveExecutor.class.getName());
+
   private final ProSessionSnapshotStore snapshotStore;
 
   public NoncombatMoveExecutor(final ProSessionSnapshotStore snapshotStore) {
@@ -57,6 +59,13 @@ public final class NoncombatMoveExecutor
     // Step 1: load snapshot once; pre-seed unitIdMap before WireStateApplier runs
     final Optional<games.strategy.triplea.ai.pro.data.ProSessionSnapshot> snapOpt =
         snapshotStore.load(session.key());
+    if (snapOpt.isEmpty()) {
+      LOG.log(
+          System.Logger.Level.WARNING,
+          "[sidecar] snapshot missing for session {0} — purchase may not have run or snapshot was"
+              + " lost (e.g. sidecar restart with non-persistent snapshot dir)",
+          session.key());
+    }
     snapOpt.ifPresent(snap -> ProSessionSnapshotStore.restoreUnitIdMap(snap, session.unitIdMap()));
 
     // Step 2: hydrate GameData from wire state

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionRegistry.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionRegistry.java
@@ -31,13 +31,12 @@ public final class SessionRegistry {
   // Tracks updatedAt per key (used by reaper). Updated by setUpdatedAt.
   private final ConcurrentHashMap<SessionKey, Long> updatedAtMap = new ConcurrentHashMap<>();
 
-  /** Production constructor: data dir defaults to ./data/sessions; snapshot dir to tmpdir. */
+  /**
+   * Production constructor: data dir defaults to {@code ./data/sessions}; snapshots go in {@code
+   * ./data/sessions/snapshots} (same persistent volume as manifests, survives container restart).
+   */
   public SessionRegistry(final CanonicalGameData canonical) {
-    this(
-        canonical,
-        Path.of("data", "sessions"),
-        new ProSessionSnapshotStore(
-            Path.of(System.getProperty("java.io.tmpdir"), "sidecar-snapshots")));
+    this(canonical, Path.of("data", "sessions"));
   }
 
   /** Constructor accepting a custom data dir (used in tests and via SidecarConfig). */

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutorIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutorIntegrationTest.java
@@ -164,9 +164,9 @@ class NoncombatMoveExecutorIntegrationTest {
    * purchase run that leaves {@code storedFactoryMoveMap} null or empty writes an empty map to the
    * snapshot. The old restore guard {@code !snap.factoryMoveMap().isEmpty()} then skipped restore,
    * leaving {@code storedFactoryMoveMap} null. Any subsequent NCM request on a fresh session (after
-   * an ack-timeout, reconnect, or per-turn session cycle) would crash with "storedFactoryMoveMap
-   * is null". Affects any nation where purchase simulation finds no factory territories (e.g.
-   * British with capital captured or all factories damaged).
+   * an ack-timeout, reconnect, or per-turn session cycle) would crash with "storedFactoryMoveMap is
+   * null". Affects any nation where purchase simulation finds no factory territories (e.g. British
+   * with capital captured or all factories damaged).
    */
   @Test
   void emptyFactoryMoveMapInSnapshotRestoresAsNonNull() throws Exception {

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutorIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutorIntegrationTest.java
@@ -2,6 +2,7 @@ package org.triplea.ai.sidecar.exec;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.ai.pro.AbstractProAi;
@@ -152,6 +153,44 @@ class NoncombatMoveExecutorIntegrationTest {
         "storedPurchaseTerritories must not be null after noncombat-move — place executor needs it");
     assertFalse(
         stored.isEmpty(), "storedPurchaseTerritories must be non-empty after noncombat-move");
+  }
+
+  /**
+   * Regression for map-room#2191: {@code restoreFactoryMoveMapFromSnapshot} must set {@code
+   * storedFactoryMoveMap} to a non-null empty map when the snapshot's {@code factoryMoveMap} is
+   * empty, so that {@code storedFactoryMoveMapIsNull()} returns {@code false}.
+   *
+   * <p>Root cause: {@code projectTerritoryMap(null)} returns {@code new HashMap<>()} (empty), so a
+   * purchase run that leaves {@code storedFactoryMoveMap} null or empty writes an empty map to the
+   * snapshot. The old restore guard {@code !snap.factoryMoveMap().isEmpty()} then skipped restore,
+   * leaving {@code storedFactoryMoveMap} null. Any subsequent NCM request on a fresh session (after
+   * an ack-timeout, reconnect, or per-turn session cycle) would crash with "storedFactoryMoveMap
+   * is null". Affects any nation where purchase simulation finds no factory territories (e.g.
+   * British with capital captured or all factories damaged).
+   */
+  @Test
+  void emptyFactoryMoveMapInSnapshotRestoresAsNonNull() throws Exception {
+    // Create a fresh ProAi with storedFactoryMoveMap == null (simulates a new session).
+    final ProAi proAi = new ProAi("sidecar-test-British", "British");
+    final GameData data = canonical.cloneForSession();
+
+    // Assert precondition: storedFactoryMoveMap is null before restore.
+    assertTrue(proAi.storedFactoryMoveMapIsNull(), "storedFactoryMoveMap must start as null");
+
+    // Snapshot with empty factoryMoveMap — exactly what projectTerritoryMap(null or emptyMap)
+    // produces when purchase finds no factory territories.
+    final var emptyFactorySnap =
+        new games.strategy.triplea.ai.pro.data.ProSessionSnapshot(
+            java.util.Map.of(), java.util.Map.of(), java.util.Map.of(), java.util.Map.of());
+
+    proAi.restoreFactoryMoveMapFromSnapshot(emptyFactorySnap, data);
+
+    // After the fix: storedFactoryMoveMap is set to an empty HashMap (non-null).
+    // Before the fix: storedFactoryMoveMap remained null → storedFactoryMoveMapIsNull() == true.
+    assertFalse(
+        proAi.storedFactoryMoveMapIsNull(),
+        "storedFactoryMoveMap must be non-null after restore from empty-factoryMoveMap snapshot"
+            + " (regression: map-room#2191)");
   }
 
   /**

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/ProSessionSnapshotStoreTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/session/ProSessionSnapshotStoreTest.java
@@ -5,16 +5,24 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import games.strategy.triplea.ai.pro.data.ProSessionSnapshot;
+import games.strategy.triplea.settings.ClientSetting;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
 
 class ProSessionSnapshotStoreTest {
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+  }
 
   @TempDir Path dir;
 
@@ -92,6 +100,40 @@ class ProSessionSnapshotStoreTest {
     final ProSessionSnapshotStore store = new ProSessionSnapshotStore(dir);
     // Should not throw
     store.delete(new SessionKey("no-such-game", "Americans"));
+  }
+
+  /**
+   * Regression test for map-room#2191: snapshot must survive a registry recreation so that a second
+   * noncombat-move request after a sidecar restart can find the purchase-phase snapshot.
+   *
+   * <p>Before the fix, the production {@link SessionRegistry} constructor stored snapshots in
+   * {@code java.io.tmpdir} (non-persistent across Docker restarts) while manifests went to a
+   * persistent data dir. After the fix, both live under {@code dataDir} and survive registry
+   * recreation.
+   */
+  @Test
+  void snapshotSurvivesSessionRegistryRecreation() throws Exception {
+    final SessionKey key = new SessionKey("g-restart", "British");
+    final String sessionId = "g-restart:British";
+
+    // First registry instance — simulates sidecar before restart
+    final SessionRegistry reg1 =
+        new SessionRegistry(org.triplea.ai.sidecar.CanonicalGameData.load(), dir);
+    reg1.createOrGet(key, sessionId, 42L);
+    final ProSessionSnapshot snapshot = emptySnapshot();
+    reg1.snapshotStore().save(key, snapshot);
+    assertTrue(reg1.snapshotStore().load(key).isPresent(), "snapshot must exist after save");
+
+    // Second registry instance from the same dir — simulates sidecar restart + rehydrate
+    final SessionRegistry reg2 =
+        new SessionRegistry(org.triplea.ai.sidecar.CanonicalGameData.load(), dir);
+    reg2.rehydrate();
+
+    // The snapshot must still be loadable — this is the invariant that prevents
+    // "storedFactoryMoveMap is null" after a sidecar container restart.
+    assertTrue(
+        reg2.snapshotStore().load(key).isPresent(),
+        "snapshot must survive SessionRegistry recreation (regression: map-room#2191)");
   }
 
   @Test

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -596,8 +596,8 @@ public abstract class AbstractProAi extends AbstractAi {
    * methods.
    *
    * <p>An empty {@code snap.factoryMoveMap()} is treated as "purchase ran but found no factory
-   * territories" (a valid state) and restores {@code storedFactoryMoveMap} to an empty map. This
-   * is distinct from a missing snapshot file (purchase never ran), which the caller handles by not
+   * territories" (a valid state) and restores {@code storedFactoryMoveMap} to an empty map. This is
+   * distinct from a missing snapshot file (purchase never ran), which the caller handles by not
    * calling this method at all. Without this distinction the NCM executor crashes with
    * "storedFactoryMoveMap is null" when British (or any nation) has no factory territories in the
    * purchase-simulation phase — map-room#2191.

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -594,11 +594,21 @@ public abstract class AbstractProAi extends AbstractAi {
    * Restores {@code storedFactoryMoveMap} from a snapshot. No-op if already populated. Call this
    * before dispatching a {@code noncombat-move} decision; do NOT combine with the other restore
    * methods.
+   *
+   * <p>An empty {@code snap.factoryMoveMap()} is treated as "purchase ran but found no factory
+   * territories" (a valid state) and restores {@code storedFactoryMoveMap} to an empty map. This
+   * is distinct from a missing snapshot file (purchase never ran), which the caller handles by not
+   * calling this method at all. Without this distinction the NCM executor crashes with
+   * "storedFactoryMoveMap is null" when British (or any nation) has no factory territories in the
+   * purchase-simulation phase — map-room#2191.
    */
   public void restoreFactoryMoveMapFromSnapshot(
       final ProSessionSnapshot snap, final GameData data) {
-    if (storedFactoryMoveMap == null && !snap.factoryMoveMap().isEmpty()) {
-      storedFactoryMoveMap = restoreTerritoryMap(snap.factoryMoveMap(), data);
+    if (storedFactoryMoveMap == null) {
+      storedFactoryMoveMap =
+          snap.factoryMoveMap().isEmpty()
+              ? new HashMap<>()
+              : restoreTerritoryMap(snap.factoryMoveMap(), data);
     }
   }
 


### PR DESCRIPTION
## Root cause (map-room#2191)

`AbstractProAi.restoreFactoryMoveMapFromSnapshot` had a guard:

```java
if (storedFactoryMoveMap == null && !snap.factoryMoveMap().isEmpty()) {
```

`projectTerritoryMap(null)` returns `new HashMap<>()` (empty), so any purchase run that leaves `storedFactoryMoveMap` null or empty writes an empty `factoryMoveMap` to the snapshot. The `!isEmpty()` guard then **skipped restore**, leaving `storedFactoryMoveMap` null.

Any subsequent NCM request on a fresh session — after an ack-timeout abort, reconnect, or per-turn session cycle — would crash with:

> `storedFactoryMoveMap is null for session British`

This affects any nation where purchase simulation finds no factory territories (e.g. British with capital captured or all factories damaged).

## Fix

Remove the `!isEmpty()` guard. Set `storedFactoryMoveMap = new HashMap<>()` when the snapshot map is empty — an empty, non-null map correctly signals "purchase ran, no factory territories" and satisfies the null-check in `NoncombatMoveExecutor`.

## Defense-in-depth (also in this PR)

`SessionRegistry`'s production constructor was storing snapshots in `java.io.tmpdir/sidecar-snapshots` while manifests went to the persistent `data/sessions` volume. Even without a container restart the paths diverged. Snapshots now live under `data/sessions/snapshots/` — same persistent volume as manifests.

## Tests

- `NoncombatMoveExecutorIntegrationTest.emptyFactoryMoveMapInSnapshotRestoresAsNonNull` — directly reproduces the root cause: fresh ProAi + empty-factoryMoveMap snapshot → `storedFactoryMoveMapIsNull()` must return `false` after restore.
- `ProSessionSnapshotStoreTest.snapshotSurvivesSessionRegistryRecreation` — regression for the persistent-volume bug.
- Full `ai-sidecar` test suite passes.

Closes map-room/map-room#2191