### PR TITLE
fix(sidecar): deduct repair IPC from unit-purchase budget (map-room#2194)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingPurchaseDelegate.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingPurchaseDelegate.java
@@ -51,12 +51,21 @@ public final class RecordingPurchaseDelegate extends PurchaseDelegate {
   }
 
   /**
-   * Captures the repair map. Does NOT call {@code super.purchaseRepair()} for the same reason as
-   * {@link #purchase}. Always returns {@code null} (success).
+   * Captures the repair map and forwards to {@code super.purchaseRepair()} to deduct repair IPC
+   * from {@code player.getResources()} via {@link
+   * games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge#addChange}. This mirrors what
+   * the real {@link games.strategy.triplea.delegate.PurchaseDelegate} does and is necessary so
+   * that the subsequent {@code ProPurchaseAi.purchase()} call initialises its {@link
+   * games.strategy.triplea.ai.pro.data.ProResourceTracker} with the correct post-repair budget.
+   *
+   * <p>Unlike {@link #purchase}, calling {@code super.purchaseRepair()} is safe here: repair does
+   * NOT add new units to the player's holding pool (it only reduces unit damage and deducts PUs),
+   * so no double-injection occurs in {@link
+   * games.strategy.triplea.ai.pro.AbstractProAi#invokePlaceForSidecar}.
    */
   @Override
   public @Nullable String purchaseRepair(final Map<Unit, IntegerMap<RepairRule>> productionRules) {
     this.capturedRepair = Map.copyOf(productionRules);
-    return null;
+    return super.purchaseRepair(productionRules);
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingPurchaseDelegate.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingPurchaseDelegate.java
@@ -53,9 +53,9 @@ public final class RecordingPurchaseDelegate extends PurchaseDelegate {
   /**
    * Captures the repair map and forwards to {@code super.purchaseRepair()} to deduct repair IPC
    * from {@code player.getResources()} via {@link
-   * games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge#addChange}. This mirrors what
-   * the real {@link games.strategy.triplea.delegate.PurchaseDelegate} does and is necessary so
-   * that the subsequent {@code ProPurchaseAi.purchase()} call initialises its {@link
+   * games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge#addChange}. This mirrors what the
+   * real {@link games.strategy.triplea.delegate.PurchaseDelegate} does and is necessary so that the
+   * subsequent {@code ProPurchaseAi.purchase()} call initialises its {@link
    * games.strategy.triplea.ai.pro.data.ProResourceTracker} with the correct post-repair budget.
    *
    * <p>Unlike {@link #purchase}, calling {@code super.purchaseRepair()} is safe here: repair does

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
@@ -121,8 +121,8 @@ class PurchaseExecutorTest {
    * budget. Before the fix, {@link RecordingPurchaseDelegate#purchaseRepair} captured but did NOT
    * deduct repair IPC from {@code player.getResources()}, so {@code ProPurchaseAi.purchase()}
    * initialized its {@link games.strategy.triplea.ai.pro.data.ProResourceTracker} with the full
-   * pre-repair budget. Combined cost (repair + unit buys) could then exceed available IPC →
-   * engine rejected "ran out of IPC".
+   * pre-repair budget. Combined cost (repair + unit buys) could then exceed available IPC → engine
+   * rejected "ran out of IPC".
    */
   @Test
   void repairCostDeductedFromUnitBudgetWhenFactoryIsDamaged() {
@@ -145,18 +145,15 @@ class PurchaseExecutorTest {
 
     final int startingPus = player.getResources().getQuantity(pus);
 
-    final PurchasePlan plan = new PurchaseExecutor().execute(session, purchaseRequestFor("Germans"));
+    final PurchasePlan plan =
+        new PurchaseExecutor().execute(session, purchaseRequestFor("Germans"));
 
     // ProAi must have decided to repair (the factory has damage and the player can afford it).
-    assertThat(plan.repairs())
-        .as("ProAi should repair the damaged factory")
-        .isNotEmpty();
+    assertThat(plan.repairs()).as("ProAi should repair the damaged factory").isNotEmpty();
 
     // Repair cost is 1 PU per damage point (Global 1940 standard).
     final int repairCost =
-        plan.repairs().stream()
-            .mapToInt(org.triplea.ai.sidecar.dto.RepairOrder::repairCount)
-            .sum();
+        plan.repairs().stream().mapToInt(org.triplea.ai.sidecar.dto.RepairOrder::repairCount).sum();
     final int unitCost = totalCost(data, plan);
 
     assertThat(repairCost + unitCost)

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
@@ -7,10 +7,13 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.NamedAttachable;
 import games.strategy.engine.data.ProductionRule;
 import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.settings.ClientSetting;
 import java.util.List;
 import java.util.UUID;
@@ -111,6 +114,56 @@ class PurchaseExecutorTest {
         new PurchaseExecutor().execute(session, purchaseRequestFor("Germans"));
 
     assertThat(totalCost(data, plan)).isEqualTo(0);
+  }
+
+  /**
+   * Regression for map-room#2194: factory repair cost must be deducted from the unit-purchase
+   * budget. Before the fix, {@link RecordingPurchaseDelegate#purchaseRepair} captured but did NOT
+   * deduct repair IPC from {@code player.getResources()}, so {@code ProPurchaseAi.purchase()}
+   * initialized its {@link games.strategy.triplea.ai.pro.data.ProResourceTracker} with the full
+   * pre-repair budget. Combined cost (repair + unit buys) could then exceed available IPC →
+   * engine rejected "ran out of IPC".
+   */
+  @Test
+  void repairCostDeductedFromUnitBudgetWhenFactoryIsDamaged() {
+    final Session session = freshSession("Germans");
+    final GameData data = session.gameData();
+    final Resource pus = data.getResourceList().getResourceOrThrow(Constants.PUS);
+    final GamePlayer player = data.getPlayerList().getPlayerId("Germans");
+
+    // Apply 7 points of SBR damage to Germany's factory.
+    final Territory germany = data.getMap().getTerritoryOrThrow("Germany");
+    final Unit factory =
+        germany.getUnitCollection().stream()
+            .filter(Matches.unitCanProduceUnitsAndCanBeDamaged())
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No damageable factory found in Germany"));
+    final int factoryDamage = 7;
+    final var damageMap = new org.triplea.java.collections.IntegerMap<Unit>();
+    damageMap.put(factory, factoryDamage);
+    data.performChange(ChangeFactory.bombingUnitDamage(damageMap, List.of(germany)));
+
+    final int startingPus = player.getResources().getQuantity(pus);
+
+    final PurchasePlan plan = new PurchaseExecutor().execute(session, purchaseRequestFor("Germans"));
+
+    // ProAi must have decided to repair (the factory has damage and the player can afford it).
+    assertThat(plan.repairs())
+        .as("ProAi should repair the damaged factory")
+        .isNotEmpty();
+
+    // Repair cost is 1 PU per damage point (Global 1940 standard).
+    final int repairCost =
+        plan.repairs().stream()
+            .mapToInt(org.triplea.ai.sidecar.dto.RepairOrder::repairCount)
+            .sum();
+    final int unitCost = totalCost(data, plan);
+
+    assertThat(repairCost + unitCost)
+        .as(
+            "repair (%d) + unit buys (%d) must not exceed starting IPC (%d)",
+            repairCost, unitCost, startingPus)
+        .isLessThanOrEqualTo(startingPus);
   }
 
   @Test

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/RecordingPurchaseDelegateTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/RecordingPurchaseDelegateTest.java
@@ -6,9 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.ProductionRule;
 import games.strategy.engine.data.RepairRule;
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge;
 import games.strategy.triplea.delegate.PurchaseDelegate;
 import games.strategy.triplea.settings.ClientSetting;
 import java.util.Map;
@@ -50,7 +53,16 @@ class RecordingPurchaseDelegateTest {
 
   @Test
   void capturesRepairMap() {
+    // purchaseRepair() now calls super so it needs a live bridge+player context.
+    // Use an empty repair map (no units to repair) so super returns null immediately
+    // after the canAfford + property check, without modifying any game state.
+    final GameData data = canonical.cloneForSession();
+    final GamePlayer player = data.getPlayerList().getPlayerId("Germans");
+    final ProAi proAi = new ProAi("test", "Germans");
     final RecordingPurchaseDelegate d = new RecordingPurchaseDelegate();
+    d.initialize("purchase", "Purchase");
+    d.setDelegateBridgeAndPlayer(new ProDummyDelegateBridge(proAi, player, data));
+
     final Map<Unit, IntegerMap<RepairRule>> input = Map.of();
     assertNull(d.purchaseRepair(input));
     assertNotNull(d.capturedRepair());


### PR DESCRIPTION
## Root cause

`RecordingPurchaseDelegate.purchaseRepair()` captured the repair map but did **not** call `super.purchaseRepair()`. Because `ProDummyDelegateBridge.addChange()` applies changes to game state via `gameData.performChange()`, not calling super meant `player.getResources()` was never updated.

When `ProPurchaseAi.purchase()` ran next, it created its `ProResourceTracker` from `player.getResources()` and saw the **full pre-repair IPC**. ProAi then planned unit buys against that inflated budget, and the combined cost (repair IPC + unit IPC) exceeded what the player actually had → TripleA engine rejected: **"ran out of IPC"**.

Observed on matchID `EZwXFWnmSLb`: Germans had 7 damage on factory → 7 IPC repair → unit purchases overran budget by 7.

## Fix

Call `super.purchaseRepair()` after capturing. `ProDummyDelegateBridge.addChange()` ensures the IPC deduction and unit-damage repair are applied to the session's `GameData`, matching what the real `PurchaseDelegate` does.

Unlike `purchase()` (which adds new units to the holding pool — a double-injection risk), `purchaseRepair()` only reduces unit damage and deducts IPC. Calling `super` is therefore safe; no units are injected a second time in `invokePlaceForSidecar`.

## Tests

- **`PurchaseExecutorTest.repairCostDeductedFromUnitBudgetWhenFactoryIsDamaged`** — new regression test: sets 7 damage on Germany's factory, runs purchase, asserts `repair_cost + unit_cost ≤ starting_IPC`. This was the direct repro of map-room#2194.
- **`RecordingPurchaseDelegateTest.capturesRepairMap`** — updated to set up a proper bridge+player context (required now that `purchaseRepair` calls super).
- Full `ai-sidecar` test suite: green.

Closes map-room/map-room#2194