### PR TITLE
fix(sidecar): clear player holding pool on wire apply (#2210)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -498,6 +498,17 @@ public final class WireStateApplier {
       final GameData gameData, final WirePlayer wp, final CompositeChange out) {
     final GamePlayer player = resolvePlayer(gameData, wp.playerId());
 
+    // Clear the player's unit collection (holding pool). In a normal TripleA turn the holding
+    // pool is empty between phases — any units present here are from a prior place-phase
+    // simulation (invokePlaceForSidecar) where §20 validation rejected the placement so the unit
+    // was never moved to the territory. Without this clear, stale units accumulate across turns
+    // and inflate subsequent place-phase outputs (map-room#2210).
+    final List<games.strategy.engine.data.Unit> holdingPool =
+        new ArrayList<>(player.getUnitCollection().getUnits());
+    if (!holdingPool.isEmpty()) {
+      out.add(ChangeFactory.removeUnits(player, holdingPool));
+    }
+
     final Resource pus = gameData.getResourceList().getResourceOrThrow("PUs");
     final int current = player.getResources().getQuantity(pus);
     final int delta = wp.pus() - current;

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
@@ -5,8 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.settings.ClientSetting;
 import java.util.List;
@@ -984,5 +987,50 @@ class WireStateApplierTest {
 
     assertThat(gd.getPlayerList().getPlayerId("Chinese").getProductionFrontier().getName())
         .isEqualTo("productionChinese_Burma_Road_Open");
+  }
+
+  /**
+   * Regression for map-room#2210: phantom units left in a player's holding pool (e.g. from a failed
+   * invokePlaceForSidecar where §20 validation rejected the placement) must be cleared when
+   * WireStateApplier applies the next turn's wire state.
+   *
+   * <p>Before the fix: {@link WireStateApplier#applyPlayer} reconciled PUs and tech but never
+   * touched the holding pool. Stale units accumulated there across HTTP request cycles, inflating
+   * subsequent place-phase outputs and causing false "factory_minor at Kwangtung" log entries.
+   */
+  @Test
+  void holdingPoolClearedWhenWireApplied() {
+    final GameData gd = fresh();
+    final GamePlayer germans = gd.getPlayerList().getPlayerId("Germans");
+
+    // Simulate what invokePlaceForSidecar does: add a unit to the holding pool before placement.
+    // In the failure case (§20 validation rejects the place), the unit stays in the holding pool
+    // rather than being moved to the territory.
+    final UnitType infantry = gd.getUnitTypeList().getUnitTypeOrThrow("infantry");
+    final Unit phantomUnit = infantry.create(1, germans).get(0);
+    gd.performChange(ChangeFactory.addUnits(germans, List.of(phantomUnit)));
+    assertThat(germans.getUnitCollection().getUnits())
+        .as("precondition: phantom in holding pool")
+        .hasSize(1);
+
+    // Apply a wire state for the next turn — the holding pool is always empty between turns.
+    // The wire state includes the Germans player (with their current PUs) but no holding-pool
+    // units.
+    final int currentPus = germans.getResources().getQuantity("PUs");
+    final WireState wire =
+        new WireState(
+            List.of(),
+            List.of(new WirePlayer("Germans", currentPus, List.of(), false)),
+            1,
+            "purchase",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, wire, freshIdMap());
+
+    assertThat(germans.getUnitCollection().getUnits())
+        .as(
+            "holding pool must be empty after wire apply — phantom from failed place must be"
+                + " cleared (regression: map-room#2210)")
+        .isEmpty();
   }
 }


### PR DESCRIPTION
## Root Cause

When `invokePlaceForSidecar` runs a purchase/place simulation, it adds units to the player's holding pool (`player.getUnitCollection()`) then calls `RecordingPlaceDelegate.placeUnits()`. If the engine rejects the placement (§20 validation fails), those units stay in the holding pool — `super.placeUnits()` returns an error string but leaves the pool dirty.

`WireStateApplier.applyPlayer()` previously reconciled PUs and tech but never touched the holding pool. Each new turn's wire-apply left the stale units in place, causing them to accumulate.

## Fix

Clear the holding pool at the start of `applyPlayer()`:

```java
// Clear phantom units from the player's holding pool. In a normal TripleA turn the holding
// pool is empty between HTTP request boundaries — any units present are stale from a prior
// place-phase simulation (e.g. invokePlaceForSidecar). Without this clear, failed or
// engine-rejected placements accumulate across turns (map-room#2210).
final List<games.strategy.engine.data.Unit> holdingPool =
    new ArrayList<>(player.getUnitCollection().getUnits());
if (!holdingPool.isEmpty()) {
    out.add(ChangeFactory.removeUnits(player, holdingPool));
}
```

This restores the normal TripleA invariant that a player's holding pool is empty between turn boundaries.

## Test

Added `holdingPoolClearedWhenWireApplied()` to `WireStateApplierTest`: seeds a phantom infantry into the Germans' holding pool on a real `GLOBAL1940` `GameData`, calls `WireStateApplier.apply()`, and asserts the pool is empty afterward.

## Test Plan

- [x] `./gradlew :game-app:ai-sidecar:test` passes (targeted run confirmed)
- [x] Spotless applied — no formatting violations
- [x] New regression test `holdingPoolClearedWhenWireApplied` fails before fix, passes after

Closes #2210