### PR TITLE
fix(sidecar): clear stale transport.unloaded + guard null unloadedTo in RemoveUnitsHistoryChange

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -456,10 +456,19 @@ public final class WireStateApplier {
               }
             }
           }
-          if (!unloadedUnits.isEmpty() && !unloadedUnits.equals(unit.getUnloaded())) {
+          // Always reconcile even when all cargo was filtered (#2268): dropping
+          // !unloadedUnits.isEmpty() ensures a stale unloaded list is cleared when every
+          // referenced cargo unit is dead or has no unloadedTo. Without this, worker GameData
+          // retains the stale list, and RemoveUnitsHistoryChange hits a NPE when it calls
+          // unloadedUnit.getUnloadedTo() and finds null.
+          if (!unloadedUnits.equals(unit.getUnloaded())) {
             changes.add(
                 ChangeFactory.unitPropertyChange(unit, unloadedUnits, Unit.PropertyName.UNLOADED));
           }
+        } else if (!unit.getUnloaded().isEmpty()) {
+          // Wire says no unloaded cargo (null/empty) but Java still has a stale list — clear it.
+          changes.add(
+              ChangeFactory.unitPropertyChange(unit, List.of(), Unit.PropertyName.UNLOADED));
         }
 
         final String wireTransportedById = wu.transportedBy();

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTest.java
@@ -904,6 +904,237 @@ class WireStateApplierTest {
         .doesNotThrowAnyException();
   }
 
+  /**
+   * Regression for #2268: when cargo dies between combat-move and NCM, the wire transport still
+   * lists the dead unit's ID in its {@code unloaded} array (TS engine doesn't clean up transport
+   * refs on unit deletion). The second apply must clear the transport's Java {@code unloaded} list
+   * so that battle-calculator workers don't inherit a stale list with null {@code unloadedTo},
+   * which causes NPE in {@code RemoveUnitsHistoryChange} during NCM odds simulation.
+   */
+  @Test
+  void transportUnloaded_deadCargoAbsentFromWire_staleUnloadedListCleared() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+
+    // Apply 1 (combat-move): transport references infantry, infantry has unloadedTo=Germany.
+    final WireUnit transportApply1 =
+        WireUnit.of(
+            "u-trn-1",
+            "transport",
+            0,
+            0,
+            0,
+            "Germans",
+            null,
+            false,
+            false,
+            false,
+            false,
+            0,
+            false,
+            false,
+            null,
+            List.of("u-inf-1"),
+            null,
+            false);
+    final WireUnit infantryApply1 =
+        WireUnit.of(
+            "u-inf-1",
+            "infantry",
+            0,
+            0,
+            0,
+            "Germans",
+            null,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+            false,
+            null,
+            null,
+            "Germany",
+            false);
+
+    final WireState wireA =
+        new WireState(
+            List.of(
+                new WireTerritory("112 Sea Zone", "Germans", List.of(transportApply1)),
+                new WireTerritory("Germany", "Germans", List.of(infantryApply1))),
+            List.of(),
+            1,
+            "combatMove",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, wireA, idMap);
+
+    final Territory seaZone = gd.getMap().getTerritoryOrNull("112 Sea Zone");
+    assertThat(seaZone).isNotNull();
+    final Unit transportUnit =
+        seaZone.getUnits().stream()
+            .filter(u -> u.getId().equals(idMap.get("u-trn-1")))
+            .findFirst()
+            .orElseThrow();
+    // Precondition: after apply 1, transport has infantry in unloaded list.
+    assertThat(transportUnit.getUnloaded()).hasSize(1);
+
+    // Apply 2 (NCM): infantry was killed in battle — absent from wire entirely.
+    // Transport's wire state still says unloaded=['u-inf-1'] (TS engine doesn't clean up
+    // transport.unloaded on unit deletion). All entries are absent from wireUnitById so the
+    // #2162 guard skips them, producing an empty resolved list. The fix must apply that
+    // empty list to clear the stale Java unloaded state.
+    final WireUnit transportApply2 =
+        WireUnit.of(
+            "u-trn-1",
+            "transport",
+            0,
+            0,
+            0,
+            "Germans",
+            null,
+            false,
+            false,
+            false,
+            false,
+            0,
+            false,
+            false,
+            null,
+            List.of("u-inf-1"),
+            null,
+            false);
+
+    final WireState wireB =
+        new WireState(
+            List.of(new WireTerritory("112 Sea Zone", "Germans", List.of(transportApply2))),
+            List.of(),
+            1,
+            "nonCombatMove",
+            "Germans",
+            List.of());
+    WireStateApplier.apply(gd, wireB, idMap);
+
+    // Stale unloaded list must be cleared — transport has no dead cargo (#2268 regression fence).
+    assertThat(transportUnit.getUnloaded())
+        .as(
+            "transport.unloaded must be empty after NCM wire apply when cargo was killed"
+                + " — stale list causes NPE in RemoveUnitsHistoryChange (regression: #2268)")
+        .isEmpty();
+  }
+
+  /**
+   * Regression for #2268 (else branch): when wire sends an empty/null unloaded list but Java
+   * transport still has stale cargo from a prior apply, the stale list must be cleared.
+   */
+  @Test
+  void transportUnloaded_emptyOnWire_clearsStaleJavaUnloadedList() {
+    final GameData gd = fresh();
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+
+    // Apply 1: establish unloaded relationship.
+    final WireUnit transportApply1 =
+        WireUnit.of(
+            "u-trn-1",
+            "transport",
+            0,
+            0,
+            0,
+            "Germans",
+            null,
+            false,
+            false,
+            false,
+            false,
+            0,
+            false,
+            false,
+            null,
+            List.of("u-inf-1"),
+            null,
+            false);
+    final WireUnit infantryApply1 =
+        WireUnit.of(
+            "u-inf-1",
+            "infantry",
+            0,
+            0,
+            0,
+            "Germans",
+            null,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+            false,
+            null,
+            null,
+            "Germany",
+            false);
+
+    WireStateApplier.apply(
+        gd,
+        new WireState(
+            List.of(
+                new WireTerritory("112 Sea Zone", "Germans", List.of(transportApply1)),
+                new WireTerritory("Germany", "Germans", List.of(infantryApply1))),
+            List.of(),
+            1,
+            "combatMove",
+            "Germans",
+            List.of()),
+        idMap);
+
+    final Territory seaZone = gd.getMap().getTerritoryOrNull("112 Sea Zone");
+    assertThat(seaZone).isNotNull();
+    final Unit transportUnit =
+        seaZone.getUnits().stream()
+            .filter(u -> u.getId().equals(idMap.get("u-trn-1")))
+            .findFirst()
+            .orElseThrow();
+    assertThat(transportUnit.getUnloaded()).hasSize(1);
+
+    // Apply 2: transport wire sends null unloaded (NCM phase — no unload happened yet).
+    final WireUnit transportApply2 =
+        WireUnit.of(
+            "u-trn-1",
+            "transport",
+            0,
+            0,
+            0,
+            "Germans",
+            null,
+            false,
+            false,
+            false,
+            false,
+            0,
+            false,
+            false,
+            null,
+            null, // unloaded = null on wire
+            null,
+            false);
+
+    WireStateApplier.apply(
+        gd,
+        new WireState(
+            List.of(new WireTerritory("112 Sea Zone", "Germans", List.of(transportApply2))),
+            List.of(),
+            1,
+            "nonCombatMove",
+            "Germans",
+            List.of()),
+        idMap);
+
+    assertThat(transportUnit.getUnloaded())
+        .as("stale Java unloaded list must be cleared when wire sends null unloaded (#2268)")
+        .isEmpty();
+  }
+
   // ---------- China production frontier (#2174) ----------
 
   @Test

--- a/game-app/game-core/src/main/java/games/strategy/engine/history/change/units/RemoveUnitsHistoryChange.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/history/change/units/RemoveUnitsHistoryChange.java
@@ -77,9 +77,15 @@ public class RemoveUnitsHistoryChange implements HistoryChange {
       for (Unit unloadedUnit : u.getUnloaded()) {
         oldUnits.add(unloadedUnit);
         allUnloadedUnits.add(unloadedUnit);
-        unloadedUnits
-            .computeIfAbsent(unloadedUnit.getUnloadedTo(), k -> new ArrayList<>())
-            .add(unloadedUnit);
+        // Guard against null unloadedTo: stale transport.unloaded entries (cargo that was
+        // killed before NCM) can have getUnloadedTo()==null; a null map key causes NPE in
+        // perform() via ChangeFactory.removeUnits(null, …). Skip — the unit is already
+        // in oldUnits and will be removed from the transport's current territory (#2268).
+        if (unloadedUnit.getUnloadedTo() != null) {
+          unloadedUnits
+              .computeIfAbsent(unloadedUnit.getUnloadedTo(), k -> new ArrayList<>())
+              .add(unloadedUnit);
+        }
       }
     }
 


### PR DESCRIPTION
Closes map-room/map-room#2268

## Root cause

Japan's NCM phase was silently skipped (0 moves dispatched) due to a `NullPointerException` deep in `ProOddsCalculator → MustFightBattle.removeUnits → RemoveUnitsHistoryChange`.

The failure chain:
1. Infantry unloads from a transport during combat-move. Wire sets `transport.unloaded=['u-inf-1']` and `infantry.unloadedTo='Japan'`. `WireStateApplier` correctly sets `transport.getUnloaded()=[java_infantry]`.
2. Infantry is killed in battle. The TS engine removes it from `G.units` but **does not** clean up `transport.unloaded`. So the NCM wire still carries `transport.unloaded=['u-inf-1']`, but `u-inf-1` is absent from all territories.
3. In `applyUnitProperties`, the existing `#2162` guard fires (`cargoWu == null → continue`), filtering out all cargo. The resolved `unloadedUnits` list is empty. But the old condition `!unloadedUnits.isEmpty() && ...` short-circuits — the empty list is **never applied** and the transport's stale `[java_infantry]` persists in Java.
4. `prepareData` serializes the session's `GameData` into battle-calculator workers. Each worker gets a copy of `transport` with `getUnloaded()=[worker_infantry]`, but `worker_infantry.getUnloadedTo()` is `null` (cleared by the NCM `onBegin` hook on the Map Room side, which the sidecar never sees).
5. `RemoveUnprotectedUnits` kills the unescorted transport → `RemoveUnitsHistoryChange(transport)` → iterates `transport.getUnloaded()` → calls `computeIfAbsent(null, ...)` → NPE in `perform()` via `ChangeFactory.removeUnits(null_territory, ...)`.

## Fix

**`WireStateApplier.applyUnitProperties`** (primary fix):
- Drop `!unloadedUnits.isEmpty() &&` from the update condition so that an empty resolved list is applied, clearing the stale `unloaded` state.
- Add an `else if (!unit.getUnloaded().isEmpty())` branch for when `wu.unloaded()` is null/empty but Java still has stale cargo — clears it.

**`RemoveUnitsHistoryChange` constructor** (defense-in-depth):
- Null-guard on `unloadedUnit.getUnloadedTo()` before `computeIfAbsent` to prevent NPE if stale state ever slips through again.

## Tests

Two new regression tests in `WireStateApplierTest`:
- `transportUnloaded_deadCargoAbsentFromWire_staleUnloadedListCleared` — two-apply scenario: apply 1 establishes the transport→cargo relationship, apply 2 omits the dead cargo; asserts `transport.getUnloaded()` is empty after apply 2.
- `transportUnloaded_emptyOnWire_clearsStaleJavaUnloadedList` — same two-apply setup but wire sends `unloaded=null` on the second apply; asserts the else-branch also clears the stale list.

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:spotlessApply :game-app:game-core:spotlessApply` — clean
- [x] `./gradlew :game-app:ai-sidecar:test` — 33 `WireStateApplierTest` cases pass, full sidecar suite clean
- [x] New regression tests `transportUnloaded_deadCargoAbsentFromWire_staleUnloadedListCleared` and `transportUnloaded_emptyOnWire_clearsStaleJavaUnloadedList` both pass
- [ ] 🧑 Manual: trigger Japan NCM with a transport that had unloaded infantry killed in the preceding combat phase; verify NCM moves are dispatched and no NPE appears in sidecar logs