### PR TITLE
fix(ai-sidecar): tolerate unknown wire properties + structured 400 logging + WirePlayer.purchasedUnits (closes map-room/map-room#2305)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
@@ -269,7 +269,19 @@ public final class DecisionHandler implements HttpHandler {
     try {
       request = JsonBodies.readValue(body, DecisionRequest.class);
     } catch (final IOException e) {
-      LOG.log(System.Logger.Level.ERROR, "Decision bad-request: JSON deserialization failed", e);
+      // Structured WARN per map-room#2305 (matches SessionLifecycleHandler.handleUpdate
+      // pattern). The decision endpoint's error body envelope (DecisionError) is a
+      // wire-contract type — it currently has no detail field, so we keep returning
+      // the opaque 400 here; the structured log gives the server-side diagnostic and
+      // the bot's response-body capture (#2306) remains useful for the response shape
+      // it does carry. Extending DecisionError with a `message` field is a separate
+      // coordinated TS+Java change and is out of scope for #2305.
+      LOG.log(
+          System.Logger.Level.WARNING,
+          "[sidecar] decision validation failed matchID={0} exClass={1} message={2} bodyBytes={3}",
+          new Object[] {
+            match.get().sessionId(), e.getClass().getSimpleName(), e.getMessage(), body.length()
+          });
       writeJson(exchange, 400, JsonBodies.errorBody("bad-request"));
       return;
     }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/JsonBodies.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/JsonBodies.java
@@ -1,6 +1,7 @@
 package org.triplea.ai.sidecar.http;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import org.triplea.ai.sidecar.dto.DecisionError;
@@ -8,7 +9,23 @@ import org.triplea.ai.sidecar.dto.DecisionPlan;
 import org.triplea.ai.sidecar.dto.DecisionReady;
 
 public final class JsonBodies {
-  public static final ObjectMapper MAPPER = new ObjectMapper();
+  /**
+   * Wire-surface ObjectMapper. Configured with {@code FAIL_ON_UNKNOWN_PROPERTIES=false} so additive
+   * TS-side wire-schema changes (new optional fields on {@code WirePlayer}, {@code WireUnit}, etc.)
+   * deserialize cleanly even before the Java POJO catches up.
+   *
+   * <p>This addresses the class of bug from map-room#2301 / map-room#2305: a TS-side wire emit of a
+   * previously-unknown field (in that case {@code WirePlayer.purchasedUnits}) caused Jackson to
+   * throw {@code UnrecognizedPropertyException}, which surfaced as opaque {@code 400 bad-request}
+   * on every {@code /session/{id}/update} call, which the bot mishandled by falling back to {@code
+   * skip*} moves with empty plans — silently burning AI turns.
+   *
+   * <p>The other two ObjectMappers in the sidecar ({@code ProSessionSnapshotStore.MAPPER}, {@code
+   * SessionStore.MAPPER}) are intentionally left strict — those files have schemas the sidecar
+   * fully owns, so unknown properties there indicate a real bug.
+   */
+  public static final ObjectMapper MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   private JsonBodies() {}
 

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/SessionCreateHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/SessionCreateHandler.java
@@ -18,6 +18,8 @@ import org.triplea.ai.sidecar.wire.SessionCreateResponse;
  * created=false} without reinitialising ProData.
  */
 public final class SessionCreateHandler implements HttpHandler {
+  private static final System.Logger LOG = System.getLogger(SessionCreateHandler.class.getName());
+
   private final SessionRegistry registry;
 
   public SessionCreateHandler(final SessionRegistry registry) {
@@ -36,7 +38,12 @@ public final class SessionCreateHandler implements HttpHandler {
     try {
       req = JsonBodies.readValue(body, SessionCreateRequest.class);
     } catch (final IOException e) {
-      writeJson(exchange, 400, JsonBodies.errorBody("bad-request", "invalid JSON body"));
+      // Structured WARN per map-room#2305 — see SessionLifecycleHandler.handleUpdate.
+      LOG.log(
+          System.Logger.Level.WARNING,
+          "[sidecar] sessions create validation failed exClass={0} message={1} bodyBytes={2}",
+          new Object[] {e.getClass().getSimpleName(), e.getMessage(), body.length()});
+      writeJson(exchange, 400, JsonBodies.errorBody("bad-request", e.getMessage()));
       return;
     }
     // Validate required fields

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/SessionLifecycleHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/SessionLifecycleHandler.java
@@ -74,7 +74,15 @@ public final class SessionLifecycleHandler implements HttpHandler {
     try {
       JsonBodies.readValue(body, SessionUpdateRequest.class);
     } catch (final IOException e) {
-      writeJson(exchange, 400, JsonBodies.errorBody("bad-request", "invalid JSON body"));
+      // Structured WARN per map-room#2305: matchID + exception class + message + body
+      // length so production drift surfaces in Loki without a follow-up logging fix.
+      // Body itself is not logged (game state, potentially large; full slice goes
+      // into the response body for the bot's own logs via map-room/map-room#2306).
+      LOG.log(
+          System.Logger.Level.WARNING,
+          "[sidecar] update validation failed matchID={0} exClass={1} message={2} bodyBytes={3}",
+          new Object[] {sessionId, e.getClass().getSimpleName(), e.getMessage(), body.length()});
+      writeJson(exchange, 400, JsonBodies.errorBody("bad-request", e.getMessage()));
       return;
     }
     // Phase 1: accept and record the delta request; actual GameData mutation is Phase 2.

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WirePlayer.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WirePlayer.java
@@ -16,6 +16,12 @@ import java.util.List;
  * "productionChinese_Burma_Road_Closed"} (Infantry only). Absent for all other players. The
  * canonical GameData defaults to the Open frontier; without this field the sidecar cannot know the
  * road is closed and always allows Artillery (see map-room#2174).
+ *
+ * <p>{@code purchasedUnits} carries the TS engine's {@code player.purchasedUnits[]} ledger — units
+ * purchased but not yet placed. The sidecar's executors do not yet read this field; the POJO exists
+ * so additive wire emission of it does not trip Jackson's {@code FAIL_ON_UNKNOWN_PROPERTIES}
+ * (map-room#2305). A follow-up change will wire it into the place plan to clamp {@code
+ * storedPurchaseTerritories} against the engine's actual ledger (map-room#2280).
  */
 public record WirePlayer(
     String playerId,
@@ -24,7 +30,8 @@ public record WirePlayer(
     boolean capitalCaptured,
     @JsonInclude(JsonInclude.Include.NON_NULL) Integer europePus,
     @JsonInclude(JsonInclude.Include.NON_NULL) Integer pacificPus,
-    @JsonInclude(JsonInclude.Include.NON_NULL) String productionFrontier) {
+    @JsonInclude(JsonInclude.Include.NON_NULL) String productionFrontier,
+    @JsonInclude(JsonInclude.Include.NON_NULL) List<WirePurchasedUnit> purchasedUnits) {
   @JsonCreator
   public WirePlayer(
       @JsonProperty("playerId") final String playerId,
@@ -33,7 +40,8 @@ public record WirePlayer(
       @JsonProperty("capitalCaptured") final boolean capitalCaptured,
       @JsonProperty("europePus") final Integer europePus,
       @JsonProperty("pacificPus") final Integer pacificPus,
-      @JsonProperty("productionFrontier") final String productionFrontier) {
+      @JsonProperty("productionFrontier") final String productionFrontier,
+      @JsonProperty("purchasedUnits") final List<WirePurchasedUnit> purchasedUnits) {
     this.playerId = playerId;
     this.pus = pus;
     this.tech = tech == null ? List.of() : tech;
@@ -41,6 +49,7 @@ public record WirePlayer(
     this.europePus = europePus;
     this.pacificPus = pacificPus;
     this.productionFrontier = productionFrontier;
+    this.purchasedUnits = purchasedUnits;
   }
 
   public WirePlayer(
@@ -48,7 +57,7 @@ public record WirePlayer(
       final int pus,
       final List<String> tech,
       final boolean capitalCaptured) {
-    this(playerId, pus, tech, capitalCaptured, null, null, null);
+    this(playerId, pus, tech, capitalCaptured, null, null, null, null);
   }
 
   public WirePlayer(
@@ -58,6 +67,17 @@ public record WirePlayer(
       final boolean capitalCaptured,
       final Integer europePus,
       final Integer pacificPus) {
-    this(playerId, pus, tech, capitalCaptured, europePus, pacificPus, null);
+    this(playerId, pus, tech, capitalCaptured, europePus, pacificPus, null, null);
+  }
+
+  public WirePlayer(
+      final String playerId,
+      final int pus,
+      final List<String> tech,
+      final boolean capitalCaptured,
+      final Integer europePus,
+      final Integer pacificPus,
+      final String productionFrontier) {
+    this(playerId, pus, tech, capitalCaptured, europePus, pacificPus, productionFrontier, null);
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WirePurchasedUnit.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WirePurchasedUnit.java
@@ -1,0 +1,24 @@
+package org.triplea.ai.sidecar.wire;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * One entry on {@link WirePlayer#purchasedUnits()}: the count of units of a given type purchased by
+ * the player but not yet placed (TS-side {@code player.purchasedUnits[]} ledger from {@code
+ * MapRoomState}). Carried over the wire to support the sidecar's clamp of {@code
+ * storedPurchaseTerritories} against the engine's actual purchase ledger (map-room#2280 follow-up,
+ * enabled by map-room#2305).
+ *
+ * <p>Currently the sidecar's executors do not yet read this field — the POJO is in place so the
+ * TS-side wire emission can be re-enabled without tripping {@code FAIL_ON_UNKNOWN_PROPERTIES}. A
+ * subsequent change will wire it into {@code PurchaseExecutor} / {@code PlaceExecutor}.
+ */
+public record WirePurchasedUnit(String type, int count) {
+  @JsonCreator
+  public WirePurchasedUnit(
+      @JsonProperty("type") final String type, @JsonProperty("count") final int count) {
+    this.type = type;
+    this.count = count;
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/JsonBodiesTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/JsonBodiesTest.java
@@ -38,4 +38,25 @@ class JsonBodiesTest {
     assertTrue(s.contains("\"status\":\"error\""));
     assertTrue(s.contains("\"error\":\"bad-request\""));
   }
+
+  /**
+   * Regression for map-room#2305: the wire-surface ObjectMapper must tolerate unknown properties so
+   * additive TS-side wire-schema changes (a new optional field on a Wire DTO) deserialize cleanly
+   * even before the Java POJO catches up. Pre-fix, an unknown property triggered {@code
+   * UnrecognizedPropertyException} which surfaced as opaque 400 on every {@code
+   * /session/{id}/update} call (map-room#2301).
+   */
+  @Test
+  void readValueIgnoresUnknownProperties() throws Exception {
+    final SessionCreateRequest r =
+        JsonBodies.readValue(
+            "{\"sessionId\":\"g-1:Germans\",\"gameId\":\"g-1\",\"nation\":\"Germans\","
+                + "\"seed\":7,\"unknownExtraField\":\"ignored\","
+                + "\"anotherUnknown\":{\"nested\":42}}",
+            SessionCreateRequest.class);
+    assertEquals("g-1:Germans", r.sessionId());
+    assertEquals("g-1", r.gameId());
+    assertEquals("Germans", r.nation());
+    assertEquals(7L, r.seed());
+  }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/SessionLifecycleHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/SessionLifecycleHandlerTest.java
@@ -57,6 +57,56 @@ class SessionLifecycleHandlerTest {
     assertEquals(400, ex.responseCode());
   }
 
+  /**
+   * map-room#2305 — the 400 response body must carry the validation exception message so the bot
+   * (which now logs response bodies after map-room#2306) has actionable diagnostic signal. Pre-fix,
+   * the body was the opaque {@code "invalid JSON body"} string with no detail.
+   */
+  @Test
+  void updateMalformedBodyResponseIncludesValidationDetail() throws Exception {
+    final SessionRegistry registry = new SessionRegistry(CanonicalGameData.load());
+    final Session s =
+        registry.createOrGet(new SessionKey("g-1", "Germans"), "g-1:Germans", 42L).session();
+    final SessionLifecycleHandler h = new SessionLifecycleHandler(registry);
+    final FakeHttpExchange ex =
+        new FakeHttpExchange("POST", "/session/" + s.sessionId() + "/update", "not-json");
+    h.handle(ex);
+    assertEquals(400, ex.responseCode());
+    final String body = ex.responseBodyString();
+    assertTrue(
+        body.contains("\"error\":\"bad-request\""), "body should retain bad-request code: " + body);
+    // Detail message should reference the JSON failure mode (Jackson formats this as either
+    // "Unrecognized token" or "Cannot deserialize" — both indicate body-shape validation).
+    assertTrue(
+        body.contains("\"message\":")
+            && body.length() > "{\"error\":\"bad-request\",\"message\":\"\"}".length(),
+        "body should include non-empty validation detail: " + body);
+  }
+
+  /**
+   * map-room#2305 regression — additive wire-schema changes (a new optional field on {@code
+   * WirePlayer}) must not trigger 400 on {@code /session/{id}/update}. Pre-fix, ada's TS-side
+   * emission of {@code purchasedUnits} caused {@code UnrecognizedPropertyException} which surfaced
+   * as opaque 400, which the bot (in turn) handled by burning AI turns silently (map-room#2301).
+   */
+  @Test
+  void updateAcceptsUnknownPropertiesOnWirePlayer() throws Exception {
+    final SessionRegistry registry = new SessionRegistry(CanonicalGameData.load());
+    final Session s =
+        registry.createOrGet(new SessionKey("g-1", "Germans"), "g-1:Germans", 42L).session();
+    final SessionLifecycleHandler h = new SessionLifecycleHandler(registry);
+    // A WireState payload with a fabricated unknown field on WirePlayer. Pre-fix this 400d.
+    final String bodyWithUnknownField =
+        "{\"state\":{\"territories\":[],\"players\":[{\"playerId\":\"Germans\",\"pus\":42,"
+            + "\"tech\":[],\"capitalCaptured\":false,\"thisFieldDoesNotExist\":\"on-the-pojo\"}],"
+            + "\"round\":1,\"phase\":\"purchase\",\"currentPlayer\":\"Germans\"}}";
+    final FakeHttpExchange ex =
+        new FakeHttpExchange("POST", "/session/" + s.sessionId() + "/update", bodyWithUnknownField);
+    h.handle(ex);
+    assertEquals(
+        204, ex.responseCode(), "unknown-property tolerance: response was " + ex.responseCode());
+  }
+
   @Test
   void deleteReturns204ForKnownSession() throws Exception {
     final SessionRegistry registry = new SessionRegistry(CanonicalGameData.load());

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/RequestResponseDtoTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/RequestResponseDtoTest.java
@@ -36,4 +36,43 @@ class RequestResponseDtoTest {
     final SessionUpdateRequest r = om.readValue(body, SessionUpdateRequest.class);
     assertEquals(2, r.state().round());
   }
+
+  /**
+   * map-room#2305 — {@code WirePlayer.purchasedUnits} carries the TS engine's {@code
+   * player.purchasedUnits[]} ledger over the wire. The POJO is in place so additive emission of
+   * this field by the TS bot does not trip Jackson's {@code FAIL_ON_UNKNOWN_PROPERTIES}; the
+   * sidecar's executors will consume it in a follow-up change (map-room#2280 follow-up) to clamp
+   * the place plan against the engine's actual ledger.
+   */
+  @Test
+  void wirePlayerPurchasedUnitsDeserializes() throws Exception {
+    final String body =
+        "{\"playerId\":\"Germans\",\"pus\":24,\"tech\":[],\"capitalCaptured\":false,"
+            + "\"purchasedUnits\":[{\"type\":\"infantry\",\"count\":3},"
+            + "{\"type\":\"tank\",\"count\":1}]}";
+    final WirePlayer p = om.readValue(body, WirePlayer.class);
+    assertEquals("Germans", p.playerId());
+    assertEquals(24, p.pus());
+    assertEquals(2, p.purchasedUnits().size());
+    assertEquals("infantry", p.purchasedUnits().get(0).type());
+    assertEquals(3, p.purchasedUnits().get(0).count());
+    assertEquals("tank", p.purchasedUnits().get(1).type());
+    assertEquals(1, p.purchasedUnits().get(1).count());
+  }
+
+  /**
+   * map-room#2305 — when {@code purchasedUnits} is absent (pre-emission, default), the field
+   * deserializes to null and {@code @JsonInclude(NON_NULL)} ensures it's not echoed on serialize.
+   * Backward-compat with WirePlayer constructors that don't accept the field.
+   */
+  @Test
+  void wirePlayerWithoutPurchasedUnitsRoundTrips() throws Exception {
+    final WirePlayer p = new WirePlayer("Germans", 42, java.util.List.of(), false);
+    final String json = om.writeValueAsString(p);
+    assertTrue(json.contains("\"playerId\":\"Germans\""));
+    assertTrue(!json.contains("purchasedUnits"));
+    final WirePlayer parsed = om.readValue(json, WirePlayer.class);
+    assertEquals("Germans", parsed.playerId());
+    assertEquals(null, parsed.purchasedUnits());
+  }
 }


### PR DESCRIPTION
## Summary

Part 2 of the map-room/map-room#2301 fix per map-room/map-room#2305. Four deliverables:

1. **Configure Jackson to ignore unknown properties on the wire-surface ObjectMapper.** `JsonBodies.MAPPER` now has `FAIL_ON_UNKNOWN_PROPERTIES=false`. Additive TS-side wire-schema changes (a new optional field on `WirePlayer` / `WireUnit` / etc.) deserialize cleanly even before the Java POJO catches up. The other two `ObjectMapper` instances in the sidecar (`ProSessionSnapshotStore.MAPPER`, `SessionStore.MAPPER`) are intentionally left strict — those files have schemas the sidecar fully owns, so unknown properties there indicate a real bug.

2. **Include validation message in 400 response body.** `SessionLifecycleHandler.handleUpdate` and `SessionCreateHandler.handle` now pass `e.getMessage()` (the Jackson exception message) into the existing `errorBody(error, message)` envelope. Pairs with chase's map-room/map-room#2306 — the bot now logs response bodies, so detail in the 400 body is immediately useful. `DecisionHandler` left as-is for the body shape (its envelope is `DecisionError` which is a wire-contract type without a `message` field — extending it is a separate coordinated TS+Java change), but its WARN log is now structured.

3. **Structured WARN log on validation failure.** All three handlers (`SessionLifecycleHandler`, `SessionCreateHandler`, `DecisionHandler`) emit `[sidecar] ... validation failed matchID={0} exClass={1} message={2} bodyBytes={3}` on Jackson deserialization failure. Bodies are not logged (potentially large game state); the body length goes alongside the exception message so future bugs of this shape are visible in Loki without a follow-up logging fix.

4. **Add `WirePlayer.purchasedUnits` POJO field.** New `WirePurchasedUnit` record (`{type, count}`) plus a new optional field on `WirePlayer`. Currently a no-op consumer — the field is in place so additive emission of it from TS doesn't trip Jackson, but no executor reads it yet. A follow-up change will wire it into `PurchaseExecutor` / `PlaceExecutor` to clamp `storedPurchaseTerritories` against the engine's actual ledger (map-room/map-room#2280 follow-up). Backward-compat constructors preserved.

## Why global Jackson config (vs per-class `@JsonIgnoreProperties`)

Picked global because:
- Single source of truth — easier to audit and reason about.
- Future Wire DTOs don't need to remember to add the annotation.
- The other two ObjectMappers in the sidecar are explicitly internal-schema (snapshot files, session manifests) and intentionally remain strict, so the global setting is scoped to the wire surface alone.

The narrower per-class `@JsonIgnoreProperties(ignoreUnknown = true)` form is already used on the request DTOs to ignore the `kind` discriminator after dispatch — that pattern is preserved.

## Test plan

- [x] Unit: `JsonBodies.readValueIgnoresUnknownProperties` — passes through `JsonBodies.MAPPER` with two fabricated unknown fields.
- [x] Unit: `SessionLifecycleHandlerTest.updateMalformedBodyResponseIncludesValidationDetail` — asserts the 400 body retains `error=bad-request` AND includes a non-empty `message` field.
- [x] Unit: `SessionLifecycleHandlerTest.updateAcceptsUnknownPropertiesOnWirePlayer` — regression for the production map-room/map-room#2301 scenario: a wire payload with a fabricated unknown field on `WirePlayer` is accepted (returns 204).
- [x] Unit: `RequestResponseDtoTest.wirePlayerPurchasedUnitsDeserializes` — round-trips the new `purchasedUnits` field with a representative `[{type, count}]` payload.
- [x] Unit: `RequestResponseDtoTest.wirePlayerWithoutPurchasedUnitsRoundTrips` — verifies the field is absent on serialize when null and parses back to null.
- [x] WARN log emission verified by inspection (structured `matchID + exClass + message + bodyBytes`, matches existing pattern in the same handler).
- [x] All existing tests continue to pass (full ai-sidecar suite: BUILD SUCCESSFUL in 5m 27s).
- [x] `./gradlew :game-app:ai-sidecar:spotlessCheck` clean.
- [ ] 🧑 Manual: chase / matt verify in staging post-merge — send a deliberately malformed payload, observe structured WARN log + 400 with detail message in body.

Bernard's map-room/map-room#2300 cross-repo workflow doc was the reference for the build/format/PR steps.

## Cross-references

- **map-room/map-room#2305** — this issue (closed by this PR)
- **map-room/map-room#2301** — parent production bug (Allies stuck, Japanese/tech, matchID `bZEMWPFrCQn`)
- **map-room/map-room#2306** — chase's bot-side response-body logging fix (already shipped)
- **map-room/map-room#2307** — felix's Part 1 circuit-breaker (already shipped — turns will now stick instead of silent-skipping)
- **map-room/map-room#2280** — ada's TS-side wire-emission of `purchasedUnits` (her PR can be re-enabled once this lands)
- **map-room/map-room#2273** — wire-protocol audit (parent context); §10.3 #16 of that audit flagged "translator rejection codes imply structurally invalid plans" — same diagnostic-signal-gap shape this PR addresses

## Notes

- The `/session/{id}/update` endpoint is currently a no-op (it parses + discards body, only touching `updatedAt`) per the wire audit's §8.2 finding. This PR does not change that — the 400-rejection issue was on the JSON parse path, which still happens. A separate follow-up (map-room/map-room#2282 in the wire audit) will redesign the endpoint.

- **Pre-existing flaky test:** `NoncombatMoveExecutorIntegrationTest.germansClaimBulgariaOnTurn1` shows ~40% failure rate on `origin/main` (verified 2/5 failures with `--rerun-tasks` on an unmodified main checkout). Not related to this change. Worth filing separately as a flake-tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
