### PR TITLE
feat(sidecar): purchase response carries PlacementGroup[] placement plan

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PlacementGroup.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PlacementGroup.java
@@ -1,0 +1,13 @@
+package org.triplea.ai.sidecar.dto;
+
+import java.util.List;
+
+/**
+ * One batch of units to place in a single territory. Part of {@link PurchasePlan#placements()}.
+ *
+ * <p>Ordered in the array per ProPurchaseAi.place dispatch order: land non-construction → water
+ * non-construction → land construction → water construction. The {@code isWater} / {@code
+ * isConstruction} flags are belt-and-braces — the bot can re-sort if needed.
+ */
+public record PlacementGroup(
+    String territory, List<String> unitTypes, boolean isWater, boolean isConstruction) {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchasePlan.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchasePlan.java
@@ -5,7 +5,10 @@ import java.util.List;
 /**
  * Purchase decision plan. {@code buys} is an ordered list of {@link PurchaseOrder} entries, ordered
  * by ProAi priority (Phase 3 reverse-order trim preserves priority). {@code repairs} is the
- * captured repair bundle from the preceding {@code purchaseRepair()} call.
+ * captured repair bundle from the preceding {@code purchaseRepair()} call. {@code placements} lists
+ * the intended placement territories in ProPurchaseAi.place dispatch order (land non-construction →
+ * water non-construction → land construction → water construction).
  */
-public record PurchasePlan(List<PurchaseOrder> buys, List<RepairOrder> repairs)
+public record PurchasePlan(
+    List<PurchaseOrder> buys, List<RepairOrder> repairs, List<PlacementGroup> placements)
     implements DecisionPlan {}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.triplea.ai.sidecar.AiTraceLogger;
+import org.triplea.ai.sidecar.dto.PlacementGroup;
 import org.triplea.ai.sidecar.dto.PurchaseOrder;
 import org.triplea.ai.sidecar.dto.PurchasePlan;
 import org.triplea.ai.sidecar.dto.PurchaseRequest;
@@ -170,18 +171,21 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
     // (rare — would indicate purchase ran with no target territories, typical of empty plans).
     final Map<Territory, ProPurchaseTerritory> stored = proAi.getStoredPurchaseTerritories();
     final List<PurchaseOrder> buys;
+    final List<PlacementGroup> placements;
     if (stored != null && !stored.isEmpty()) {
       buys = toPurchaseOrdersFromStored(stored);
+      placements = toPlacementGroups(stored);
     } else {
       final IntegerMap<ProductionRule> captured = recorder.capturedPurchase();
       final IntegerMap<ProductionRule> trimmed = trimToFit(captured, pusToSpend, pus);
       buys = toPurchaseOrders(trimmed);
+      placements = List.of();
     }
     for (final PurchaseOrder order : buys) {
       AiTraceLogger.logPurchaseOrder(player.getName(), order.unitType(), order.count());
     }
     final List<RepairOrder> repairs = toRepairOrders(recorder.capturedRepair(), data);
-    return new PurchasePlan(buys, repairs);
+    return new PurchasePlan(buys, repairs, placements);
   }
 
   /**
@@ -215,6 +219,55 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
       sum += rule.getCosts().getInt(pus) * map.getInt(rule);
     }
     return sum;
+  }
+
+  /**
+   * Builds the ordered placement plan from {@code storedPurchaseTerritories}.
+   *
+   * <p>Dispatch order mirrors {@code ProPurchaseAi.place}: land non-construction first, then water
+   * non-construction, then land construction, then water construction. Within each bucket the
+   * iteration order follows the insertion order of {@code stored}.
+   */
+  static List<PlacementGroup> toPlacementGroups(final Map<Territory, ProPurchaseTerritory> stored) {
+    final List<PlacementGroup> landNonConst = new ArrayList<>();
+    final List<PlacementGroup> waterNonConst = new ArrayList<>();
+    final List<PlacementGroup> landConst = new ArrayList<>();
+    final List<PlacementGroup> waterConst = new ArrayList<>();
+
+    for (final ProPurchaseTerritory ppt : stored.values()) {
+      for (final ProPlaceTerritory placeTerr : ppt.getCanPlaceTerritories()) {
+        final List<Unit> units = placeTerr.getPlaceUnits();
+        if (units.isEmpty()) {
+          continue;
+        }
+        final boolean isWater = placeTerr.getTerritory().isWater();
+        final boolean isConstruction =
+            units.stream().anyMatch(u -> u.getType().getUnitAttachment().isConstruction());
+        final List<String> unitTypes = new ArrayList<>();
+        for (final Unit u : units) {
+          unitTypes.add(u.getType().getName());
+        }
+        final PlacementGroup group =
+            new PlacementGroup(
+                placeTerr.getTerritory().getName(), unitTypes, isWater, isConstruction);
+        if (!isWater && !isConstruction) {
+          landNonConst.add(group);
+        } else if (isWater && !isConstruction) {
+          waterNonConst.add(group);
+        } else if (!isWater) {
+          landConst.add(group);
+        } else {
+          waterConst.add(group);
+        }
+      }
+    }
+
+    final List<PlacementGroup> result = new ArrayList<>();
+    result.addAll(landNonConst);
+    result.addAll(waterNonConst);
+    result.addAll(landConst);
+    result.addAll(waterConst);
+    return result;
   }
 
   private static List<PurchaseOrder> toPurchaseOrders(final IntegerMap<ProductionRule> map) {

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchasePlanJsonTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchasePlanJsonTest.java
@@ -14,7 +14,8 @@ class PurchasePlanJsonTest {
     PurchasePlan plan =
         new PurchasePlan(
             List.of(new PurchaseOrder("infantry", 3, null), new PurchaseOrder("armour", 1, null)),
-            List.of(new RepairOrder("Germany", "factory_major", 2)));
+            List.of(new RepairOrder("Germany", "factory_major", 2)),
+            List.of());
     String json = mapper.writeValueAsString((DecisionPlan) plan);
     assertTrue(json.contains("\"kind\":\"purchase\""));
     DecisionPlan decoded = mapper.readValue(json, DecisionPlan.class);
@@ -24,5 +25,30 @@ class PurchasePlanJsonTest {
     assertEquals("infantry", back.buys().get(0).unitType());
     assertEquals(3, back.buys().get(0).count());
     assertEquals("Germany", back.repairs().get(0).territory());
+  }
+
+  @Test
+  void purchasePlanRoundTripsWithPlacements() throws Exception {
+    PurchasePlan plan =
+        new PurchasePlan(
+            List.of(new PurchaseOrder("infantry", 2, "Germany")),
+            List.of(),
+            List.of(
+                new PlacementGroup("Germany", List.of("infantry", "infantry"), false, false),
+                new PlacementGroup("5 Sea Zone", List.of("destroyer"), true, false),
+                new PlacementGroup("Germany", List.of("factory_major"), false, true)));
+    String json = mapper.writeValueAsString((DecisionPlan) plan);
+    assertTrue(json.contains("\"placements\""));
+    assertTrue(json.contains("\"isWater\""));
+    assertTrue(json.contains("\"isConstruction\""));
+    DecisionPlan decoded = mapper.readValue(json, DecisionPlan.class);
+    assertInstanceOf(PurchasePlan.class, decoded);
+    PurchasePlan back = (PurchasePlan) decoded;
+    assertEquals(3, back.placements().size());
+    assertEquals("Germany", back.placements().get(0).territory());
+    assertFalse(back.placements().get(0).isWater());
+    assertFalse(back.placements().get(0).isConstruction());
+    assertTrue(back.placements().get(1).isWater());
+    assertTrue(back.placements().get(2).isConstruction());
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
 import org.triplea.ai.sidecar.CanonicalGameData;
+import org.triplea.ai.sidecar.dto.PlacementGroup;
 import org.triplea.ai.sidecar.dto.PurchaseOrder;
 import org.triplea.ai.sidecar.dto.PurchasePlan;
 import org.triplea.ai.sidecar.dto.PurchaseRequest;
@@ -177,5 +178,57 @@ class PurchaseExecutorTest {
           .as("unit type %s has a production rule", order.unitType())
           .isNotNull();
     }
+  }
+
+  /**
+   * Verifies that when ProAi buys units for turn 1 Germans, the response's {@code placements} list:
+   *
+   * <ul>
+   *   <li>is non-empty (storedPurchaseTerritories is populated after a successful purchase)
+   *   <li>maintains the correct bucket order: land non-construction → water non-construction → land
+   *       construction → water construction
+   *   <li>each group has a non-blank territory name and at least one unit type
+   * </ul>
+   */
+  @Test
+  void placementsArePopulatedAndOrderedCorrectly() throws Exception {
+    final Session session = freshSession("Germans");
+    final PurchasePlan plan =
+        new PurchaseExecutor().execute(session, purchaseRequestFor("Germans"));
+
+    // ProAi always buys something for turn-1 Germans; placements must follow from buys.
+    assertThat(plan.buys()).as("ProAi should buy units for turn-1 Germans").isNotEmpty();
+    assertThat(plan.placements())
+        .as("placements must be populated when buys is non-empty")
+        .isNotEmpty();
+
+    // Each group must have valid territory and units.
+    for (final PlacementGroup pg : plan.placements()) {
+      assertThat(pg.territory()).as("placement territory must not be blank").isNotBlank();
+      assertThat(pg.unitTypes()).as("placement unitTypes must not be empty").isNotEmpty();
+    }
+
+    // Ordering: priority(i) ≤ priority(i+1) for all consecutive groups.
+    final List<PlacementGroup> groups = plan.placements();
+    for (int i = 0; i < groups.size() - 1; i++) {
+      assertThat(bucketOf(groups.get(i)))
+          .as(
+              "placement order violation at index %d (%s priority=%d) before index %d (%s priority=%d)",
+              i,
+              groups.get(i).territory(),
+              bucketOf(groups.get(i)),
+              i + 1,
+              groups.get(i + 1).territory(),
+              bucketOf(groups.get(i + 1)))
+          .isLessThanOrEqualTo(bucketOf(groups.get(i + 1)));
+    }
+  }
+
+  /** Returns the dispatch-order bucket index for a placement group (0 = highest priority). */
+  private static int bucketOf(final PlacementGroup pg) {
+    if (!pg.isWater() && !pg.isConstruction()) return 0; // land non-construction
+    if (pg.isWater() && !pg.isConstruction()) return 1; // water non-construction
+    if (!pg.isWater()) return 2; // land construction
+    return 3; // water construction
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerPurchaseTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerPurchaseTest.java
@@ -80,7 +80,7 @@ class DecisionHandlerPurchaseTest {
     final Session s = newSession(registry);
 
     final PurchasePlan fixedPlan =
-        new PurchasePlan(List.of(new PurchaseOrder("infantry", 3, null)), List.of());
+        new PurchasePlan(List.of(new PurchaseOrder("infantry", 3, null)), List.of(), List.of());
 
     final DecisionHandler h = handlerWithPurchaseStub(registry, (session, req) -> fixedPlan);
 
@@ -109,6 +109,7 @@ class DecisionHandlerPurchaseTest {
         new PurchasePlan(
             List.of(
                 new PurchaseOrder("infantry", 2, null), new PurchaseOrder("artillery", 1, null)),
+            List.of(),
             List.of());
 
     final DecisionHandler h = handlerWithPurchaseStub(registry, (session, req) -> fixedPlan);
@@ -131,7 +132,7 @@ class DecisionHandlerPurchaseTest {
     final SessionRegistry registry = newRegistry();
     final Session s = newSession(registry);
 
-    final PurchasePlan emptyPlan = new PurchasePlan(List.of(), List.of());
+    final PurchasePlan emptyPlan = new PurchasePlan(List.of(), List.of(), List.of());
     final DecisionHandler h = handlerWithPurchaseStub(registry, (session, req) -> emptyPlan);
 
     final FakeHttpExchange ex =

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
@@ -63,7 +63,7 @@ class DecisionHandlerTest {
       final DecisionExecutor<RetreatQueryRequest, RetreatPlan> rq,
       final DecisionExecutor<ScrambleRequest, ScramblePlan> sr) {
     return new DecisionHandler(
-        registry, rq, sr, (session, req) -> new PurchasePlan(List.of(), List.of()));
+        registry, rq, sr, (session, req) -> new PurchasePlan(List.of(), List.of(), List.of()));
   }
 
   // ---------------------------------------------------------------------

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerWireFormatTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerWireFormatTest.java
@@ -90,7 +90,7 @@ class DecisionHandlerWireFormatTest {
     // Default purchase stub: returns an empty plan so wire-format tests that don't exercise
     // purchase still compile and route correctly.
     return new DecisionHandler(
-        registry, rq, sr, (session, req) -> new PurchasePlan(List.of(), List.of()));
+        registry, rq, sr, (session, req) -> new PurchasePlan(List.of(), List.of(), List.of()));
   }
 
   private JsonNode responseJson(final FakeHttpExchange ex) throws Exception {
@@ -189,7 +189,7 @@ class DecisionHandlerWireFormatTest {
     final SessionRegistry registry = newRegistry();
     final Session s = newSession(registry);
     final PurchasePlan fixedPlan =
-        new PurchasePlan(List.of(new PurchaseOrder("infantry", 1, null)), List.of());
+        new PurchasePlan(List.of(new PurchaseOrder("infantry", 1, null)), List.of(), List.of());
     final DecisionHandler h =
         new DecisionHandler(
             registry,


### PR DESCRIPTION
## Summary

- Adds `PlacementGroup` DTO (territory, unitTypes[], isWater, isConstruction)
- Extends `PurchasePlan` record with `List<PlacementGroup> placements`
- `PurchaseExecutor` populates placements from `storedPurchaseTerritories`, ordered: land non-construction → water non-construction → land construction → water construction (mirrors `ProPurchaseAi.place` dispatch order lines 460-505 + 575-576)
- Empty list when `storedPurchaseTerritories` is null/empty (fallback path)
- Updates all test fixtures that construct `PurchasePlan` to pass the new `placements` arg
- New `PurchasePlanJsonTest.purchasePlanRoundTripsWithPlacements` — verifies `isWater`/`isConstruction` flags survive JSON round-trip
- New `PurchaseExecutorTest.placementsArePopulatedAndOrderedCorrectly` — asserts placements non-empty for turn-1 Germans and bucket ordering invariant holds

## Cross-repo companion

TS type PR (must land first): map-room/map-room#2362

Spotless applied before commit. Run gate: `:ai-sidecar:spotlessCheck` + `:ai-sidecar:compileJava` + `:ai-sidecar:compileTestJava` all green; `:ai-sidecar:test` on affected test classes all green. Full `:ai-sidecar:check` encounters a stale Gradle binary-results cache path (`/Users/family/workcrew/triplea/...` vs actual path) that causes 4 unrelated tests to report a `NoSuchFileException` on result serialization — not test logic failures.

See map-room#2359

🤖 Generated with [Claude Code](https://claude.com/claude-code)