### PR TITLE
feat(sidecar): populate politicalActions[] in PurchasePlan purchase response

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchasePlan.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchasePlan.java
@@ -1,5 +1,7 @@
 package org.triplea.ai.sidecar.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /**
@@ -7,8 +9,34 @@ import java.util.List;
  * by ProAi priority (Phase 3 reverse-order trim preserves priority). {@code repairs} is the
  * captured repair bundle from the preceding {@code purchaseRepair()} call. {@code placements} lists
  * the intended placement territories in ProPurchaseAi.place dispatch order (land non-construction →
- * water non-construction → land construction → water construction).
+ * water non-construction → land construction → water construction). {@code politicalActions} lists
+ * war declarations the AI decided to make during purchase simulation; absent or {@code null} in
+ * older responses is treated as an empty list on the TS side.
  */
 public record PurchasePlan(
-    List<PurchaseOrder> buys, List<RepairOrder> repairs, List<PlacementGroup> placements)
-    implements DecisionPlan {}
+    List<PurchaseOrder> buys,
+    List<RepairOrder> repairs,
+    List<PlacementGroup> placements,
+    List<WarDeclaration> politicalActions)
+    implements DecisionPlan {
+
+  @JsonCreator
+  public PurchasePlan(
+      @JsonProperty("buys") final List<PurchaseOrder> buys,
+      @JsonProperty("repairs") final List<RepairOrder> repairs,
+      @JsonProperty("placements") final List<PlacementGroup> placements,
+      @JsonProperty("politicalActions") final List<WarDeclaration> politicalActions) {
+    this.buys = buys;
+    this.repairs = repairs;
+    this.placements = placements;
+    this.politicalActions = politicalActions != null ? politicalActions : List.of();
+  }
+
+  /** Convenience constructor for callsites that do not populate politicalActions. */
+  public PurchasePlan(
+      final List<PurchaseOrder> buys,
+      final List<RepairOrder> repairs,
+      final List<PlacementGroup> placements) {
+    this(buys, repairs, placements, List.of());
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PoliticsObserver.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PoliticsObserver.java
@@ -105,8 +105,18 @@ public final class PoliticsObserver {
    * Mirrors the warPlayers extraction in {@code ProPoliticsAi}.
    */
   public List<WarDeclaration> toWarDeclarations(final GamePlayer actingPlayer) {
+    return toWarDeclarations(captured, actingPlayer);
+  }
+
+  /**
+   * Static variant that projects an arbitrary list of {@link PoliticalActionAttachment}s to {@link
+   * WarDeclaration}s. Used by {@link org.triplea.ai.sidecar.exec.PurchaseExecutor} to project
+   * {@code storedPoliticalActions} populated during purchase simulation.
+   */
+  static List<WarDeclaration> toWarDeclarations(
+      final List<PoliticalActionAttachment> actions, final GamePlayer actingPlayer) {
     final List<WarDeclaration> out = new ArrayList<>();
-    for (final PoliticalActionAttachment action : captured) {
+    for (final PoliticalActionAttachment action : actions) {
       for (final PoliticalActionAttachment.RelationshipChange change :
           action.getRelationshipChanges()) {
         if (change.relationshipType == null

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
@@ -16,6 +16,7 @@ import games.strategy.triplea.ai.pro.data.ProPlaceTerritory;
 import games.strategy.triplea.ai.pro.data.ProPurchaseTerritory;
 import games.strategy.triplea.ai.pro.data.ProSplitResourceTracker;
 import games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge;
+import games.strategy.triplea.attachments.PoliticalActionAttachment;
 import games.strategy.triplea.delegate.EndRoundDelegate;
 import games.strategy.triplea.delegate.MoveDelegate;
 import games.strategy.triplea.delegate.PlaceDelegate;
@@ -34,6 +35,7 @@ import org.triplea.ai.sidecar.dto.PurchaseOrder;
 import org.triplea.ai.sidecar.dto.PurchasePlan;
 import org.triplea.ai.sidecar.dto.PurchaseRequest;
 import org.triplea.ai.sidecar.dto.RepairOrder;
+import org.triplea.ai.sidecar.dto.WarDeclaration;
 import org.triplea.ai.sidecar.session.ProSessionSnapshotStore;
 import org.triplea.ai.sidecar.session.Session;
 import org.triplea.ai.sidecar.wire.WirePlayer;
@@ -185,7 +187,17 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
       AiTraceLogger.logPurchaseOrder(player.getName(), order.unitType(), order.count());
     }
     final List<RepairOrder> repairs = toRepairOrders(recorder.capturedRepair(), data);
-    return new PurchasePlan(buys, repairs, placements);
+
+    final List<PoliticalActionAttachment> storedActions = proAi.getStoredPoliticalActions();
+    final List<WarDeclaration> politicalActions;
+    if (storedActions != null && !storedActions.isEmpty()) {
+      politicalActions = PoliticsObserver.toWarDeclarations(storedActions, player);
+      proAi.clearStoredPoliticalActions();
+    } else {
+      politicalActions = List.of();
+    }
+
+    return new PurchasePlan(buys, repairs, placements, politicalActions);
   }
 
   /**

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchasePlanJsonTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchasePlanJsonTest.java
@@ -51,4 +51,34 @@ class PurchasePlanJsonTest {
     assertTrue(back.placements().get(1).isWater());
     assertTrue(back.placements().get(2).isConstruction());
   }
+
+  @Test
+  void purchasePlanRoundTripsWithPoliticalActions() throws Exception {
+    PurchasePlan plan =
+        new PurchasePlan(
+            List.of(new PurchaseOrder("infantry", 2, "Germany")),
+            List.of(),
+            List.of(),
+            List.of(new WarDeclaration("Russians"), new WarDeclaration("British")));
+    String json = mapper.writeValueAsString((DecisionPlan) plan);
+    assertTrue(json.contains("\"politicalActions\""));
+    assertTrue(json.contains("\"Russians\""));
+    DecisionPlan decoded = mapper.readValue(json, DecisionPlan.class);
+    assertInstanceOf(PurchasePlan.class, decoded);
+    PurchasePlan back = (PurchasePlan) decoded;
+    assertEquals(2, back.politicalActions().size());
+    assertEquals("Russians", back.politicalActions().get(0).target());
+    assertEquals("British", back.politicalActions().get(1).target());
+  }
+
+  @Test
+  void purchasePlanWithMissingPoliticalActionsDefaultsToEmpty() throws Exception {
+    String json =
+        "{\"kind\":\"purchase\",\"buys\":[{\"unitType\":\"infantry\",\"count\":1}],"
+            + "\"repairs\":[],\"placements\":[]}";
+    DecisionPlan decoded = mapper.readValue(json, DecisionPlan.class);
+    assertInstanceOf(PurchasePlan.class, decoded);
+    PurchasePlan back = (PurchasePlan) decoded;
+    assertEquals(0, back.politicalActions().size());
+  }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
@@ -231,4 +231,23 @@ class PurchaseExecutorTest {
     if (!pg.isWater()) return 2; // land construction
     return 3; // water construction
   }
+
+  /**
+   * Smoke test: {@code politicalActions} is always a non-null list. Round 1 Germans will not
+   * declare any wars, so the list is expected to be empty. The important invariant is that the
+   * field is present and well-typed regardless of whether any actions were decided.
+   *
+   * <p>Note: {@code politicalActions} reflects the AI's decisions on the simulation clone ({@code
+   * dataCopy}), not the live session's {@link games.strategy.engine.data.RelationshipTracker}. The
+   * live tracker is only updated after the bot dispatches the returned war declarations to the
+   * engine via {@code declareWar} moves.
+   */
+  @Test
+  void politicalActionsIsNonNullAfterPurchase() throws Exception {
+    final Session session = freshSession("Germans");
+    final PurchasePlan plan =
+        new PurchaseExecutor().execute(session, purchaseRequestFor("Germans"));
+
+    assertThat(plan.politicalActions()).as("politicalActions must never be null").isNotNull();
+  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -134,6 +134,14 @@ public abstract class AbstractProAi extends AbstractAi {
     storedStrafingTerritories = strafingTerritories;
   }
 
+  public List<PoliticalActionAttachment> getStoredPoliticalActions() {
+    return storedPoliticalActions;
+  }
+
+  public void clearStoredPoliticalActions() {
+    storedPoliticalActions = null;
+  }
+
   /**
    * Sidecar-only toggle: disable the politics step inside {@link #purchase}'s turn-simulation loop.
    * The sidecar's bot calls {@code kind=politics} before {@code kind=purchase}, so by the time
@@ -349,14 +357,11 @@ public abstract class AbstractProAi extends AbstractAi {
    * <p>The sidecar's {@code PurchaseExecutor} lives in a separate package ({@code
    * org.triplea.ai.sidecar.exec}) and therefore cannot invoke {@link #purchase} directly.
    *
-   * <p>This method disables the politics step inside {@link #purchase}'s turn-simulation loop for
-   * the duration of the call. By the time the sidecar calls this method, real politics has already
-   * executed on the session GameData via {@code invokePoliticsForSidecar}; {@code dataCopy} (cloned
-   * inside {@link #purchase}) inherits the correct post-politics relationships. Re-running politics
-   * in simulation would roll fresh RNG and may declare additional wars, inflating attack-option
-   * scoring and producing purchases for territories that won't actually be conquered.
-   *
-   * @see #setSimulatePoliticsInPurchase
+   * <p>Politics simulation runs with the default {@code simulatePoliticsInPurchase=true}, so the
+   * purchase simulation may declare additional wars on {@code dataCopy} and populate {@link
+   * #storedPoliticalActions}. {@code PurchaseExecutor} reads {@link #getStoredPoliticalActions()}
+   * after this method returns to project them onto the {@code PurchasePlan} wire response, then
+   * calls {@link #clearStoredPoliticalActions()} to prevent replay on the next turn.
    */
   public void invokePurchaseForSidecar(
       final boolean purchaseForBid,
@@ -364,16 +369,7 @@ public abstract class AbstractProAi extends AbstractAi {
       final IPurchaseDelegate purchaseDelegate,
       final GameData data,
       final GamePlayer player) {
-    // Disable simulated politics; real politics has already executed on the session's
-    // GameData via invokePoliticsForSidecar before this call.
-    setSimulatePoliticsInPurchase(false);
-    try {
-      purchase(purchaseForBid, pusToSpend, purchaseDelegate, data, player);
-    } finally {
-      // Restore default behaviour for any subsequent code paths (defensive — the same
-      // ProAi instance is reused across turns within a session).
-      setSimulatePoliticsInPurchase(true);
-    }
+    purchase(purchaseForBid, pusToSpend, purchaseDelegate, data, player);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Removes `setSimulatePoliticsInPurchase(false)` suppression from `invokePurchaseForSidecar` so ProAi's purchase simulation can declare wars and populate `storedPoliticalActions`
- Adds `getStoredPoliticalActions()` / `clearStoredPoliticalActions()` accessors on `AbstractProAi` so `PurchaseExecutor` can read and clear the list after the purchase future resolves
- Adds a static overload `PoliticsObserver.toWarDeclarations(List<PoliticalActionAttachment>, GamePlayer)` — reuses the same projection logic (including `MAP_ROOM_PRIMARY_NATIONS` filter) already used by combat-move
- Populates the new `politicalActions` field on the `PurchasePlan` wire response; a 3-arg convenience constructor keeps all existing callsites unchanged; `@JsonCreator` null-guard handles old JSON without the field

Mirror of map-room/map-room#2359 (wire-expansion for `placements`).

## Test plan

- [x] `PurchasePlanJsonTest.purchasePlanRoundTripsWithPoliticalActions` — round-trip with populated list
- [x] `PurchasePlanJsonTest.purchasePlanWithMissingPoliticalActionsDefaultsToEmpty` — backward compat: old JSON without `politicalActions` deserializes to empty list
- [x] `PurchaseExecutorTest.politicalActionsIsNonNullAfterPurchase` — smoke: `plan.politicalActions()` is non-null for turn-1 Germans
- [x] `./gradlew :game-app:ai-sidecar:check` — BUILD SUCCESSFUL (7m 56s, all tests pass)

> **Note on test scope:** `politicalActions` reflects the AI's decisions on the simulation clone (`dataCopy`), NOT the live session's `RelationshipTracker`. The live tracker is only updated after the bot dispatches the returned war declarations to the engine. The smoke test asserts non-null rather than at-war state for this reason (see Javadoc on `PurchaseExecutorTest.politicalActionsIsNonNullAfterPurchase`).

Closes map-room/map-room#2366

🤖 Generated with [Claude Code](https://claude.com/claude-code)