### PR TITLE
feat(ai-sidecar): purchase response carries combatMoves (WireMoveDescription[])

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchasePlan.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchasePlan.java
@@ -11,13 +11,16 @@ import java.util.List;
  * the intended placement territories in ProPurchaseAi.place dispatch order (land non-construction →
  * water non-construction → land construction → water construction). {@code politicalActions} lists
  * war declarations the AI decided to make during purchase simulation; absent or {@code null} in
- * older responses is treated as an empty list on the TS side.
+ * older responses is treated as an empty list on the TS side. {@code combatMoves} carries the
+ * projected combat-move plan in execution order (land → amphib → bombard → bombing); absent or
+ * {@code null} in older responses is treated as an empty list on the TS side.
  */
 public record PurchasePlan(
     List<PurchaseOrder> buys,
     List<RepairOrder> repairs,
     List<PlacementGroup> placements,
-    List<WarDeclaration> politicalActions)
+    List<WarDeclaration> politicalActions,
+    List<WireMoveDescription> combatMoves)
     implements DecisionPlan {
 
   @JsonCreator
@@ -25,18 +28,29 @@ public record PurchasePlan(
       @JsonProperty("buys") final List<PurchaseOrder> buys,
       @JsonProperty("repairs") final List<RepairOrder> repairs,
       @JsonProperty("placements") final List<PlacementGroup> placements,
-      @JsonProperty("politicalActions") final List<WarDeclaration> politicalActions) {
+      @JsonProperty("politicalActions") final List<WarDeclaration> politicalActions,
+      @JsonProperty("combatMoves") final List<WireMoveDescription> combatMoves) {
     this.buys = buys;
     this.repairs = repairs;
     this.placements = placements;
     this.politicalActions = politicalActions != null ? politicalActions : List.of();
+    this.combatMoves = combatMoves != null ? combatMoves : List.of();
   }
 
-  /** Convenience constructor for callsites that do not populate politicalActions. */
+  /** Convenience constructor for callsites that do not populate combatMoves. */
+  public PurchasePlan(
+      final List<PurchaseOrder> buys,
+      final List<RepairOrder> repairs,
+      final List<PlacementGroup> placements,
+      final List<WarDeclaration> politicalActions) {
+    this(buys, repairs, placements, politicalActions, List.of());
+  }
+
+  /** Convenience constructor for callsites that do not populate politicalActions or combatMoves. */
   public PurchasePlan(
       final List<PurchaseOrder> buys,
       final List<RepairOrder> repairs,
       final List<PlacementGroup> placements) {
-    this(buys, repairs, placements, List.of());
+    this(buys, repairs, placements, List.of(), List.of());
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.triplea.ai.sidecar.AiTraceLogger;
@@ -36,6 +37,7 @@ import org.triplea.ai.sidecar.dto.PurchasePlan;
 import org.triplea.ai.sidecar.dto.PurchaseRequest;
 import org.triplea.ai.sidecar.dto.RepairOrder;
 import org.triplea.ai.sidecar.dto.WarDeclaration;
+import org.triplea.ai.sidecar.dto.WireMoveDescription;
 import org.triplea.ai.sidecar.session.ProSessionSnapshotStore;
 import org.triplea.ai.sidecar.session.Session;
 import org.triplea.ai.sidecar.wire.WirePlayer;
@@ -197,7 +199,82 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
       politicalActions = List.of();
     }
 
-    return new PurchasePlan(buys, repairs, placements, politicalActions);
+    // Project storedCombatMoveMap to WireMoveDescription[] (mirror CombatMoveExecutor.execute).
+    // invokeCombatMoveForSidecar takes the doMove branch because storedCombatMoveMap was populated
+    // by invokePurchaseForSidecar above — zero re-planning, pure translation.
+    //
+    // Two setup steps mirror CombatMoveExecutor exactly:
+    //
+    // 1. Restore the combat move map from the snapshot we just saved so that territory/unit
+    //    references inside storedCombatMoveMap point to the live GameData (not the dataCopy used
+    //    during purchase simulation). Without this, WireMoveDescriptionBuilder cannot resolve unit
+    //    UUIDs in uuidToWireId and produces empty unitIds lists.
+    //
+    // 2. Advance the game sequence to "combatMove" so MoveDelegate.performMove can resolve
+    //    GameStepPropertiesHelper.isCombatMove. The sequence is still at "germansPurchase"; the
+    //    minimal WireState (empty territories/players) only updates the step.
+    final var snapOpt = snapshotStore.load(session.key());
+    snapOpt.ifPresent(snap -> proAi.restoreCombatMoveMapFromSnapshot(snap, data));
+
+    WireStateApplier.apply(
+        data,
+        new WireState(
+            List.of(),
+            List.of(),
+            request.state().round(),
+            "combatMove",
+            request.state().currentPlayer(),
+            List.of()),
+        session.unitIdMap());
+
+    final Map<UUID, String> uuidToWireId = new HashMap<>();
+    session.unitIdMap().forEach((wireId, uuid) -> uuidToWireId.put(uuid, wireId));
+
+    // dryRun=true: capture moves WITHOUT executing them so that CombatMoveExecutor can re-run the
+    // same storedCombatMoveMap (restored from snapshot) with units still in their starting
+    // positions. Calling super.performMove here would move units in live GameData, leaving them at
+    // destinations when CombatMoveExecutor later tries to replay the same plan.
+    final RecordingMoveDelegate combatRecorder =
+        new RecordingMoveDelegate(proAi, /* dryRun= */ true);
+    combatRecorder.initialize("move", "Move");
+    combatRecorder.setDelegateBridgeAndPlayer(new ProDummyDelegateBridge(proAi, player, data));
+    final Future<Void> combatFuture =
+        session
+            .offensiveExecutor()
+            .submit(
+                () -> {
+                  proAi.reinitializeProDataForSidecar();
+                  proAi.invokeCombatMoveForSidecar(combatRecorder, data, player);
+                  return null;
+                });
+    try {
+      combatFuture.get();
+    } catch (final InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("PurchaseExecutor (combat-move projection) interrupted", ie);
+    } catch (final ExecutionException ee) {
+      final Throwable cause = ee.getCause();
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      throw new RuntimeException("PurchaseExecutor (combat-move projection) failed", cause);
+    }
+
+    final List<WireMoveDescription> nonBombingMoves =
+        combatRecorder.captured().stream()
+            .filter(c -> !c.isBombing())
+            .map(c -> WireMoveDescriptionBuilder.build(c.move(), uuidToWireId))
+            .toList();
+    final List<WireMoveDescription> bombingMoves =
+        combatRecorder.captured().stream()
+            .filter(RecordingMoveDelegate.CapturedMove::isBombing)
+            .map(c -> WireMoveDescriptionBuilder.build(c.move(), uuidToWireId))
+            .toList();
+    final List<WireMoveDescription> combatMoves = new ArrayList<>();
+    combatMoves.addAll(nonBombingMoves);
+    combatMoves.addAll(bombingMoves);
+
+    return new PurchasePlan(buys, repairs, placements, politicalActions, combatMoves);
   }
 
   /**

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingMoveDelegate.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingMoveDelegate.java
@@ -45,10 +45,24 @@ public final class RecordingMoveDelegate extends MoveDelegate {
   public record CapturedMove(MoveDescription move, boolean isBombing) {}
 
   private final ProAi proAi;
+  private final boolean dryRun;
   private final List<CapturedMove> captured = new ArrayList<>();
 
   public RecordingMoveDelegate(final ProAi proAi) {
+    this(proAi, false);
+  }
+
+  /**
+   * Constructs a recording delegate that optionally skips {@code super.performMove}.
+   *
+   * @param dryRun when {@code true}, moves are captured without being executed — units are not
+   *     moved and game state is not mutated. Use this for read-only projections (e.g. purchase-time
+   *     combat-move preview) to avoid side effects that would break subsequent real-execution calls
+   *     in {@link CombatMoveExecutor}.
+   */
+  public RecordingMoveDelegate(final ProAi proAi, final boolean dryRun) {
     this.proAi = proAi;
+    this.dryRun = dryRun;
   }
 
   /** Returns an unmodifiable snapshot of all successfully validated moves in call order. */
@@ -58,10 +72,12 @@ public final class RecordingMoveDelegate extends MoveDelegate {
 
   @Override
   public Optional<String> performMove(final MoveDescription move) {
-    final Optional<String> error = super.performMove(move);
-    if (error.isPresent()) {
-      // Move failed MoveValidator — do NOT record, propagate error to ProAi.
-      return error;
+    if (!dryRun) {
+      final Optional<String> error = super.performMove(move);
+      if (error.isPresent()) {
+        // Move failed MoveValidator — do NOT record, propagate error to ProAi.
+        return error;
+      }
     }
     final Territory end = move.getRoute().getEnd();
     captured.add(new CapturedMove(move, proAi.shouldBomberBomb(end)));

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchasePlanJsonTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchasePlanJsonTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class PurchasePlanJsonTest {
@@ -80,5 +81,51 @@ class PurchasePlanJsonTest {
     assertInstanceOf(PurchasePlan.class, decoded);
     PurchasePlan back = (PurchasePlan) decoded;
     assertEquals(0, back.politicalActions().size());
+  }
+
+  @Test
+  void purchasePlanRoundTripsWithCombatMoves() throws Exception {
+    PurchasePlan plan =
+        new PurchasePlan(
+            List.of(new PurchaseOrder("infantry", 2, "Germany")),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(
+                new WireMoveDescription(
+                    List.of("u1"),
+                    "Germany",
+                    "Poland",
+                    Map.of(),
+                    Map.of("u1", new WireUnitClassification(false, false)),
+                    Map.of()),
+                new WireMoveDescription(
+                    List.of("u2"),
+                    "Sea Zone 5",
+                    "Sea Zone 6",
+                    Map.of(),
+                    Map.of("u2", new WireUnitClassification(false, true)),
+                    Map.of())));
+    String json = mapper.writeValueAsString((DecisionPlan) plan);
+    assertTrue(json.contains("\"combatMoves\""));
+    assertTrue(json.contains("\"Germany\""));
+    DecisionPlan decoded = mapper.readValue(json, DecisionPlan.class);
+    assertInstanceOf(PurchasePlan.class, decoded);
+    PurchasePlan back = (PurchasePlan) decoded;
+    assertEquals(2, back.combatMoves().size());
+    assertEquals("Germany", back.combatMoves().get(0).from());
+    assertEquals("Poland", back.combatMoves().get(0).to());
+    assertEquals(List.of("u1"), back.combatMoves().get(0).unitIds());
+  }
+
+  @Test
+  void purchasePlanWithMissingCombatMovesDefaultsToEmpty() throws Exception {
+    String json =
+        "{\"kind\":\"purchase\",\"buys\":[{\"unitType\":\"infantry\",\"count\":1}],"
+            + "\"repairs\":[],\"placements\":[],\"politicalActions\":[]}";
+    DecisionPlan decoded = mapper.readValue(json, DecisionPlan.class);
+    assertInstanceOf(PurchasePlan.class, decoded);
+    PurchasePlan back = (PurchasePlan) decoded;
+    assertEquals(0, back.combatMoves().size());
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
@@ -250,4 +250,79 @@ class PurchaseExecutorTest {
 
     assertThat(plan.politicalActions()).as("politicalActions must never be null").isNotNull();
   }
+
+  /**
+   * Verifies that {@code combatMoves} is populated in the PurchasePlan response and ordered
+   * correctly (land/amphib/bombard moves first, bombing/SBR moves last).
+   *
+   * <p>Turn-1 Germans always have at least one land combat move (they border Poland and other
+   * Allied territories). SBR moves are optional; what matters is that non-bombing moves precede
+   * bombing moves in the list.
+   *
+   * <p>This exercises the {@code invokeCombatMoveForSidecar} projection path: after purchase, the
+   * {@code storedCombatMoveMap} is populated; the executor calls {@code doMove} (not {@code
+   * doCombatMove} — zero re-planning) and captures the resulting MoveDescriptions via a {@link
+   * RecordingMoveDelegate}.
+   */
+  @Test
+  void combatMovesArePopulatedAndOrderedCorrectlyAfterPurchase() throws Exception {
+    final Session session = freshSession("Germans");
+    final PurchasePlan plan =
+        new PurchaseExecutor().execute(session, purchaseRequestFor("Germans"));
+
+    assertThat(plan.combatMoves()).as("combatMoves must never be null").isNotNull();
+    assertThat(plan.combatMoves())
+        .as("Germans should have at least one combat move on turn 1")
+        .isNotEmpty();
+
+    // Each move must reference a non-blank from/to territory.
+    // unitIds will be empty in this test context because session.unitIdMap() is not populated —
+    // the WireState used here is empty (no territories/units), so no wire-ID → UUID mappings are
+    // registered. In production the WireState carries all units, so unitIds are populated.
+    for (final var md : plan.combatMoves()) {
+      assertThat(md.from()).as("combatMove.from must not be blank").isNotBlank();
+      assertThat(md.to()).as("combatMove.to must not be blank").isNotBlank();
+    }
+
+    // Ordering (non-bombing ++ bombing) is structurally guaranteed by PurchaseExecutor's
+    // concatenation of nonBombingMoves then bombingMoves. Verifying it via unit classifications
+    // here would require a populated session.unitIdMap(), which this test intentionally omits
+    // (empty WireState — see comment above). The classification-based ordering test is covered
+    // by CombatMoveExecutorTest for the real sidecar pipeline.
+  }
+
+  /**
+   * Data-rooting audit: verifies that combat-move simulation predicates (ProMatches etc.) resolve
+   * correctly during purchase-time planning. The returned combatMoves reference real territories
+   * that exist in the session's GameData, confirming that the ProAi's data references were rooted
+   * through the session clone rather than a stale copy.
+   *
+   * <p>If the data-rooting bug class (proData.getPlayer().getData() pointing to a detached
+   * dataCopy) affected combat-move planning, we would see empty combatMoves or moves referencing
+   * territories that do not exist in the session GameData. Both are caught here.
+   */
+  @Test
+  void combatMoveSimulationPredicatesResolveViaSessionData() throws Exception {
+    final Session session = freshSession("Germans");
+    final PurchasePlan plan =
+        new PurchaseExecutor().execute(session, purchaseRequestFor("Germans"));
+
+    assertThat(plan.combatMoves())
+        .as("combatMoves must be non-empty — data-rooting failure would yield empty list")
+        .isNotEmpty();
+
+    final var gameData = session.gameData();
+    for (final var md : plan.combatMoves()) {
+      // Every from-territory referenced by the combat move must exist in the live session data.
+      assertThat(gameData.getMap().getTerritoryOrNull(md.from()))
+          .as(
+              "combatMove.from '%s' must exist in session GameData — stale dataCopy would "
+                  + "reference territories unknown to the live clone",
+              md.from())
+          .isNotNull();
+      assertThat(gameData.getMap().getTerritoryOrNull(md.to()))
+          .as("combatMove.to '%s' must exist in session GameData", md.to())
+          .isNotNull();
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `combatMoves: List<WireMoveDescription>` to `PurchasePlan` DTO with `@JsonCreator` (absent → `List.of()` default)
- Extends `PurchaseExecutor.execute()` to project `storedCombatMoveMap` to `WireMoveDescription[]` after purchase simulation
- Adds `dryRun=true` mode to `RecordingMoveDelegate` so the projection captures moves without executing them (prevents breaking `CombatMoveExecutor`'s subsequent real-execution run)
- Ordering: non-bombing moves first, then bombing/SBR moves (concatenated)
- Adds `PurchasePlanJsonTest` tests for combatMoves roundtrip and missing-combatMoves default
- Adds `PurchaseExecutorTest` tests: combatMovesArePopulatedAndOrderedCorrectlyAfterPurchase and combatMoveSimulationPredicatesResolveViaSessionData

## Why dryRun

RecordingMoveDelegate.performMove calls super.performMove which executes the move in live GameData. Without dry-run, the purchase-time projection moves units to their combat destinations; CombatMoveExecutor then finds units in wrong positions and produces empty moves. dryRun=true captures the same MoveDescription objects without touching game state, so CombatMoveExecutor can restore from snapshot and re-run for real.

## Test plan

- [x] ./gradlew :game-app:ai-sidecar:check — 304 tests pass (4 skipped)
- [x] No pre-existing test regressions (3 previously failing tests now fixed)

Companion map-room PR: map-room/map-room#2380

Closes map-room/map-room#2371