### PR TITLE
fix(proai): seed AI RNG sources for sidecar determinism (map-room#2377)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionRegistry.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionRegistry.java
@@ -190,6 +190,10 @@ public final class SessionRegistry {
     final GameData data = canonical.cloneForSession();
     final ProAi proAi = new ProAi("sidecar-" + key.gameId() + "-" + key.nation(), key.nation());
     proAi.getProData().setSeed(seed);
+    // Seed the battle calculator BEFORE prepareData runs (which constructs workers). The
+    // calculator otherwise uses an unseeded MersenneTwister per trial, leaking process-wide
+    // entropy into the wire response (map-room/map-room#2376 / #2377).
+    proAi.seedBattleCalc(seed);
     final ExecutorService offensiveExecutor =
         Executors.newSingleThreadExecutor(
             r -> {

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ProAiDeterminismAuditTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ProAiDeterminismAuditTest.java
@@ -49,26 +49,41 @@ import org.triplea.ai.sidecar.wire.WireState;
  * <p>This audit is deliberately non-fixing. Failures surface specific divergence sites that are
  * filed as separate follow-up issues; the audit's only role is to capture the empirical evidence.
  *
- * <p><b>Why {@link Disabled}:</b> as of the initial audit (2026-05-09) every fixture is RED.
- * Leaving the tests enabled would block {@code :game-app:ai-sidecar:check} indefinitely. The tests
- * are meant to be re-enabled by whichever follow-up PR believes it has fixed the underlying
- * non-determinism (primary suspect: {@code Math.random()} in {@code
- * ProPurchaseUtils.randomizePurchaseOption}); at that point they become a regression suite pinning
- * the (gamestate, seed) → wire-response invariant.
+ * <p><b>Status after map-room/map-room#2377:</b> the gross non-determinism (different unit types
+ * bought entirely; completely different placement totals) has been eliminated. What remains is a
+ * subtler residual flake where {@code politicalActions} occasionally flips at the {@code random <=
+ * warChance} threshold check inside {@link games.strategy.triplea.ai.pro.ProPoliticsAi}.
+ * Empirically (~10 reruns of each fixture):
  *
- * <p>To re-run the audit manually:
+ * <ul>
+ *   <li>Round-1 Russians purchase: deterministic (Russia has no war-declaration options on round 1,
+ *       so the threshold flip can't bite).
+ *   <li>Round-1 Germans / British purchase: {@code buys} and {@code placements} now identical
+ *       across runs; only {@code politicalActions} occasionally flips between empty and a single
+ *       war target.
+ *   <li>Round-1 Japanese purchase: still cascading divergence (more diverse unit types and more
+ *       potential war targets, so threshold drift cascades through the plan).
+ *   <li>Round-1 Germans / Japanese NCM: residual move-source-territory drift.
+ * </ul>
+ *
+ * <p>Per the discussion on map-room/map-room#2376, the remaining flake is not architecturally
+ * load-bearing — sidecar calls are one-shot, the bot does not compare wire responses across
+ * retries, and Session-elimination is gated on "calls being self-contained from gamestate" rather
+ * than on byte-identical reproducibility. The remaining drift is captured as a follow-up for
+ * incremental cleanup; this audit class stays {@link Disabled} so CI does not flake on the
+ * threshold-boundary cases.
+ *
+ * <p>To re-run the audit manually (delete or comment-out the class-level {@link Disabled}):
  *
  * <pre>{@code
  * ./gradlew :game-app:ai-sidecar:test \
- *   --tests org.triplea.ai.sidecar.exec.ProAiDeterminismAuditTest -PenableAudit
+ *   --tests org.triplea.ai.sidecar.exec.ProAiDeterminismAuditTest
  * }</pre>
- *
- * (the {@code -PenableAudit} flag is documentation only — JUnit ignores Gradle properties; you
- * still need to comment out the {@code @Disabled} annotation locally to actually run the test).
  */
 @Disabled(
-    "Audit harness for map-room/map-room#2376. Currently RED across all fixtures. Re-enable from"
-        + " the PR that fixes the underlying non-determinism so this becomes a regression test.")
+    "Audit harness for map-room/map-room#2376. Politics threshold-flip flake remains after #2377;"
+        + " not architecturally load-bearing — see class javadoc. Re-enable progressively as"
+        + " further determinism fixes land.")
 class ProAiDeterminismAuditTest {
 
   /** Seed used for every audit run. Matches the constant in {@link PurchaseExecutorTest}. */
@@ -150,10 +165,11 @@ class ProAiDeterminismAuditTest {
   private Session freshSession(final String nation) {
     final GameData data = canonical.cloneForSession();
     final ProAi proAi = new ProAi("audit-" + nation + "-" + UUID.randomUUID(), nation);
-    // CRITICAL: mirrors SessionRegistry.buildSession line 192. Without this, ProData.rng is
-    // default-seeded (`new Random()`) and politics planning becomes non-deterministic
-    // independent of any other findings.
+    // CRITICAL: mirrors SessionRegistry.buildSession exactly. Without these two seed-set calls,
+    // ProData.rng and the ConcurrentBattleCalculator both run unseeded, masking the determinism
+    // contract that production code carefully establishes (map-room/map-room#2376 / #2377).
     proAi.getProData().setSeed(SEED);
+    proAi.seedBattleCalc(SEED);
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     return new Session(
         "s-audit-" + UUID.randomUUID(),

--- a/game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
@@ -13,7 +13,21 @@ public final class PlainRandomSource implements IRandomSource {
   private final Object lock = new Object();
 
   @GuardedBy("lock")
-  private final RandomGenerator random = new MersenneTwister();
+  private final RandomGenerator random;
+
+  /** Default constructor: nondeterministic seeding (current behaviour). */
+  public PlainRandomSource() {
+    this.random = new MersenneTwister();
+  }
+
+  /**
+   * Seeded constructor: produces a deterministic sequence given the same {@code seed}. Used by the
+   * AI sidecar's deterministic battle-calculator path so {@code (gamestate, seed) → wire-response}
+   * is a pure function (see map-room/map-room#2376 / #2377).
+   */
+  public PlainRandomSource(final long seed) {
+    this.random = new MersenneTwister(seed);
+  }
 
   @Override
   public int[] getRandom(final int max, final int count, final String annotation) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
@@ -27,4 +27,15 @@ public class ProAi extends AbstractProAi {
   protected void prepareData(final GameData data) {
     concurrentCalc.setGameData(data);
   }
+
+  /**
+   * Switch this ProAi's battle calculator into deterministic single-worker mode (see {@link
+   * games.strategy.triplea.odds.calculator.ConcurrentBattleCalculator#setSeed} javadoc). Must be
+   * called before the first {@link #prepareData} so the seed is in place when worker construction
+   * runs. Used by the AI sidecar for {@code (gamestate, seed) → wire-response} purity (see
+   * map-room/map-room#2376 / #2377).
+   */
+  public void seedBattleCalc(final long seed) {
+    concurrentCalc.setSeed(seed);
+  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
@@ -14,8 +14,8 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.PoliticsDelegate;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -60,8 +60,8 @@ class ProPoliticsAi {
     ProLogger.trace("Valid War options: " + validWarActions);
 
     // Divide war actions into enemy and neutral
-    final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap = new HashMap<>();
-    final Map<PoliticalActionAttachment, List<GamePlayer>> neutralMap = new HashMap<>();
+    final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap = new LinkedHashMap<>();
+    final Map<PoliticalActionAttachment, List<GamePlayer>> neutralMap = new LinkedHashMap<>();
     for (final PoliticalActionAttachment action : validWarActions) {
       final List<GamePlayer> warPlayers = new ArrayList<>();
       for (final PoliticalActionAttachment.RelationshipChange relationshipChange :
@@ -106,7 +106,7 @@ class ProPoliticsAi {
               + attackOptions);
 
       // Find attack options per war action
-      final Map<PoliticalActionAttachment, Double> attackPercentageMap = new HashMap<>();
+      final Map<PoliticalActionAttachment, Double> attackPercentageMap = new LinkedHashMap<>();
       for (final PoliticalActionAttachment action : enemyMap.keySet()) {
         int count = 0;
         final List<GamePlayer> enemyPlayers = enemyMap.get(action);
@@ -125,7 +125,10 @@ class ProPoliticsAi {
 
       // Decide whether to declare war on an enemy
       final List<PoliticalActionAttachment> options = new ArrayList<>(attackPercentageMap.keySet());
-      Collections.shuffle(options);
+      // Shuffle with the seeded rng so the war-target selection is deterministic given
+      // (gamestate, seed). The default Collections.shuffle(list) overload uses an unseeded
+      // ThreadLocalRandom and would leak process entropy here (map-room/map-room#2376 / #2377).
+      Collections.shuffle(options, rng);
       for (final PoliticalActionAttachment action : options) {
         final double roundFactor = (round - 1) * .05; // 0, .05, .1, .15, etc
         final double warChance =
@@ -142,7 +145,7 @@ class ProPoliticsAi {
 
       // Decide whether to declare war on a neutral
       final List<PoliticalActionAttachment> options = new ArrayList<>(neutralMap.keySet());
-      Collections.shuffle(options);
+      Collections.shuffle(options, rng);
       final double random = rng.nextDouble();
       final double warChance = .01;
       ProLogger.debug("warChance=" + warChance + ", random=" + random);
@@ -158,7 +161,7 @@ class ProPoliticsAi {
           AiPoliticalUtils.getPoliticalActionsOther(
               player, politicsDelegate.getTestedConditions(), data);
       if (!actionChoicesOther.isEmpty()) {
-        Collections.shuffle(actionChoicesOther);
+        Collections.shuffle(actionChoicesOther, rng);
         int i = 0;
         final double random = rng.nextDouble();
         final int maxOtherActionsPerTurn =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -45,6 +45,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -815,7 +816,7 @@ class ProPurchaseAi {
               purchaseTerritories,
               remainingConstructions,
               t);
-          final Map<ProPurchaseOption, Double> defenseEfficiencies = new HashMap<>();
+          final Map<ProPurchaseOption, Double> defenseEfficiencies = new LinkedHashMap<>();
           for (final ProPurchaseOption ppo : purchaseOptionsForTerritory) {
             if (isLand) {
               defenseEfficiencies.put(
@@ -833,7 +834,7 @@ class ProPurchaseAi {
             }
           }
           final Optional<ProPurchaseOption> optionalSelectedOption =
-              ProPurchaseUtils.randomizePurchaseOption(defenseEfficiencies, "Defense");
+              ProPurchaseUtils.randomizePurchaseOption(proData, defenseEfficiencies, "Defense");
           if (optionalSelectedOption.isEmpty()) {
             break;
           }
@@ -1185,29 +1186,30 @@ class ProPurchaseAi {
         // Select purchase option
         Optional<ProPurchaseOption> optionalSelectedOption = Optional.empty();
         if (!selectFodderUnit && attackAndDefenseDifference > 0 && !landDefenseOptions.isEmpty()) {
-          final Map<ProPurchaseOption, Double> defenseEfficiencies = new HashMap<>();
+          final Map<ProPurchaseOption, Double> defenseEfficiencies = new LinkedHashMap<>();
           for (final ProPurchaseOption ppo : landDefenseOptions) {
             defenseEfficiencies.put(
                 ppo, ppo.getDefenseEfficiency(enemyDistance, data, ownedLocalUnits, unitsToPlace));
           }
           optionalSelectedOption =
-              ProPurchaseUtils.randomizePurchaseOption(defenseEfficiencies, "Land Defense");
+              ProPurchaseUtils.randomizePurchaseOption(
+                  proData, defenseEfficiencies, "Land Defense");
         } else if (!selectFodderUnit && !landAttackOptions.isEmpty()) {
-          final Map<ProPurchaseOption, Double> attackEfficiencies = new HashMap<>();
+          final Map<ProPurchaseOption, Double> attackEfficiencies = new LinkedHashMap<>();
           for (final ProPurchaseOption ppo : landAttackOptions) {
             attackEfficiencies.put(
                 ppo, ppo.getAttackEfficiency(enemyDistance, data, ownedLocalUnits, unitsToPlace));
           }
           optionalSelectedOption =
-              ProPurchaseUtils.randomizePurchaseOption(attackEfficiencies, "Land Attack");
+              ProPurchaseUtils.randomizePurchaseOption(proData, attackEfficiencies, "Land Attack");
         } else if (!landFodderOptions.isEmpty()) {
-          final Map<ProPurchaseOption, Double> fodderEfficiencies = new HashMap<>();
+          final Map<ProPurchaseOption, Double> fodderEfficiencies = new LinkedHashMap<>();
           for (final ProPurchaseOption ppo : landFodderOptions) {
             fodderEfficiencies.put(
                 ppo, ppo.getFodderEfficiency(enemyDistance, data, ownedLocalUnits, unitsToPlace));
           }
           optionalSelectedOption =
-              ProPurchaseUtils.randomizePurchaseOption(fodderEfficiencies, "Land Fodder");
+              ProPurchaseUtils.randomizePurchaseOption(proData, fodderEfficiencies, "Land Fodder");
           if (optionalSelectedOption.isPresent()) {
             addedFodderUnits += optionalSelectedOption.get().getQuantity();
           }
@@ -1647,7 +1649,7 @@ class ProPurchaseAi {
                 purchaseTerritories,
                 0,
                 t);
-            final Map<ProPurchaseOption, Double> defenseEfficiencies = new HashMap<>();
+            final Map<ProPurchaseOption, Double> defenseEfficiencies = new LinkedHashMap<>();
             for (final ProPurchaseOption ppo : seaPurchaseOptionsForTerritory) {
               defenseEfficiencies.put(
                   ppo,
@@ -1660,7 +1662,8 @@ class ProPurchaseAi {
                       unusedLocalCarrierCapacity));
             }
             final Optional<ProPurchaseOption> optionalSelectedOption =
-                ProPurchaseUtils.randomizePurchaseOption(defenseEfficiencies, "Sea Defense");
+                ProPurchaseUtils.randomizePurchaseOption(
+                    proData, defenseEfficiencies, "Sea Defense");
             if (optionalSelectedOption.isEmpty()) {
               break;
             }
@@ -1859,7 +1862,7 @@ class ProPurchaseAi {
               purchaseTerritories,
               0,
               t);
-          final Map<ProPurchaseOption, Double> defenseEfficiencies = new HashMap<>();
+          final Map<ProPurchaseOption, Double> defenseEfficiencies = new LinkedHashMap<>();
           for (final ProPurchaseOption ppo : seaPurchaseOptionsForTerritory) {
             defenseEfficiencies.put(
                 ppo,
@@ -1872,7 +1875,7 @@ class ProPurchaseAi {
                     unusedLocalCarrierCapacity));
           }
           final Optional<ProPurchaseOption> optionalSelectedOption =
-              ProPurchaseUtils.randomizePurchaseOption(defenseEfficiencies, "Sea Defense");
+              ProPurchaseUtils.randomizePurchaseOption(proData, defenseEfficiencies, "Sea Defense");
           if (optionalSelectedOption.isEmpty()) {
             break;
           }
@@ -2029,7 +2032,7 @@ class ProPurchaseAi {
                   purchaseTerritories,
                   0,
                   t);
-              final Map<ProPurchaseOption, Double> amphibEfficiencies = new HashMap<>();
+              final Map<ProPurchaseOption, Double> amphibEfficiencies = new LinkedHashMap<>();
               for (final ProPurchaseOption ppo : amphibPurchaseOptionsForTerritory) {
                 if (ppo.getTransportCost() <= transportCapacity) {
                   amphibEfficiencies.put(
@@ -2038,7 +2041,7 @@ class ProPurchaseAi {
                 }
               }
               final Optional<ProPurchaseOption> optionalSelectedOption =
-                  ProPurchaseUtils.randomizePurchaseOption(amphibEfficiencies, "Amphib");
+                  ProPurchaseUtils.randomizePurchaseOption(proData, amphibEfficiencies, "Amphib");
               if (optionalSelectedOption.isEmpty()) {
                 break;
               }
@@ -2065,12 +2068,13 @@ class ProPurchaseAi {
                 purchaseTerritories,
                 0,
                 t);
-            final Map<ProPurchaseOption, Double> transportEfficiencies = new HashMap<>();
+            final Map<ProPurchaseOption, Double> transportEfficiencies = new LinkedHashMap<>();
             for (final ProPurchaseOption ppo : seaTransportPurchaseOptionsForTerritory) {
               transportEfficiencies.put(ppo, ppo.getTransportEfficiencyRatio());
             }
             final Optional<ProPurchaseOption> optionalSelectedOption =
-                ProPurchaseUtils.randomizePurchaseOption(transportEfficiencies, "Sea Transport");
+                ProPurchaseUtils.randomizePurchaseOption(
+                    proData, transportEfficiencies, "Sea Transport");
             if (optionalSelectedOption.isEmpty()) {
               break;
             }
@@ -2244,7 +2248,7 @@ class ProPurchaseAi {
             purchaseTerritories,
             0,
             t);
-        final Map<ProPurchaseOption, Double> defenseEfficiencies = new HashMap<>();
+        final Map<ProPurchaseOption, Double> defenseEfficiencies = new LinkedHashMap<>();
         for (final ProPurchaseOption ppo : purchaseOptionsForTerritory) {
           defenseEfficiencies.put(
               ppo,
@@ -2253,7 +2257,7 @@ class ProPurchaseAi {
                       1, data, ownedLocalUnits, placeTerritory.getPlaceUnits()));
         }
         final Optional<ProPurchaseOption> optionalSelectedOption =
-            ProPurchaseUtils.randomizePurchaseOption(defenseEfficiencies, "Defense");
+            ProPurchaseUtils.randomizePurchaseOption(proData, defenseEfficiencies, "Defense");
         if (optionalSelectedOption.isEmpty()) {
           break;
         }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -41,13 +41,23 @@ import org.triplea.java.collections.IntegerMap;
 public final class ProPurchaseUtils {
 
   /**
-   * Randomly selects one of the specified purchase options of the specified type.
+   * Randomly selects one of the specified purchase options of the specified type, using the
+   * deterministic RNG owned by {@link ProData} so that the same {@code (gamestate, seed)} pair
+   * produces the same selection sequence across runs.
+   *
+   * <p>Previously this method consulted {@link Math#random()}, a process-wide unseeded RNG that
+   * caused {@code invokePurchaseForSidecar} to produce divergent wire responses across fresh
+   * sessions even when the sidecar carefully seeded {@link ProData#setSeed(long)}. See the
+   * map-room/map-room#2376 audit for the empirical evidence and map-room/map-room#2377 for the fix
+   * rationale.
    *
    * @return The selected purchase option or empty if no purchase option of the specified type is
    *     available.
    */
   public static Optional<ProPurchaseOption> randomizePurchaseOption(
-      final Map<ProPurchaseOption, Double> purchaseEfficiencies, final String type) {
+      final ProData proData,
+      final Map<ProPurchaseOption, Double> purchaseEfficiencies,
+      final String type) {
 
     ProLogger.trace("Select purchase option for " + type);
     double totalEfficiency = 0;
@@ -66,7 +76,7 @@ public final class ProPurchaseUtils {
       ProLogger.trace(
           ppo.getUnitType().getName() + ", probability=" + chance + ", upperBound=" + upperBound);
     }
-    final double randomNumber = Math.random() * 100;
+    final double randomNumber = proData.getRng().nextDouble() * 100;
     ProLogger.trace("Random number: " + randomNumber);
     for (final ProPurchaseOption ppo : purchasePercentages.keySet()) {
       if (randomNumber <= purchasePercentages.get(ppo)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
@@ -12,6 +12,8 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameDataUtils;
+import games.strategy.engine.random.IRandomSource;
+import games.strategy.engine.random.PlainRandomSource;
 import games.strategy.triplea.delegate.battle.BattleResults;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
@@ -23,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Setter;
 
 class BattleCalculator implements IBattleCalculator {
@@ -38,15 +41,33 @@ class BattleCalculator implements IBattleCalculator {
   private volatile boolean cancelled = false;
   private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
+  /**
+   * When non-null, every {@link DummyDelegateBridge} created in {@link #calculate} shares a single
+   * {@link PlainRandomSource} seeded with this value, instead of the default per-trial unseeded
+   * {@code MersenneTwister}. Enables deterministic battle calculator output for the AI sidecar (see
+   * map-room/map-room#2376 / #2377).
+   */
+  @Nullable private final Long seed;
+
   BattleCalculator(GameData data) {
+    this(data, null);
+  }
+
+  BattleCalculator(GameData data, @Nullable Long seed) {
     gameData =
         GameDataUtils.cloneGameData(data, GameDataManager.Options.forBattleCalculator())
             .orElseThrow();
+    this.seed = seed;
   }
 
   BattleCalculator(byte[] data) {
+    this(data, null);
+  }
+
+  BattleCalculator(byte[] data, @Nullable Long seed) {
     gameData = GameDataUtils.createGameDataFromBytes(data).orElseThrow();
     gameData.getProperties().set(EDIT_MODE, false);
+    this.seed = seed;
   }
 
   @Override
@@ -92,8 +113,14 @@ class BattleCalculator implements IBattleCalculator {
       final List<Unit> defenderOrderOfLosses =
           OrderOfLossesInputPanel.getUnitListByOrderOfLoss(
               this.defenderOrderOfLosses, defendingUnits, gameData);
+      // When seeded, all trials in this call share a single seeded random source so the
+      // aggregate is reproducible. When unseeded, each trial gets its own unseeded RNG (legacy
+      // behaviour) — see map-room/map-room#2377.
+      final IRandomSource sharedRandomSource = seed != null ? new PlainRandomSource(seed) : null;
       for (int i = 0; i < runCount && !cancelled; i++) {
         final CompositeChange allChanges = new CompositeChange();
+        final IRandomSource trialRandomSource =
+            sharedRandomSource != null ? sharedRandomSource : new PlainRandomSource();
         final DummyDelegateBridge bridge =
             new DummyDelegateBridge(
                 attacker2,
@@ -105,7 +132,8 @@ class BattleCalculator implements IBattleCalculator {
                 retreatAfterRound,
                 retreatAfterXUnitsLeft,
                 retreatWhenOnlyAirLeft,
-                tuvCalculator);
+                tuvCalculator,
+                trialRandomSource);
         final MustFightBattle battle =
             new MustFightBattle(location2, attacker2, gameData, battleTracker);
         battle.setHeadless(true);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
@@ -30,6 +30,16 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
   private final List<BattleCalculator> workers = new CopyOnWriteArrayList<>();
   // do not let calc be set up til data is set
   private volatile boolean isDataSet = false;
+
+  /**
+   * When non-null, switches the calculator into a deterministic single-worker mode: {@link
+   * #createWorkers} produces exactly one {@link BattleCalculator} seeded with this value, and
+   * {@link #calculate} runs all trials sequentially in that worker. Used by the AI sidecar to make
+   * ProAi a pure function of {@code (gamestate, seed)} (see map-room/map-room#2376 / #2377). When
+   * null, the calculator behaves as before — multi-worker, unseeded.
+   */
+  @Nullable private volatile Long seed = null;
+
   // shortcut setting of previous game data if we are trying to set it to a new one, or shutdown
   private final AtomicInteger cancelCurrentOperation = new AtomicInteger(0);
   // do not let setting of game data happen multiple times while we offload creating workers and
@@ -41,6 +51,14 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
   private final Object mutexSetGameData = new Object();
   // do not let multiple calculations or setting calc data happen at same time
   private final Object mutexCalcIsRunning = new Object();
+
+  /**
+   * Switch the calculator into deterministic single-worker mode (see {@link #seed} javadoc). Must
+   * be called before {@link #setGameData} for the next worker construction to pick it up.
+   */
+  public void setSeed(final long seed) {
+    this.seed = seed;
+  }
 
   /** Return value may be ignored. Exceptions are being handled properly. */
   public CompletableFuture<Boolean> setGameData(@Nullable final GameData data) {
@@ -129,16 +147,23 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
         }
       }
       if (cancelCurrentOperation.get() >= 0) {
-        // Create the first battle calc on the current thread to measure the end-to-end copy time.
-        workers.add(new BattleCalculator(serializedData));
-        int threadsToUse = getThreadsToUse((System.currentTimeMillis() - startTime), startMemory);
-        // Now, create the remaining ones in parallel.
-        workers.addAll(
-            IntStream.range(1, threadsToUse)
-                .parallel()
-                .filter(j -> cancelCurrentOperation.get() >= 0)
-                .mapToObj(j -> new BattleCalculator(serializedData))
-                .collect(Collectors.toList()));
+        if (seed != null) {
+          // Deterministic mode: exactly one seeded worker, no parallelism. The seed propagates
+          // into every per-trial PlainRandomSource via BattleCalculator. See seed-field javadoc.
+          workers.add(new BattleCalculator(serializedData, seed));
+        } else {
+          // Create the first battle calc on the current thread to measure the end-to-end copy
+          // time.
+          workers.add(new BattleCalculator(serializedData));
+          int threadsToUse = getThreadsToUse((System.currentTimeMillis() - startTime), startMemory);
+          // Now, create the remaining ones in parallel.
+          workers.addAll(
+              IntStream.range(1, threadsToUse)
+                  .parallel()
+                  .filter(j -> cancelCurrentOperation.get() >= 0)
+                  .mapToObj(j -> new BattleCalculator(serializedData))
+                  .collect(Collectors.toList()));
+        }
       }
     }
     if (cancelCurrentOperation.get() < 0 || data == null) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
@@ -12,6 +12,7 @@ import games.strategy.engine.display.IDisplay;
 import games.strategy.engine.history.DelegateHistoryWriter;
 import games.strategy.engine.history.IDelegateHistoryWriter;
 import games.strategy.engine.player.Player;
+import games.strategy.engine.random.IRandomSource;
 import games.strategy.engine.random.IRandomStats;
 import games.strategy.engine.random.PlainRandomSource;
 import games.strategy.triplea.ResourceLoader;
@@ -28,7 +29,7 @@ import org.triplea.sound.ISound;
 
 /** Delegate bridge implementation with minimum valid behavior. */
 public class DummyDelegateBridge implements IDelegateBridge {
-  private final PlainRandomSource randomSource = new PlainRandomSource();
+  private final IRandomSource randomSource;
   private final IDisplay display = new HeadlessDisplay();
   private final ISound soundChannel = new HeadlessSoundChannel();
   private final DummyPlayer attackingPlayer;
@@ -51,6 +52,38 @@ public class DummyDelegateBridge implements IDelegateBridge {
       final int retreatAfterXUnitsLeft,
       final boolean retreatWhenOnlyAirLeft,
       final TuvCostsCalculator tuvCalculator) {
+    this(
+        attacker,
+        data,
+        allChanges,
+        attackerOrderOfLosses,
+        defenderOrderOfLosses,
+        attackerKeepOneLandUnit,
+        retreatAfterRound,
+        retreatAfterXUnitsLeft,
+        retreatWhenOnlyAirLeft,
+        tuvCalculator,
+        new PlainRandomSource());
+  }
+
+  /**
+   * Variant accepting an explicit {@link IRandomSource}. Used by the AI sidecar's deterministic
+   * battle-calculator path to inject a seeded RNG so calc results are reproducible across runs (see
+   * map-room/map-room#2376 / #2377).
+   */
+  public DummyDelegateBridge(
+      final GamePlayer attacker,
+      final GameData data,
+      final CompositeChange allChanges,
+      final List<Unit> attackerOrderOfLosses,
+      final List<Unit> defenderOrderOfLosses,
+      final boolean attackerKeepOneLandUnit,
+      final int retreatAfterRound,
+      final int retreatAfterXUnitsLeft,
+      final boolean retreatWhenOnlyAirLeft,
+      final TuvCostsCalculator tuvCalculator,
+      final IRandomSource randomSource) {
+    this.randomSource = randomSource;
     attackingPlayer =
         new DummyPlayer(
             this,


### PR DESCRIPTION
## Summary

Closes map-room/map-room#2377. Eliminates the gross non-determinism the #2376 audit found — `invokePurchaseForSidecar` now produces identical `buys` and `placements` across fresh sessions seeded with the same `(gamestate, seed)` pair.

A residual flake remains in `politicalActions` at the `random <= warChance` threshold check. Per the discussion on #2376 it is **not architecturally load-bearing** (sidecar calls are one-shot, the bot does not compare wire responses across retries, Session-elimination is gated on "calls self-contained from gamestate" rather than byte-identical reproducibility) and is captured for incremental cleanup as map-room/map-room#2387.

## What this PR fixes

Three RNG sources bypassed `ProData.rng` even when the sidecar carefully called `proData.setSeed(seed)`:

| # | Site | Was | Now |
|---|---|---|---|
| 1 | `ProPurchaseUtils.randomizePurchaseOption` (~17 callers from `ProPurchaseAi`) | `Math.random() * 100` | `proData.getRng().nextDouble() * 100` |
| 2 | `ConcurrentBattleCalculator` per-trial RNG (every `DummyDelegateBridge` had its own `new PlainRandomSource(new MersenneTwister())`) | per-trial unseeded MersenneTwister | new `setSeed(long)` switches into deterministic single-worker mode where one shared seeded `PlainRandomSource` covers every trial in a `calculate()` call |
| 3 | `ProPoliticsAi.politicalActions` | `Collections.shuffle(list)` (unseeded `ThreadLocalRandom`) + `HashMap` over `PoliticalActionAttachment` keys | `Collections.shuffle(list, rng)` (seeded) + `LinkedHashMap` |

`ProPurchaseAi`'s nine `Map<ProPurchaseOption, Double>` efficiency maps also become `LinkedHashMap`. `ProPurchaseOption` has no `equals`/`hashCode` override and was keyed by identity-hash, so a plain HashMap iterated in different order across fresh ProAi instances — leaking entropy into the upper-bound calculation that drives `randomizePurchaseOption`.

`ProAi.seedBattleCalc(long)` is the new pass-through. `SessionRegistry.buildSession` calls it immediately after `proAi.getProData().setSeed(seed)` so production sidecar sessions get the deterministic mode automatically.

## Empirical impact

Audit harness (`ProAiDeterminismAuditTest`, currently `@Disabled` per discussion):

| Fixture | Before #2377 | After #2377 |
|---|---|---|
| Russians purchase | RED — entirely different units (1 armour + 1 inf + 2 art ↔ 3 inf + 2 art) | ✅ GREEN reliably |
| British purchase | RED — entirely different units (2 art + 1 inf + 1 mech_inf ↔ 3 inf + 1 armour) | `buys` + `placements` identical; only `politicalActions` occasionally flips ([] ↔ [Japanese]) |
| Germans purchase | RED — placement interleave + politicalActions both diverged | `buys` + `placements` identical; only `politicalActions` occasionally flips ([] ↔ [Russians]) |
| Japanese purchase | RED — entirely different units, different war target sets | Still cascading divergence (more diverse units + more potential war targets — threshold drift propagates) |
| Germans NCM | RED — different source-territory selections | Residual move-source drift |
| Japanese NCM | RED — completely different move set | Residual move-source drift |

Pre-existing flake `NoncombatMoveExecutorIntegrationTest.germansClaimBulgariaOnTurn1` (regression test for map-room#2195, hit on the audit machine before this PR) is now reliably passing — incidental win from the calc-seed fix.

## Architectural note

The original #2376 framing said determinism gates Session-elimination. Per the #2376 discussion, this is overstated: what actually gates Session-elimination is *self-contained calls* (each invocation reconstructs everything it needs from gamestate / passed-in snapshots), not byte-identical reproducibility. So this PR is enough to ship — the remaining politics-threshold drift can land separately.

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:check` — green (all suites including the previously-flaky Bulgaria test)
- [x] `./gradlew :game-app:game-core:test` — green (no regressions from `PlainRandomSource` / `BattleCalculator` / `DummyDelegateBridge` constructor additions)
- [x] `./gradlew :game-app:ai-sidecar:spotlessCheck :game-app:game-core:spotlessCheck` — green
- [x] Run `ProAiDeterminismAuditTest` manually (delete class-level `@Disabled`) — Russians purchase reliably GREEN; Germans/British purchase have identical `buys` + `placements` with residual `politicalActions` flake; Japanese + NCM still RED (captured in #2387)
- [ ] 🧑 Manual: confirm the audit's `@Disabled` keeps `:check` green in CI even without the local fix being available (i.e., the test class is properly skipped, not silently failing)

## Files changed

- `game-app/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java` — add seeded constructor
- `game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java` — accept optional `IRandomSource` (existing constructor delegates to unseeded variant)
- `game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java` — accept optional seed; share one seeded `PlainRandomSource` across all trials in a `calculate()` call
- `game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java` — `setSeed(long)` + single-seeded-worker path
- `game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java` — `seedBattleCalc(long)` pass-through
- `game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java` — `randomizePurchaseOption` consumes seeded `proData.getRng()`
- `game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java` — call sites updated; efficiency maps become `LinkedHashMap`
- `game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java` — `Collections.shuffle(…, rng)` + `LinkedHashMap`
- `game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/session/SessionRegistry.java` — call `proAi.seedBattleCalc(seed)`
- `game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ProAiDeterminismAuditTest.java` — mirror the seeding in `freshSession`; updated docstring; class-level `@Disabled` retained per #2376 discussion

## Closes

map-room/map-room#2377

## See also

- map-room/map-room#2376 — audit
- map-room/triplea#82 — the audit harness PR (already merged)
- map-room/map-room#2387 — residual politicalActions threshold flake (this PR's natural follow-up)
- map-room/map-room#2378 — test fixtures don't seed proData.rng (separate issue)
- map-room/map-room#2379 — ProTechAi ThreadLocalRandom (out of scope; only matters if tech becomes a sidecar surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)