### PR TITLE
feat(ai-sidecar): reseed proData RNG + battle calc from wire seed at start of execute()

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/NoncombatMoveRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/NoncombatMoveRequest.java
@@ -7,9 +7,15 @@ import org.triplea.ai.sidecar.wire.WireState;
  * Request for the {@code noncombat-move} decision kind. The sidecar restores {@code
  * storedFactoryMoveMap} and {@code storedPurchaseTerritories} from the session snapshot and calls
  * {@code AbstractProAi#invokeNonCombatMoveForSidecar} to produce the move list.
+ *
+ * <p>{@code seed} is the per-call wire seed derived TS-side via {@code seedForCall(rootSeed, round,
+ * phase, nation)} in map-room#2388. {@link
+ * org.triplea.ai.sidecar.exec.NoncombatMoveExecutor#execute(org.triplea.ai.sidecar.session.Session,
+ * NoncombatMoveRequest)} reseeds {@code proData.getRng()} and the battle calculator from this value
+ * at the start of every call so ProAi behaviour is deterministic given {@code (gamestate, seed)}.
  */
 @JsonIgnoreProperties("kind")
-public record NoncombatMoveRequest(WireState state) implements DecisionRequest {
+public record NoncombatMoveRequest(WireState state, long seed) implements DecisionRequest {
   public String kind() {
     return "noncombat-move";
   }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchaseRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchaseRequest.java
@@ -7,9 +7,15 @@ import org.triplea.ai.sidecar.wire.WireState;
  * Request for the {@code purchase} decision kind. Phase 3 is the first offensive kind wired
  * end-to-end; sidecar hydrates a cached {@code GameData} from {@code state} and invokes {@code
  * AbstractProAi#purchase}.
+ *
+ * <p>{@code seed} is the per-call wire seed derived TS-side via {@code seedForCall(rootSeed, round,
+ * phase, nation)} in map-room#2388. {@link
+ * org.triplea.ai.sidecar.exec.PurchaseExecutor#execute(org.triplea.ai.sidecar.session.Session,
+ * PurchaseRequest)} reseeds {@code proData.getRng()} and the battle calculator from this value at
+ * the start of every call so ProAi behaviour is deterministic given {@code (gamestate, seed)}.
  */
 @JsonIgnoreProperties("kind")
-public record PurchaseRequest(WireState state) implements DecisionRequest {
+public record PurchaseRequest(WireState state, long seed) implements DecisionRequest {
   public String kind() {
     return "purchase";
   }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
@@ -82,6 +82,14 @@ public final class NoncombatMoveExecutor
 
     final var proAi = session.proAi();
 
+    // Reseed proData.getRng() and the battle calculator from the per-call wire seed so the
+    // (gamestate, seed) → wire-response mapping is a pure function — independent of any
+    // RNG drift from prior decision calls on this session. Mirrors the seeding pattern
+    // established in SessionRegistry.buildSession (#2377) but at per-call granularity, which
+    // is what the stateless-sidecar campaign needs (#2384, #2376 audit gate).
+    proAi.getProData().setSeed(request.seed());
+    proAi.seedBattleCalc(request.seed());
+
     // Step 3: restore storedFactoryMoveMap and storedPurchaseTerritories
     snapOpt.ifPresent(
         snap -> {

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
@@ -130,6 +130,17 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
     final int pusToSpend = player.getResources().getQuantity(pus);
 
     final ProAi proAi = session.proAi();
+
+    // Reseed proData.getRng() and the battle calculator from the per-call wire seed so the
+    // (gamestate, seed) → wire-response mapping is a pure function — independent of any
+    // RNG drift from prior decision calls on this session. Mirrors the seeding pattern
+    // established in SessionRegistry.buildSession (#2377) but at per-call granularity, which
+    // is what the stateless-sidecar campaign needs (#2384, #2376 audit gate). Applied before
+    // dispatching invokePurchaseForSidecar AND before the internal combat-move projection
+    // below (the projection consumes the same proAi instance and must see the same seed).
+    proAi.getProData().setSeed(request.seed());
+    proAi.seedBattleCalc(request.seed());
+
     final RecordingPurchaseDelegate recorder = new RecordingPurchaseDelegate();
     recorder.initialize("purchase", "Purchase");
     recorder.setDelegateBridgeAndPlayer(new ProDummyDelegateBridge(proAi, player, data));

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchaseRequestJsonTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchaseRequestJsonTest.java
@@ -10,11 +10,12 @@ class PurchaseRequestJsonTest {
   void purchaseRequestDeserialisesThroughSealedDecisionRequest() throws Exception {
     ObjectMapper mapper = new ObjectMapper();
     String json =
-        "{\"kind\":\"purchase\",\"state\":{"
+        "{\"kind\":\"purchase\",\"seed\":42,\"state\":{"
             + "\"territories\":[],\"players\":[],\"round\":1,"
             + "\"phase\":\"purchase\",\"currentPlayer\":\"Germans\"}}";
     DecisionRequest req = mapper.readValue(json, DecisionRequest.class);
     assertInstanceOf(PurchaseRequest.class, req);
     assertEquals("Germans", ((PurchaseRequest) req).state().currentPlayer());
+    assertEquals(42L, ((PurchaseRequest) req).seed());
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutorIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutorIntegrationTest.java
@@ -80,12 +80,12 @@ class NoncombatMoveExecutorIntegrationTest {
 
     // Step 1: purchase — populates storedFactoryMoveMap and storedPurchaseTerritories
     new PurchaseExecutor(store)
-        .execute(session, new PurchaseRequest(wireState("purchase", "Germans")));
+        .execute(session, new PurchaseRequest(wireState("purchase", "Germans"), 0L));
 
     // Step 2: noncombat-move — consumes storedFactoryMoveMap, preserves storedPurchaseTerritories
     final NoncombatMovePlan plan =
         new NoncombatMoveExecutor(store)
-            .execute(session, new NoncombatMoveRequest(noncombatWireState("Germans")));
+            .execute(session, new NoncombatMoveRequest(noncombatWireState("Germans"), 0L));
 
     assertNotNull(plan, "noncombat-move plan must not be null");
     // Germans typically move factories and units on noncombat-move
@@ -105,13 +105,13 @@ class NoncombatMoveExecutorIntegrationTest {
     final Session session = freshSession("Germans");
 
     new PurchaseExecutor(store)
-        .execute(session, new PurchaseRequest(wireState("purchase", "Germans")));
+        .execute(session, new PurchaseRequest(wireState("purchase", "Germans"), 0L));
 
     // If any captured move had isBombing==true, the executor would throw AssertionError.
     // The plan being returned means the invariant held.
     final NoncombatMovePlan plan =
         new NoncombatMoveExecutor(store)
-            .execute(session, new NoncombatMoveRequest(noncombatWireState("Germans")));
+            .execute(session, new NoncombatMoveRequest(noncombatWireState("Germans"), 0L));
 
     assertNotNull(plan, "plan must not be null (no bombing invariant violation)");
   }
@@ -126,9 +126,9 @@ class NoncombatMoveExecutorIntegrationTest {
     final Session session = freshSession("Germans");
 
     new PurchaseExecutor(store)
-        .execute(session, new PurchaseRequest(wireState("purchase", "Germans")));
+        .execute(session, new PurchaseRequest(wireState("purchase", "Germans"), 0L));
     new NoncombatMoveExecutor(store)
-        .execute(session, new NoncombatMoveRequest(noncombatWireState("Germans")));
+        .execute(session, new NoncombatMoveRequest(noncombatWireState("Germans"), 0L));
 
     // storedPurchaseTerritories must still be non-null (not cleared by noncombat-move)
     final Field field = AbstractProAi.class.getDeclaredField("storedPurchaseTerritories");
@@ -200,10 +200,10 @@ class NoncombatMoveExecutorIntegrationTest {
     final Session session = freshSession("Germans");
 
     new PurchaseExecutor(store)
-        .execute(session, new PurchaseRequest(wireState("purchase", "Germans")));
+        .execute(session, new PurchaseRequest(wireState("purchase", "Germans"), 0L));
     final NoncombatMovePlan plan =
         new NoncombatMoveExecutor(store)
-            .execute(session, new NoncombatMoveRequest(noncombatWireState("Germans")));
+            .execute(session, new NoncombatMoveRequest(noncombatWireState("Germans"), 0L));
 
     assertNotNull(plan);
     assertTrue(
@@ -224,7 +224,7 @@ class NoncombatMoveExecutorIntegrationTest {
 
     // Run purchase normally to establish the session state
     new PurchaseExecutor(store)
-        .execute(session, new PurchaseRequest(wireState("purchase", "Germans")));
+        .execute(session, new PurchaseRequest(wireState("purchase", "Germans"), 0L));
 
     // Inject a stale UUID into the snapshot's factoryMoveMap
     final var staleUuid = UUID.randomUUID().toString();
@@ -249,7 +249,7 @@ class NoncombatMoveExecutorIntegrationTest {
 
     final NoncombatMovePlan plan =
         new NoncombatMoveExecutor(store)
-            .execute(session, new NoncombatMoveRequest(noncombatWireState("Germans")));
+            .execute(session, new NoncombatMoveRequest(noncombatWireState("Germans"), 0L));
 
     assertNotNull(plan, "plan must not be null even with stale snapshot stored");
   }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ProAiDeterminismAuditTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/ProAiDeterminismAuditTest.java
@@ -48,29 +48,38 @@ import org.triplea.ai.sidecar.wire.WireState;
  * <p>This audit is deliberately non-fixing. Failures surface specific divergence sites that are
  * filed as separate follow-up issues; the audit's only role is to capture the empirical evidence.
  *
- * <p><b>Status after map-room/map-room#2377:</b> the gross non-determinism (different unit types
- * bought entirely; completely different placement totals) has been eliminated. What remains is a
- * subtler residual flake where {@code politicalActions} occasionally flips at the {@code random <=
- * warChance} threshold check inside {@link games.strategy.triplea.ai.pro.ProPoliticsAi}.
- * Empirically (~10 reruns of each fixture):
+ * <p><b>Status after map-room/map-room#2384 (per-call wire seeding):</b> {@link
+ * org.triplea.ai.sidecar.exec.PurchaseExecutor#execute PurchaseExecutor.execute} and {@link
+ * org.triplea.ai.sidecar.exec.NoncombatMoveExecutor#execute NoncombatMoveExecutor.execute} now
+ * reseed {@code proData.getRng()} and the battle calculator from {@code request.seed()} on every
+ * call. The mechanical seeding contract is in place: every sidecar call is a function of {@code
+ * (gamestate, wire seed)} as far as the seeded RNG sources are concerned. Empirically (10 reruns
+ * per fixture against this branch):
  *
  * <ul>
- *   <li>Round-1 Russians purchase: deterministic (Russia has no war-declaration options on round 1,
- *       so the threshold flip can't bite).
- *   <li>Round-1 Germans / British purchase: {@code buys} and {@code placements} now identical
- *       across runs; only {@code politicalActions} occasionally flips between empty and a single
- *       war target.
- *   <li>Round-1 Japanese purchase: still cascading divergence (more diverse unit types and more
- *       potential war targets, so threshold drift cascades through the plan).
- *   <li>Round-1 Germans / Japanese NCM: residual move-source-territory drift.
+ *   <li>Round-1 Russians purchase: <b>GREEN</b> — buys, placements, politicalActions, combatMoves
+ *       all byte-identical. Russia has no war-declaration options on round 1, so threshold flips
+ *       can't bite, and Russia's combat-move plan converges on the same source-territory ordering.
+ *   <li>Round-1 Germans / Japanese / British purchase: {@code buys} and {@code placements} now
+ *       byte-identical across runs (the gross drift from before #2377 is gone), but {@code
+ *       politicalActions} and {@code combatMoves} source-ordering still flip across runs.
+ *   <li>Round-1 Germans / Japanese NCM: residual move-source-territory drift, downstream of the
+ *       same flake.
  * </ul>
+ *
+ * <p>The residual divergence is downstream of {@code HashMap<Territory, ?>} / {@code HashMap<Unit,
+ * ?>} iteration inside {@link games.strategy.triplea.ai.pro.data.ProTerritoryManager} and {@link
+ * games.strategy.triplea.ai.pro.AbstractProAi#storedCombatMoveMap storedCombatMoveMap}: identity
+ * hashes drift across {@code GameData} clones and HashMap iteration order shifts the attack-options
+ * list passed to {@link games.strategy.triplea.ai.pro.ProPoliticsAi}, which then cascades into the
+ * {@code random <= warChance} threshold check. Closing it requires either deterministic hashing or
+ * LinkedHashMap throughout {@code ProAi} — both larger scope than #2384 and tracked as a follow-up.
  *
  * <p>Per the discussion on map-room/map-room#2376, the remaining flake is not architecturally
  * load-bearing — sidecar calls are one-shot, the bot does not compare wire responses across
  * retries, and Session-elimination is gated on "calls being self-contained from gamestate" rather
- * than on byte-identical reproducibility. The remaining drift is captured as a follow-up for
- * incremental cleanup; this audit class stays {@link Disabled} so CI does not flake on the
- * threshold-boundary cases.
+ * than on byte-identical reproducibility. This audit class stays {@link Disabled} so CI does not
+ * flake on the threshold-boundary cases.
  *
  * <p>To re-run the audit manually (delete or comment-out the class-level {@link Disabled}):
  *
@@ -80,9 +89,9 @@ import org.triplea.ai.sidecar.wire.WireState;
  * }</pre>
  */
 @Disabled(
-    "Audit harness for map-room/map-room#2376. Politics threshold-flip flake remains after #2377;"
-        + " not architecturally load-bearing — see class javadoc. Re-enable progressively as"
-        + " further determinism fixes land.")
+    "Audit harness for map-room/map-room#2376. Residual HashMap-iteration flake remains after"
+        + " #2384 — not architecturally load-bearing, see class javadoc. Re-enable progressively"
+        + " as further determinism fixes (LinkedHashMap throughout ProAi) land.")
 class ProAiDeterminismAuditTest {
 
   /** Seed used for every audit run. Matches the constant in {@link PurchaseExecutorTest}. */
@@ -136,10 +145,11 @@ class ProAiDeterminismAuditTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Noncombat-move determinism — full pipeline (purchase + combat-move +
-  // noncombat-move) per run. If purchase or combat-move is non-deterministic,
-  // NCM determinism cannot hold either; if NCM diverges but purchase passes,
-  // the divergence is in the move planning itself.
+  // Noncombat-move determinism — purchase + noncombat-move per run. (Combat-move
+  // executor was deleted in #2382 / triplea#86 once the bot bypassed it TS-side;
+  // purchase's snapshot is sufficient to seed NCM.) If purchase is
+  // non-deterministic, NCM determinism cannot hold either; if NCM diverges but
+  // purchase passes, the divergence is in the move planning itself.
   // ---------------------------------------------------------------------------
 
   @Test
@@ -193,7 +203,7 @@ class ProAiDeterminismAuditTest {
       try {
         final PurchasePlan plan =
             new PurchaseExecutor(store)
-                .execute(session, new PurchaseRequest(wireState("purchase", nation)));
+                .execute(session, new PurchaseRequest(wireState("purchase", nation), SEED));
         final String wire = MAPPER.writeValueAsString(plan);
         if (first == null) {
           first = wire;
@@ -220,10 +230,11 @@ class ProAiDeterminismAuditTest {
       final Session session = freshSession(nation);
       try {
         new PurchaseExecutor(store)
-            .execute(session, new PurchaseRequest(wireState("purchase", nation)));
+            .execute(session, new PurchaseRequest(wireState("purchase", nation), SEED));
         final NoncombatMovePlan plan =
             new NoncombatMoveExecutor(store)
-                .execute(session, new NoncombatMoveRequest(wireState("nonCombatMove", nation)));
+                .execute(
+                    session, new NoncombatMoveRequest(wireState("nonCombatMove", nation), SEED));
         final String wire = MAPPER.writeValueAsString(plan);
         if (first == null) {
           first = wire;

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
@@ -56,7 +56,7 @@ class PurchaseExecutorTest {
 
   private static PurchaseRequest purchaseRequestFor(final String nation) {
     return new PurchaseRequest(
-        new WireState(List.of(), List.of(), 1, "purchase", nation, List.of()));
+        new WireState(List.of(), List.of(), 1, "purchase", nation, List.of()), 0L);
   }
 
   private static int playerPus(final GameData data, final String nation) {


### PR DESCRIPTION
## Summary

Per-call wire seeding for the stateless-sidecar campaign. Builds on map-room#2377 (seeded RNG sources) and the TS-side seed plumbing in map-room#2388 (every sidecar `/decide` request now carries `seed: number`).

- Adds `long seed` to `PurchaseRequest` and `NoncombatMoveRequest` DTOs (records). Wire format already carries seed; sidecar was silently ignoring it via `FAIL_ON_UNKNOWN_PROPERTIES=false`.
- `PurchaseExecutor.execute` and `NoncombatMoveExecutor.execute` now call `proAi.getProData().setSeed(request.seed())` and `proAi.seedBattleCalc(request.seed())` at the start of every dispatch, immediately before the `invoke*ForSidecar` call. Mirrors the seeding pattern established in `SessionRegistry.buildSession` but at per-call rather than per-session granularity.

Effect: ProAi behaviour is now a function of `(gamestate, wire seed)` for the seeded RNG sources — independent of any RNG drift from prior decision calls on the same session. This is what the stateless-sidecar architecture (map-room#2386) needs to retire the `Session` / `SessionRegistry` / `SessionSnapshot` machinery and model every `/decide` call as a pure function.

## Audit harness status (map-room#2376)

Per-call seeding is mechanically in place. Empirical results (10 reruns per fixture):

- ✅ **Round-1 Russians purchase**: byte-identical across runs (no war-declaration options on round 1, so threshold flips can't bite; combat-move plan converges).
- ⚠️ **Round-1 Germans / Japanese / British purchase**: `buys` and `placements` byte-identical (gross drift from before #2377 is gone), but `politicalActions` and `combatMoves` source-ordering still flip across runs.
- ⚠️ **Round-1 Germans / Japanese NCM**: residual move-source-territory drift, downstream of the same flake.

The residual divergence is downstream of `HashMap<Territory, ?>` / `HashMap<Unit, ?>` iteration inside `ProTerritoryManager` and `storedCombatMoveMap`: identity hashes drift across `GameData` clones, HashMap iteration order shifts the attack-options list passed to `ProPoliticsAi`, which cascades into the `random <= warChance` threshold check. Closing it requires deterministic hashing or `LinkedHashMap` throughout `ProAi` — larger scope than #2384 and captured as a follow-up.

Per the discussion on map-room#2376, the residual flake is not architecturally load-bearing — sidecar calls are one-shot, the bot does not compare wire responses across retries, and Session-elimination is gated on "calls being self-contained from gamestate" rather than on byte-identical reproducibility. Audit class stays `@Disabled` with updated javadoc explaining the post-#2384 state.

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:check` — BUILD SUCCESSFUL (11m 9s)
- [x] `./gradlew spotlessApply` / `spotlessCheck` — clean
- [x] Audit harness manually re-enabled and run: 1/6 fixture GREEN (Russians purchase), 5/6 still flake on residual HashMap-iteration; `@Disabled` reverted with documented post-#2384 javadoc

## Closes

- map-room/map-room#2384

## Does NOT close

- map-room/map-room#2376 — audit harness re-enable is gated on the residual HashMap-iteration flake being closed (separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)