### PR TITLE
fix(proai): replace ThreadLocalRandom in ProTechAi.tech with proData.getRng()

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -801,7 +801,7 @@ public abstract class AbstractProAi extends AbstractAi {
   @Override
   protected void tech(
       final ITechDelegate techDelegate, final GameData data, final GamePlayer player) {
-    ProTechAi.tech(techDelegate, data, player);
+    ProTechAi.tech(techDelegate, data, player, proData);
   }
 
   public Optional<Territory> retreatQuery(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -29,7 +29,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import org.triplea.java.PredicateBuilder;
@@ -40,7 +39,11 @@ import org.triplea.java.collections.IntegerMap;
 final class ProTechAi {
   private ProTechAi() {}
 
-  static void tech(final ITechDelegate techDelegate, final GameData data, final GamePlayer player) {
+  static void tech(
+      final ITechDelegate techDelegate,
+      final GameData data,
+      final GamePlayer player,
+      final ProData proData) {
     if (!Properties.getWW2V3TechModel(data.getProperties())) {
       return;
     }
@@ -57,16 +60,15 @@ final class ProTechAi {
     // If the token was not used, set the token num -1
     final int techTokensQuantity =
         techTokensOptional.map(resource -> player.getResources().getQuantity(resource)).orElse(-1);
-    final ThreadLocalRandom localRandom = ThreadLocalRandom.current();
     int tokensToBuy = 0;
-    if (!capDanger && techTokensQuantity < 3 && pusRemaining > localRandom.nextInt(160)) {
+    if (!capDanger && techTokensQuantity < 3 && pusRemaining > proData.getRng().nextInt(160)) {
       tokensToBuy = 1;
     }
     if (techTokensQuantity > 0 || tokensToBuy > 0) {
       final List<TechnologyFrontier> cats = TechAdvance.getPlayerTechCategories(player);
       // retaining 65% chance of choosing land advances using basic ww2v3 model.
       if (data.getTechnologyFrontier().isEmpty()) {
-        if (localRandom.nextFloat() > 0.35) {
+        if (proData.getRng().nextFloat() > 0.35) {
           techDelegate.rollTech(techTokensQuantity + tokensToBuy, cats.get(1), tokensToBuy, null);
         } else {
           techDelegate.rollTech(techTokensQuantity + tokensToBuy, cats.get(0), tokensToBuy, null);
@@ -74,7 +76,7 @@ final class ProTechAi {
       } else {
         techDelegate.rollTech(
             techTokensQuantity + tokensToBuy,
-            cats.get(localRandom.nextInt(cats.size())),
+            cats.get(proData.getRng().nextInt(cats.size())),
             tokensToBuy,
             null);
       }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProTechAiDeterminismTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProTechAiDeterminismTest.java
@@ -1,0 +1,69 @@
+package games.strategy.triplea.ai.pro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.triplea.Constants;
+import games.strategy.triplea.delegate.data.TechResults;
+import games.strategy.triplea.delegate.remote.ITechDelegate;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.lang.reflect.Field;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+class ProTechAiDeterminismTest {
+
+  /** Records every call to {@link Random}'s internal next() generator. */
+  private static final class CountingRandom extends Random {
+    int callCount = 0;
+
+    CountingRandom(final long seed) {
+      super(seed);
+    }
+
+    @Override
+    protected int next(final int bits) {
+      callCount++;
+      return super.next(bits);
+    }
+  }
+
+  /**
+   * Verifies that {@link ProTechAi#tech} drives all random decisions through the injected {@link
+   * ProData#getRng()} rather than {@link java.util.concurrent.ThreadLocalRandom#current()}.
+   *
+   * <p>Strategy: inject a {@link CountingRandom} spy into {@link ProData} via reflection, call
+   * tech(), and assert the spy was consulted. Before the fix (ThreadLocalRandom path), the spy gets
+   * 0 calls — RED. After the fix (proData.getRng() path), the spy gets ≥1 call — GREEN.
+   */
+  @Test
+  void techDrivenByProDataRng() throws Exception {
+    final GameData data = TestMapGameData.GLOBAL1940.getGameData();
+    data.getProperties().set(Constants.WW2V3_TECH_MODEL, Boolean.TRUE);
+    final GamePlayer player = data.getPlayerList().getPlayerId("Germans");
+
+    final ProData proData = new ProData();
+    final CountingRandom spy = new CountingRandom(42L);
+    injectRng(proData, spy);
+
+    final ITechDelegate delegate = mock(ITechDelegate.class);
+    when(delegate.rollTech(anyInt(), any(), anyInt(), any())).thenReturn(new TechResults("stub"));
+
+    ProTechAi.tech(delegate, data, player, proData);
+
+    assertThat(spy.callCount)
+        .as("ProTechAi.tech must use proData.getRng(), not ThreadLocalRandom")
+        .isGreaterThan(0);
+  }
+
+  private static void injectRng(final ProData proData, final Random rng) throws Exception {
+    final Field f = ProData.class.getDeclaredField("rng");
+    f.setAccessible(true);
+    f.set(proData, rng);
+  }
+}


### PR DESCRIPTION
## Summary

`ProTechAi.tech` contained three `ThreadLocalRandom.current()` calls for tech-spending decisions:
- `nextInt(160)` — token-buying threshold
- `nextFloat()` — land/sea tech category split (65/35)
- `nextInt(cats.size())` — random category selection (global tech frontier path)

`ThreadLocalRandom` is JVM-startup-seeded per thread, completely independent of `proData.getRng()` and the sidecar wire seed set by `SessionRegistry`. This makes tech decisions non-deterministic across fresh sessions given the same `(gamestate, seed)` pair — the same determinism hole fixed in #84 for purchase/politics.

## Changes

- **`ProTechAi.java`**: Add `ProData proData` as a 4th parameter to `tech()`; replace all three `localRandom` sites with `proData.getRng()`; remove `ThreadLocalRandom` import.
- **`AbstractProAi.java`**: Pass `proData` at the only call site.
- **`ProTechAiDeterminismTest.java`**: Spy-rng injected via reflection asserts `proData.getRng()` is consulted. Test was RED (0 spy calls) before this fix, GREEN (≥1 call) after.

## Test plan

- [x] `ProTechAiDeterminismTest.techDrivenByProDataRng` passes GREEN after fix
- [x] `./gradlew :game-app:game-core:check` — all tests + spotless pass
- [x] Spotless applied before push

Closes map-room/map-room#2379
Same pattern as #84 (ProPurchaseUtils / ProPoliticsAi / ConcurrentBattleCalculator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)