### PR TITLE
test(ai-sidecar): seed proData.rng + battleCalc in freshSession helpers (map-room/map-room#2378)

### DIFF
--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutorIntegrationTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutorIntegrationTest.java
@@ -48,6 +48,9 @@ class NoncombatMoveExecutorIntegrationTest {
   private Session freshSession(final String nation) {
     final GameData data = canonical.cloneForSession();
     final ProAi proAi = new ProAi("sidecar-test-" + nation, nation);
+    // Mirror SessionRegistry.buildSession: seed both RNG sources so test output is deterministic.
+    proAi.getProData().setSeed(42L);
+    proAi.seedBattleCalc(42L);
     return new Session(
         "s-test-" + UUID.randomUUID(),
         new SessionKey("g1", nation, 1),

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
@@ -44,6 +44,9 @@ class PurchaseExecutorTest {
   private Session freshSession(final String nation) {
     final GameData data = canonical.cloneForSession();
     final ProAi proAi = new ProAi("sidecar-test-" + nation, nation);
+    // Mirror SessionRegistry.buildSession: seed both RNG sources so test output is deterministic.
+    proAi.getProData().setSeed(42L);
+    proAi.seedBattleCalc(42L);
     return new Session(
         "s-test-" + UUID.randomUUID(),
         new SessionKey("g1", nation, 1),


### PR DESCRIPTION
## Summary

- `PurchaseExecutorTest.freshSession` and `NoncombatMoveExecutorIntegrationTest.freshSession` constructed `Session` objects without calling `proAi.getProData().setSeed()` or `proAi.seedBattleCalc()`, leaving `ProData.rng` default-seeded from `nanoTime()` — non-deterministic across test runs
- Added the two seed calls in both helpers, exactly mirroring `SessionRegistry.buildSession` and the pattern `ProAiDeterminismAuditTest.freshSession` already used correctly
- Fix path taken: **Option 2** (update test helpers) — keeps seeding out of the `Session` constructor, which is a plain record, and avoids conflicting with the per-call reseed pattern in executors

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:spotlessApply` clean
- [x] `./gradlew :game-app:ai-sidecar:check` — all 56 tasks pass (BUILD SUCCESSFUL in 7m 13s)
- [x] `germansClaimBulgariaOnTurn1` run 5× with `--rerun-tasks` — all BUILD SUCCESSFUL (no flakes)

## Re-enabling @Disabled tests

`ProAiDeterminismAuditTest` remains `@Disabled` — its flake is from residual HashMap-iteration non-determinism within ProAi (tracked in the `@Disabled` annotation), which is independent of this fix.

Closes map-room/map-room#2378

🤖 Generated with [Claude Code](https://claude.com/claude-code)