### PR TITLE
fix(ai-sidecar): add sbrMoves field to PurchasePlan — route bombing moves separately from combatMoves

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchasePlan.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchasePlan.java
@@ -12,15 +12,17 @@ import java.util.List;
  * water non-construction → land construction → water construction). {@code politicalActions} lists
  * war declarations the AI decided to make during purchase simulation; absent or {@code null} in
  * older responses is treated as an empty list on the TS side. {@code combatMoves} carries the
- * projected combat-move plan in execution order (land → amphib → bombard → bombing); absent or
- * {@code null} in older responses is treated as an empty list on the TS side.
+ * projected non-SBR combat-move plan (land → amphib → bombard); absent or {@code null} in older
+ * responses is treated as an empty list on the TS side. {@code sbrMoves} carries the projected
+ * strategic-bombing-raid moves; absent or {@code null} is treated as an empty list on the TS side.
  */
 public record PurchasePlan(
     List<PurchaseOrder> buys,
     List<RepairOrder> repairs,
     List<PlacementGroup> placements,
     List<WarDeclaration> politicalActions,
-    List<WireMoveDescription> combatMoves)
+    List<WireMoveDescription> combatMoves,
+    List<WireMoveDescription> sbrMoves)
     implements DecisionPlan {
 
   @JsonCreator
@@ -29,28 +31,43 @@ public record PurchasePlan(
       @JsonProperty("repairs") final List<RepairOrder> repairs,
       @JsonProperty("placements") final List<PlacementGroup> placements,
       @JsonProperty("politicalActions") final List<WarDeclaration> politicalActions,
-      @JsonProperty("combatMoves") final List<WireMoveDescription> combatMoves) {
+      @JsonProperty("combatMoves") final List<WireMoveDescription> combatMoves,
+      @JsonProperty("sbrMoves") final List<WireMoveDescription> sbrMoves) {
     this.buys = buys;
     this.repairs = repairs;
     this.placements = placements;
     this.politicalActions = politicalActions != null ? politicalActions : List.of();
     this.combatMoves = combatMoves != null ? combatMoves : List.of();
+    this.sbrMoves = sbrMoves != null ? sbrMoves : List.of();
   }
 
-  /** Convenience constructor for callsites that do not populate combatMoves. */
+  /** Convenience constructor for callsites that do not populate sbrMoves. */
+  public PurchasePlan(
+      final List<PurchaseOrder> buys,
+      final List<RepairOrder> repairs,
+      final List<PlacementGroup> placements,
+      final List<WarDeclaration> politicalActions,
+      final List<WireMoveDescription> combatMoves) {
+    this(buys, repairs, placements, politicalActions, combatMoves, List.of());
+  }
+
+  /** Convenience constructor for callsites that do not populate combatMoves or sbrMoves. */
   public PurchasePlan(
       final List<PurchaseOrder> buys,
       final List<RepairOrder> repairs,
       final List<PlacementGroup> placements,
       final List<WarDeclaration> politicalActions) {
-    this(buys, repairs, placements, politicalActions, List.of());
+    this(buys, repairs, placements, politicalActions, List.of(), List.of());
   }
 
-  /** Convenience constructor for callsites that do not populate politicalActions or combatMoves. */
+  /**
+   * Convenience constructor for callsites that do not populate politicalActions, combatMoves, or
+   * sbrMoves.
+   */
   public PurchasePlan(
       final List<PurchaseOrder> buys,
       final List<RepairOrder> repairs,
       final List<PlacementGroup> placements) {
-    this(buys, repairs, placements, List.of(), List.of());
+    this(buys, repairs, placements, List.of(), List.of(), List.of());
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
@@ -238,11 +238,9 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
             .filter(RecordingMoveDelegate.CapturedMove::isBombing)
             .map(c -> WireMoveDescriptionBuilder.build(c.move(), uuidToWireId))
             .toList();
-    final List<WireMoveDescription> combatMoves = new ArrayList<>();
-    combatMoves.addAll(nonBombingMoves);
-    combatMoves.addAll(bombingMoves);
 
-    return new PurchasePlan(buys, repairs, placements, politicalActions, combatMoves);
+    return new PurchasePlan(
+        buys, repairs, placements, politicalActions, nonBombingMoves, bombingMoves);
   }
 
   /**

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchasePlanJsonTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/dto/PurchasePlanJsonTest.java
@@ -128,4 +128,79 @@ class PurchasePlanJsonTest {
     PurchasePlan back = (PurchasePlan) decoded;
     assertEquals(0, back.combatMoves().size());
   }
+
+  @Test
+  void purchasePlanRoundTripsWithSbrMoves() throws Exception {
+    PurchasePlan plan =
+        new PurchasePlan(
+            List.of(new PurchaseOrder("bomber", 1, null)),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(
+                new WireMoveDescription(
+                    List.of("u-bomber"),
+                    "Germany",
+                    "Leningrad",
+                    Map.of(),
+                    Map.of("u-bomber", new WireUnitClassification(true, false)),
+                    Map.of())));
+    String json = mapper.writeValueAsString((DecisionPlan) plan);
+    assertTrue(json.contains("\"sbrMoves\""));
+    assertTrue(json.contains("\"Leningrad\""));
+    DecisionPlan decoded = mapper.readValue(json, DecisionPlan.class);
+    assertInstanceOf(PurchasePlan.class, decoded);
+    PurchasePlan back = (PurchasePlan) decoded;
+    assertEquals(0, back.combatMoves().size());
+    assertEquals(1, back.sbrMoves().size());
+    assertEquals("Germany", back.sbrMoves().get(0).from());
+    assertEquals("Leningrad", back.sbrMoves().get(0).to());
+    assertEquals(List.of("u-bomber"), back.sbrMoves().get(0).unitIds());
+  }
+
+  @Test
+  void purchasePlanWithMissingSbrMovesDefaultsToEmpty() throws Exception {
+    String json =
+        "{\"kind\":\"purchase\",\"buys\":[{\"unitType\":\"infantry\",\"count\":1}],"
+            + "\"repairs\":[],\"placements\":[],\"politicalActions\":[],\"combatMoves\":[]}";
+    DecisionPlan decoded = mapper.readValue(json, DecisionPlan.class);
+    assertInstanceOf(PurchasePlan.class, decoded);
+    PurchasePlan back = (PurchasePlan) decoded;
+    assertEquals(0, back.sbrMoves().size());
+  }
+
+  @Test
+  void purchasePlanCombatMovesAndSbrMovesAreIndependentFields() throws Exception {
+    PurchasePlan plan =
+        new PurchasePlan(
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(
+                new WireMoveDescription(
+                    List.of("u-tank"),
+                    "Germany",
+                    "Poland",
+                    Map.of(),
+                    Map.of("u-tank", new WireUnitClassification(false, false)),
+                    Map.of())),
+            List.of(
+                new WireMoveDescription(
+                    List.of("u-bomber"),
+                    "Germany",
+                    "Moscow",
+                    Map.of(),
+                    Map.of("u-bomber", new WireUnitClassification(true, false)),
+                    Map.of())));
+    String json = mapper.writeValueAsString((DecisionPlan) plan);
+    DecisionPlan decoded = mapper.readValue(json, DecisionPlan.class);
+    assertInstanceOf(PurchasePlan.class, decoded);
+    PurchasePlan back = (PurchasePlan) decoded;
+    assertEquals(1, back.combatMoves().size());
+    assertEquals("Poland", back.combatMoves().get(0).to());
+    assertEquals(1, back.sbrMoves().size());
+    assertEquals("Moscow", back.sbrMoves().get(0).to());
+  }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
@@ -220,26 +220,29 @@ class PurchaseExecutorTest {
   }
 
   /**
-   * Verifies that {@code combatMoves} is populated in the PurchasePlan response and ordered
-   * correctly (land/amphib/bombard moves first, bombing/SBR moves last).
+   * Verifies that {@code combatMoves} is populated in the PurchasePlan response for non-SBR moves,
+   * and that {@code sbrMoves} is a separate non-null field for bombing moves.
    *
    * <p>Turn-1 Germans always have at least one land combat move (they border Poland and other
-   * Allied territories). SBR moves are optional; what matters is that non-bombing moves precede
-   * bombing moves in the list.
+   * Allied territories). SBR moves are optional depending on ProAi's decision; what matters is that
+   * both fields are separate and non-null (regression guard for map-room#2412 where sbrMoves was
+   * absent and bombings were silently routed to combatMoves).
    *
    * <p>This exercises the {@code invokeCombatMoveForSidecar} projection path: after purchase, the
    * {@code storedCombatMoveMap} is populated; the executor calls {@code doMove} (not {@code
    * doCombatMove} — zero re-planning) and captures the resulting MoveDescriptions via a {@link
-   * RecordingMoveDelegate}.
+   * RecordingMoveDelegate}. The {@code isBombing} flag on each captured move determines which field
+   * it lands in.
    */
   @Test
-  void combatMovesArePopulatedAndOrderedCorrectlyAfterPurchase() throws Exception {
+  void combatMovesArePopulatedAndRoutedCorrectlyAfterPurchase() throws Exception {
     final GameData data = canonical.cloneForSession();
     final PurchasePlan plan = new PurchaseExecutor().executeOn(data, purchaseRequestFor("Germans"));
 
     assertThat(plan.combatMoves()).as("combatMoves must never be null").isNotNull();
+    assertThat(plan.sbrMoves()).as("sbrMoves must never be null").isNotNull();
     assertThat(plan.combatMoves())
-        .as("Germans should have at least one combat move on turn 1")
+        .as("Germans should have at least one non-SBR combat move on turn 1")
         .isNotEmpty();
 
     // Each move must reference a non-blank from/to territory.
@@ -250,6 +253,36 @@ class PurchaseExecutorTest {
       assertThat(md.from()).as("combatMove.from must not be blank").isNotBlank();
       assertThat(md.to()).as("combatMove.to must not be blank").isNotBlank();
     }
+    for (final var md : plan.sbrMoves()) {
+      assertThat(md.from()).as("sbrMove.from must not be blank").isNotBlank();
+      assertThat(md.to()).as("sbrMove.to must not be blank").isNotBlank();
+    }
+  }
+
+  /**
+   * Regression test for map-room#2412: bombing moves must be routed to {@code sbrMoves}, not merged
+   * into {@code combatMoves}.
+   *
+   * <p>Before the fix, PurchaseExecutor concatenated nonBombingMoves and bombingMoves into a single
+   * {@code combatMoves} list. PurchasePlan had no {@code sbrMoves} field. The TS bot read {@code
+   * pp.sbrMoves ?? []} which was always absent → G.aiState.pendingSbrMoves never populated →
+   * bombers dispatched as regular moveUnit in combatMove phase instead of sbrMoveUnit in sbrPlan.
+   *
+   * <p>This test verifies the invariant: the combined size of {@code combatMoves} and {@code
+   * sbrMoves} is non-zero (Germans always move on turn 1), and both fields are non-null separate
+   * lists (not merged).
+   */
+  @Test
+  void sbrMovesFieldIsNonNullAndSeparateFromCombatMoves() throws Exception {
+    final GameData data = canonical.cloneForSession();
+    final PurchasePlan plan = new PurchaseExecutor().executeOn(data, purchaseRequestFor("Germans"));
+
+    assertThat(plan.combatMoves()).as("combatMoves must not be null").isNotNull();
+    assertThat(plan.sbrMoves()).as("sbrMoves must not be null").isNotNull();
+
+    // Both fields together must be non-empty — Germans always have moves on turn 1.
+    final int totalMoves = plan.combatMoves().size() + plan.sbrMoves().size();
+    assertThat(totalMoves).as("combined combat + sbr moves must be non-empty").isGreaterThan(0);
   }
 
   /**


### PR DESCRIPTION
## Root cause

`PurchasePlan` had no `sbrMoves` field. `PurchaseExecutor` correctly partitioned
`CapturedMove.isBombing()` into `nonBombingMoves`/`bombingMoves` but then **merged both**
into a single flat `combatMoves` list. The `isBombing` distinction was silently lost at
the JSON boundary.

The TS bot reads `pp.sbrMoves ?? []` — which was always absent in the response — so
`G.aiState.pendingSbrMoves` was never populated. Bombers were dispatched as regular
`moveUnit` in the combatMove phase instead of `sbrMoveUnit` in sbrPlan.

Confirmed via production logs: match `5juLPJ_hVGK`, bomber `u441` (Germans) dispatched
to Novgorod as `moveUnit`, ZERO `sbr`-related traces.

## Fix

- Add `sbrMoves: List<WireMoveDescription>` field to `PurchasePlan` DTO
- `PurchaseExecutor` now passes `nonBombingMoves` as `combatMoves` and `bombingMoves` as `sbrMoves` — no merge
- Null-safe `@JsonProperty("sbrMoves")` default in `@JsonCreator` (backward compat: missing field → empty list)
- Updated convenience constructors to default `sbrMoves = List.of()`

## Tests

- `PurchasePlanJsonTest`: `purchasePlanRoundTripsWithSbrMoves`, `purchasePlanWithMissingSbrMovesDefaultsToEmpty`, `purchasePlanCombatMovesAndSbrMovesAreIndependentFields`
- `PurchaseExecutorTest`: updated `combatMovesArePopulatedAndRoutedCorrectlyAfterPurchase` to assert both fields non-null; added `sbrMovesFieldIsNonNullAndSeparateFromCombatMoves`

## Note on #2395 acceptance

The #2395 test contract was valid but the TS integration tests mocked the sidecar to return `sbrMoves` directly — they couldn't catch the Java-side silent failure. The companion map-room PR adds TS regression guards for the full routing contract.

Paired with: map-room/map-room#2413

Closes map-room/map-room#2412

🤖 Generated with [Claude Code](https://claude.com/claude-code)