### PR TITLE
fix(proai): prevent invalid multi-step unload routes; de-dupe amphib planning log churn

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -321,11 +321,12 @@ public class ProCombatMoveAi {
     // Assign units to territories by prioritization
     int numToAttack = Math.min(1, prioritizedTerritories.size());
     boolean haveRemovedAllAmphibTerritories = false;
+    final Map<Unit, Territory> prevAmphibAssignmentsScaling = new HashMap<>();
     while (true) {
       final List<ProTerritory> territoriesToTryToAttack =
           prioritizedTerritories.subList(0, numToAttack);
       ProLogger.debug("Current number of territories: " + numToAttack);
-      tryToAttackTerritories(territoriesToTryToAttack, List.of());
+      tryToAttackTerritories(territoriesToTryToAttack, List.of(), prevAmphibAssignmentsScaling);
 
       // Determine if all attacks are successful
       boolean areSuccessful = true;
@@ -856,9 +857,10 @@ public class ProCombatMoveAi {
         territoryManager.getAttackOptions().getUnitMoveMap();
 
     // Assign units to territories by prioritization
+    final Map<Unit, Territory> prevAmphibAssignments = new HashMap<>();
     while (true) {
       Map<Unit, Set<Territory>> sortedUnitAttackOptions =
-          tryToAttackTerritories(prioritizedTerritories, alreadyMovedUnits);
+          tryToAttackTerritories(prioritizedTerritories, alreadyMovedUnits, prevAmphibAssignments);
 
       // Clear bombers
       attackMap.values().forEach(proTerritory -> proTerritory.getBombers().clear());
@@ -1244,7 +1246,9 @@ public class ProCombatMoveAi {
   }
 
   private Map<Unit, Set<Territory>> tryToAttackTerritories(
-      final List<ProTerritory> prioritizedTerritories, final List<Unit> alreadyMovedUnits) {
+      final List<ProTerritory> prioritizedTerritories,
+      final List<Unit> alreadyMovedUnits,
+      final Map<Unit, Territory> prevAmphibAssignments) {
 
     final Map<Territory, ProTerritory> attackMap =
         territoryManager.getAttackOptions().getTerritoryMap();
@@ -1687,13 +1691,16 @@ public class ProCombatMoveAi {
         for (final Unit unit : minAmphibUnitsToAdd) {
           sortedUnitAttackOptions.remove(unit);
         }
-        ProLogger.trace(
-            "Adding amphibious attack to "
-                + minWinTerritory
-                + ", units="
-                + minAmphibUnitsToAdd.size()
-                + ", unloadFrom="
-                + minUnloadFromTerritory);
+        if (!minWinTerritory.equals(prevAmphibAssignments.get(transport))) {
+          ProLogger.trace(
+              "Adding amphibious attack to "
+                  + minWinTerritory
+                  + ", units="
+                  + minAmphibUnitsToAdd.size()
+                  + ", unloadFrom="
+                  + minUnloadFromTerritory);
+          prevAmphibAssignments.put(transport, minWinTerritory);
+        }
       }
     }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -102,6 +102,12 @@ public final class ProMoveUtils {
                   u,
                   player);
         } else if (unitList.stream().allMatch(Matches.unitIsLand())) {
+          // Land unit on a transport must move via calculateAmphibRoutes, not here.
+          // Routing from a sea zone would produce a multi-step unload route which
+          // MoveValidator rejects with "Unloading units must stop where they are unloaded".
+          if (startTerritory.isWater()) {
+            continue;
+          }
           // Land unit
           optionalRoute =
               map.getRouteForUnit(


### PR DESCRIPTION
Closes map-room/map-room#2538 (Bug B)

## Bug B.1 — invalid multi-step unload route

`ProMoveUtils.calculateMoveRoutes()` did not guard against land units whose `proData.getUnitTerritory(unit)` returns a sea zone (unit is physically on a transport). These units bypassed the `amphibUnits` skip-set and entered the regular land-routing branch, which then called `map.getRouteForUnit(seaZone, landTarget, ...)`. Path-finding returned a multi-step route like `Route(115 Sea Zone → Baltic States → Eastern Poland)`, which `MoveValidator` rejected with _"Unloading units must stop where they are unloaded"_.

The move was never forwarded to Map Room (the `RecordingMoveDelegate` only captures validated moves), but the failed attempt was logged as an error and wasted planning cycles.

**Fix:** In `calculateMoveRoutes`, the land-unit branch now early-exits via `continue` when `startTerritory.isWater()`. Land units on transports are handled exclusively by `calculateAmphibRoutes`, which always generates a valid 1-step unload route.

## Bug B.2 — amphib planning log churn

`determineUnitsToAttackWith()` runs an outer `while(true)` loop that calls `tryToAttackTerritories()` once per territory to eliminate from the plan. Each call resets `amphibAttackMap` (line 1265) and re-evaluates all transports from scratch. The per-transport trace "Adding amphibious attack to X" fired every iteration, even when the same transport was re-assigned to the same territory — producing 25+ identical consecutive lines in the planning log.

**Fix:** A `Map<Unit, Territory> prevAmphibAssignments` is maintained across outer-while iterations (separate instance for each call site). The trace log is only emitted when a transport's assignment changes from the previous iteration; `prevAmphibAssignments` is updated on each change.

## Test plan

- [x] `./gradlew :game-app:game-core:compileJava` — clean
- [x] `./gradlew :game-app:game-core:test` — all pass
- [x] `./gradlew :game-app:game-core:spotlessApply` — no reformatting needed
- [ ] 🧑 Manual: replay matchID bq2Ab7o8T-Z (or equivalent) with AI_SIDECAR_LOG_LEVEL=FINER — confirm no "Unloading units must stop" errors and no 25+ repeated amphib-attack lines for Baltic States