### PR TITLE
fix(proai): skip non-adjacent unload when transport blocked by closed canal

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -303,10 +303,25 @@ public final class ProMoveUtils {
         // Set territory transport is moving to
         attackMap.get(t).getTransportTerritoryMap().put(transport, transportTerritory);
 
-        // Unload transport
+        // Unload transport — only if the transport reached an adjacent position.
+        // A closed canal (e.g. Turkish Straits when Turkey is neutral) can stop the
+        // transport short of its planned sea zone; in that case t is not a neighbour of
+        // transportTerritory and the unload route would be non-adjacent/invalid.
         if (!loadedUnits.isEmpty() && !t.isWater()) {
-          final Route route = new Route(transportTerritory, t);
-          moves.addMove(loadedUnits, route);
+          if (map.getNeighbors(transportTerritory).contains(t)) {
+            final Route route = new Route(transportTerritory, t);
+            moves.addMove(loadedUnits, route);
+          } else {
+            ProLogger.warn(
+                data.getSequence().getRound()
+                    + "-"
+                    + data.getSequence().getStep().getName()
+                    + ": skipping non-adjacent unload "
+                    + transportTerritory
+                    + " -> "
+                    + t
+                    + " (transport blocked before reaching planned sea zone)");
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- `calculateAmphibRoutes` (`ProMoveUtils.java:308`) generated the unload route `Route(transportTerritory, t)` unconditionally after the movement loop
- When a closed canal (e.g. Turkish Straits: 99 SZ ↔ 100 SZ when Turkey is neutral) blocked the transport short of its planned sea zone, `transportTerritory` ended up non-adjacent to `t` (e.g. transport stopped at 99 SZ, target Caucasus adjacent to 100 SZ only)
- The invalid non-adjacent unload route was captured by `RecordingMoveDelegate(dryRun=true)` without `MoveValidator` validation, producing amphib plans that Map Room's engine correctly rejects at dispatch time
- Fix: guard the unload with `map.getNeighbors(transportTerritory).contains(t)`; if the transport couldn't reach an adjacent position, skip the unload and emit a WARN log

## Test plan

- [x] `./gradlew :game-app:game-core:test` — BUILD SUCCESSFUL
- [x] `./gradlew :game-app:ai-sidecar:test` — BUILD SUCCESSFUL (exit code 0, all integration tests pass including `combatMovesArePopulatedAndRoutedCorrectlyAfterPurchase`, `StatelessReplayDeterminismTest`)
- [x] `./gradlew :game-app:game-core:spotlessCheck` — clean
- [x] 🧑 Manual: play a game to Italian round 2+ with Turkey neutral, verify no "blocked canal" cascade failures in bot dispatcher

Closes map-room/map-room#2520

🤖 Generated with [Claude Code](https://claude.com/claude-code)