### PR TITLE
feat(observability): ai-sidecar JUL stdout formatter + scoped match/round/player context

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
@@ -23,40 +23,77 @@ import java.util.UUID;
  * a {@link ThreadLocal} carries the matchID through the executor stack without having to thread it
  * through every method signature.
  *
- * <p>If no matchID is set when an emit happens (e.g. tests, or a background path that never went
- * through {@code DecisionHandler}), the line is tagged {@code matchID=unknown} so the Loki query
- * {@code {matchID=~"unknown|..."} } still surfaces those lines for triage.
+ * <p>If no context is bound when an emit happens (e.g. tests, or a background path that never went
+ * through {@code DecisionHandler}), every field falls back to the {@code -} sentinel so grep
+ * patterns like {@code grep 'player=Germans'} never miss a line due to field absence.
  */
 public final class AiTraceLogger {
 
   private static final System.Logger LOG = System.getLogger(AiTraceLogger.class.getName());
-  private static final String UNKNOWN_MATCH_ID = "unknown";
+
+  /** Sentinel used for any context field not bound on the current thread. */
+  public static final String SENTINEL = "-";
+
   private static final ThreadLocal<String> MATCH_ID = new ThreadLocal<>();
+  private static final ThreadLocal<String> ROUND = new ThreadLocal<>();
+  private static final ThreadLocal<String> PLAYER = new ThreadLocal<>();
 
   private AiTraceLogger() {}
 
   /**
    * Bind the matchID for the current thread. Call at the request boundary (e.g. start of {@code
-   * DecisionHandler.handle}). Pair with {@link #clearMatchId()} in a finally block so a thread-pool
-   * worker doesn't leak a stale matchID into the next request.
+   * DecisionHandler.handle}). Pair with {@link #clearAll()} in a finally block so a thread-pool
+   * worker doesn't leak a stale context into the next request.
    */
   public static void setMatchId(final String matchId) {
     MATCH_ID.set(matchId);
   }
 
-  /** Clear the per-thread matchID. Always call from a finally block. */
+  /** Bind the game round for the current thread. */
+  public static void setRound(final int round) {
+    ROUND.set(Integer.toString(round));
+  }
+
+  /** Bind the current player name for the current thread. */
+  public static void setPlayer(final String player) {
+    PLAYER.set(player);
+  }
+
+  /** Clear all per-thread context fields. Always call from a finally block. */
+  public static void clearAll() {
+    MATCH_ID.remove();
+    ROUND.remove();
+    PLAYER.remove();
+  }
+
+  /**
+   * @deprecated Use {@link #clearAll()} to clear all context fields together.
+   */
+  @Deprecated
   public static void clearMatchId() {
     MATCH_ID.remove();
   }
 
   /**
-   * Read the per-thread matchID, falling back to {@code "unknown"} when no boundary set one. Public
-   * so request-boundary tests can assert that {@code DecisionHandler} binds and clears the matchID
+   * Read the per-thread matchID, falling back to {@link #SENTINEL} when no boundary set one. Public
+   * so request-boundary tests can assert that {@code DecisionHandler} binds and clears the context
    * around executor dispatch.
    */
   public static String currentMatchId() {
     final String v = MATCH_ID.get();
-    return v == null ? UNKNOWN_MATCH_ID : v;
+    return v == null ? SENTINEL : v;
+  }
+
+  /** Read the per-thread round, falling back to {@link #SENTINEL}. */
+  public static String currentRound() {
+    final String v = ROUND.get();
+    return v == null ? SENTINEL : v;
+  }
+
+  /** Read the per-thread player, falling back to {@link #SENTINEL}. */
+  public static String currentPlayer() {
+    final String v = PLAYER.get();
+    return v == null ? SENTINEL : v;
   }
 
   /**

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/SidecarLogFormatter.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/SidecarLogFormatter.java
@@ -1,0 +1,84 @@
+package org.triplea.ai.sidecar;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/**
+ * JUL {@link Formatter} emitting a single stdout line per record in the shared logging convention
+ * (see map-room issue #2549):
+ *
+ * <pre>
+ * {@code <ISO8601-ms-UTC> <LEVEL> [ai-sidecar] match=<id> round=<n> player=<nation> <message>}
+ * </pre>
+ *
+ * <p>Reads per-thread context (match/round/player) from {@link AiTraceLogger}. Fields not bound on
+ * the current thread emit the {@code -} sentinel so grep patterns like {@code grep
+ * 'player=Germans'} never miss a line due to field absence.
+ *
+ * <p>JUL levels map to the fixed vocabulary: SEVERE→ERROR, WARNING→WARN, INFO→INFO, anything below
+ * INFO→DEBUG.
+ * <!-- TODO(#2549/#2551): verify exact format string byte-matches alpha's TS impl before merge -->
+ */
+public final class SidecarLogFormatter extends Formatter {
+
+  static final String TAG = "[ai-sidecar]";
+
+  // Always 3 fractional digits (yyyy-MM-dd'T'HH:mm:ss.SSS'Z') for lexical sort correctness.
+  private static final DateTimeFormatter TS_FMT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+
+  @Override
+  public String format(final LogRecord record) {
+    final String ts = TS_FMT.format(record.getInstant());
+    final String level = mapLevel(record.getLevel());
+    final String match = AiTraceLogger.currentMatchId();
+    final String round = AiTraceLogger.currentRound();
+    final String player = AiTraceLogger.currentPlayer();
+    final String message = formatMessage(record);
+
+    final StringBuilder sb = new StringBuilder(160);
+    sb.append(ts)
+        .append(' ')
+        .append(level)
+        .append(' ')
+        .append(TAG)
+        .append(' ')
+        .append("match=")
+        .append(match)
+        .append(' ')
+        .append("round=")
+        .append(round)
+        .append(' ')
+        .append("player=")
+        .append(player)
+        .append(' ')
+        .append(message);
+
+    final Throwable thrown = record.getThrown();
+    if (thrown != null) {
+      sb.append(' ').append(thrown.getClass().getSimpleName());
+      final String msg = thrown.getMessage();
+      if (msg != null) {
+        sb.append(": ").append(msg.replace('\n', ' ').replace('\r', ' '));
+      }
+    }
+    sb.append('\n');
+    return sb.toString();
+  }
+
+  static String mapLevel(final Level level) {
+    if (level.intValue() >= Level.SEVERE.intValue()) {
+      return "ERROR";
+    }
+    if (level.intValue() >= Level.WARNING.intValue()) {
+      return "WARN";
+    }
+    if (level.intValue() >= Level.INFO.intValue()) {
+      return "INFO";
+    }
+    return "DEBUG";
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/SidecarMain.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/SidecarMain.java
@@ -13,6 +13,8 @@ import java.util.logging.Logger;
 import org.triplea.ai.sidecar.http.HttpService;
 
 public final class SidecarMain {
+  private static final System.Logger LOG = System.getLogger(SidecarMain.class.getName());
+
   private SidecarMain() {}
 
   public static void main(final String[] args) throws IOException, InterruptedException {
@@ -23,7 +25,7 @@ public final class SidecarMain {
     final CanonicalGameData canonical = CanonicalGameData.load();
 
     final HttpService svc = HttpService.start(cfg, canonical);
-    System.out.printf("[ai-sidecar] listening on %s:%d%n", cfg.bindHost(), svc.boundPort());
+    LOG.log(System.Logger.Level.INFO, "listening on {0}:{1}", cfg.bindHost(), svc.boundPort());
 
     final CountDownLatch latch = new CountDownLatch(1);
     Runtime.getRuntime()
@@ -51,7 +53,11 @@ public final class SidecarMain {
         LogManager.getLogManager().readConfiguration(is);
       }
     } catch (final IOException e) {
-      System.err.println("Failed to load sidecar logging.properties: " + e.getMessage());
+      // Logger may not be configured yet — this failure is rare startup infrastructure.
+      LOG.log(
+          System.Logger.Level.WARNING,
+          "Failed to load sidecar logging.properties: {0}",
+          e.getMessage());
     }
 
     // Apply SIDECAR_LOG_LEVEL env var override on top of the baseline.
@@ -70,9 +76,7 @@ public final class SidecarMain {
     // Mirror the level into ProLogSettings so ProLogger's own depth filter matches.
     ProLogSettings.loadSettings().setLogLevel(julLevel);
 
-    System.getLogger(SidecarMain.class.getName())
-        .log(
-            System.Logger.Level.INFO, "Sidecar logging initialized: level={0}", julLevel.getName());
+    LOG.log(System.Logger.Level.INFO, "Sidecar logging initialized: level={0}", julLevel.getName());
   }
 
   static Level parseJulLevel(final String envValue) {
@@ -82,11 +86,11 @@ public final class SidecarMain {
     try {
       return Level.parse(envValue.toUpperCase(Locale.ROOT));
     } catch (final IllegalArgumentException e) {
-      System.err.println(
-          "SIDECAR_LOG_LEVEL="
-              + envValue
-              + " is not a valid java.util.logging level; "
-              + "defaulting to INFO. Valid: SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST.");
+      LOG.log(
+          System.Logger.Level.WARNING,
+          "SIDECAR_LOG_LEVEL={0} is not a valid java.util.logging level; defaulting to INFO."
+              + " Valid: SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST.",
+          envValue);
       return Level.INFO;
     }
   }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/SidecarStdoutHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/SidecarStdoutHandler.java
@@ -1,0 +1,34 @@
+package org.triplea.ai.sidecar;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.StreamHandler;
+
+/**
+ * JUL {@link StreamHandler} that writes to {@code System.out} and flushes after every record.
+ *
+ * <p>Configured in {@code logging.properties} as the sole sidecar handler so all JUL output goes to
+ * one stream. Docker captures stdout in arrival order; flush-per-record prevents buffered writes
+ * from arriving out of sequence relative to TS-side stdout lines.
+ *
+ * <p>Uses {@link SidecarLogFormatter} for the shared single-line format (#2549).
+ */
+public final class SidecarStdoutHandler extends StreamHandler {
+
+  public SidecarStdoutHandler() {
+    super(System.out, new SidecarLogFormatter());
+    setLevel(Level.ALL);
+  }
+
+  @Override
+  public synchronized void publish(final LogRecord record) {
+    super.publish(record);
+    flush();
+  }
+
+  @Override
+  public synchronized void close() {
+    flush();
+    // Do not close System.out — it is shared JVM infrastructure.
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
@@ -86,6 +86,7 @@ public final class DecisionHandler implements HttpHandler {
     }
 
     AiTraceLogger.setMatchId(matchIdFor(request));
+    setRoundAndPlayer(request);
     try {
       switch (request) {
         case PurchaseRequest pr -> {
@@ -106,7 +107,7 @@ public final class DecisionHandler implements HttpHandler {
       LOG.log(System.Logger.Level.ERROR, "Decision handler internal error", e);
       writeJson(exchange, 500, JsonBodies.errorBody("internal"));
     } finally {
-      AiTraceLogger.clearMatchId();
+      AiTraceLogger.clearAll();
     }
   }
 
@@ -120,6 +121,22 @@ public final class DecisionHandler implements HttpHandler {
       case NoncombatMoveRequest nm -> nm.state().currentPlayer() + ":r" + nm.state().round();
       case OtherOffensiveRequest oo -> "kind=" + oo.kind();
     };
+  }
+
+  private static void setRoundAndPlayer(final DecisionRequest request) {
+    switch (request) {
+      case PurchaseRequest pr -> {
+        AiTraceLogger.setRound(pr.state().round());
+        AiTraceLogger.setPlayer(pr.state().currentPlayer());
+      }
+      case NoncombatMoveRequest nm -> {
+        AiTraceLogger.setRound(nm.state().round());
+        AiTraceLogger.setPlayer(nm.state().currentPlayer());
+      }
+      case OtherOffensiveRequest ignored -> {
+        // OtherOffensiveRequest has no state — leave round/player as sentinel.
+      }
+    }
   }
 
   private static void writeJson(final HttpExchange ex, final int status, final String body)

--- a/game-app/ai-sidecar/src/main/resources/logging.properties
+++ b/game-app/ai-sidecar/src/main/resources/logging.properties
@@ -1,15 +1,14 @@
 # Default sidecar logging configuration.
 # Overridden at runtime by the SIDECAR_LOG_LEVEL env var applied in SidecarMain.initializeLogging.
+#
+# SidecarStdoutHandler writes to System.out, flushes after every record, and formats via
+# SidecarLogFormatter (shared #2549 convention: <ISO8601-ms-UTC> <LEVEL> [ai-sidecar] match= round= player= <message>).
+# Single stdout stream prevents Docker from interleaving stderr + stdout out of time order.
 
-handlers = java.util.logging.ConsoleHandler
+handlers = org.triplea.ai.sidecar.SidecarStdoutHandler
 .level = INFO
 
-# ConsoleHandler writes to stderr by default; docker logs captures both stdout and stderr.
-java.util.logging.ConsoleHandler.level = ALL
-java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-
-# Compact single-line format: timestamp level logger - message
-java.util.logging.SimpleFormatter.format = %1$tFT%1$tT %4$s %3$s - %5$s%6$s%n
+org.triplea.ai.sidecar.SidecarStdoutHandler.level = ALL
 
 # Suppress JDK HttpServer access logs (GET /health, no-request-line, etc.)
 # at FINE-level. The root logger is raised to FINE when SIDECAR_LOG_LEVEL=FINE,

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceLoggerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceLoggerTest.java
@@ -91,22 +91,49 @@ class AiTraceLoggerTest {
   // ---------------------------------------------------------------------------
 
   @AfterEach
-  void clearMatchIdContext() {
-    AiTraceLogger.clearMatchId();
+  void clearContext() {
+    AiTraceLogger.clearAll();
   }
 
   @Test
-  void currentMatchId_unset_returnsUnknown() {
-    AiTraceLogger.clearMatchId();
-    assertThat(AiTraceLogger.currentMatchId()).isEqualTo("unknown");
+  void currentMatchId_unset_returnsSentinel() {
+    AiTraceLogger.clearAll();
+    assertThat(AiTraceLogger.currentMatchId()).isEqualTo(AiTraceLogger.SENTINEL);
   }
 
   @Test
   void setAndClearMatchId_roundTrip() {
     AiTraceLogger.setMatchId("match-abc-123");
     assertThat(AiTraceLogger.currentMatchId()).isEqualTo("match-abc-123");
-    AiTraceLogger.clearMatchId();
-    assertThat(AiTraceLogger.currentMatchId()).isEqualTo("unknown");
+    AiTraceLogger.clearAll();
+    assertThat(AiTraceLogger.currentMatchId()).isEqualTo(AiTraceLogger.SENTINEL);
+  }
+
+  @Test
+  void setAndClearRound_roundTrip() {
+    AiTraceLogger.setRound(5);
+    assertThat(AiTraceLogger.currentRound()).isEqualTo("5");
+    AiTraceLogger.clearAll();
+    assertThat(AiTraceLogger.currentRound()).isEqualTo(AiTraceLogger.SENTINEL);
+  }
+
+  @Test
+  void setAndClearPlayer_roundTrip() {
+    AiTraceLogger.setPlayer("Germans");
+    assertThat(AiTraceLogger.currentPlayer()).isEqualTo("Germans");
+    AiTraceLogger.clearAll();
+    assertThat(AiTraceLogger.currentPlayer()).isEqualTo(AiTraceLogger.SENTINEL);
+  }
+
+  @Test
+  void clearAll_clearsAllFields() {
+    AiTraceLogger.setMatchId("m");
+    AiTraceLogger.setRound(2);
+    AiTraceLogger.setPlayer("Russians");
+    AiTraceLogger.clearAll();
+    assertThat(AiTraceLogger.currentMatchId()).isEqualTo(AiTraceLogger.SENTINEL);
+    assertThat(AiTraceLogger.currentRound()).isEqualTo(AiTraceLogger.SENTINEL);
+    assertThat(AiTraceLogger.currentPlayer()).isEqualTo(AiTraceLogger.SENTINEL);
   }
 
   @Test
@@ -118,14 +145,14 @@ class AiTraceLoggerTest {
     final Thread worker =
         new Thread(
             () -> {
-              // Worker has no inherited matchID — must see "unknown".
+              // Worker has no inherited matchID — must see sentinel.
               seenInWorker.set(AiTraceLogger.currentMatchId());
               AiTraceLogger.setMatchId("worker-thread-match");
             });
     worker.start();
     worker.join();
 
-    assertThat(seenInWorker.get()).isEqualTo("unknown");
+    assertThat(seenInWorker.get()).isEqualTo(AiTraceLogger.SENTINEL);
     // Main thread context was never touched by worker's setMatchId — still its own value.
     assertThat(AiTraceLogger.currentMatchId()).isEqualTo("main-thread-match");
   }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarLogFormatterTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/SidecarLogFormatterTest.java
@@ -1,0 +1,165 @@
+package org.triplea.ai.sidecar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SidecarLogFormatter}.
+ *
+ * <p>Covers: field presence and order, {@code -} sentinel for unbound context, ISO-8601-ms-UTC
+ * timestamp with exactly 3 fractional digits, level mapping, and exception appending.
+ */
+class SidecarLogFormatterTest {
+
+  private final SidecarLogFormatter formatter = new SidecarLogFormatter();
+
+  @AfterEach
+  void clearContext() {
+    AiTraceLogger.clearAll();
+  }
+
+  // -------------------------------------------------------------------------
+  // Field ordering and sentinel
+  // -------------------------------------------------------------------------
+
+  @Test
+  void format_noContext_allFieldsUseSentinel() {
+    final LogRecord rec = record(Level.INFO, "hello");
+    final String line = formatter.format(rec);
+
+    assertThat(line).contains("match=- ");
+    assertThat(line).contains("round=- ");
+    assertThat(line).contains("player=- ");
+    assertThat(line).contains(" hello");
+    assertThat(line).endsWith("\n");
+  }
+
+  @Test
+  void format_withContext_fieldsCarryRealValues() {
+    AiTraceLogger.setMatchId("match-abc");
+    AiTraceLogger.setRound(3);
+    AiTraceLogger.setPlayer("Germans");
+
+    final String line = formatter.format(record(Level.INFO, "msg"));
+
+    assertThat(line).contains("match=match-abc ");
+    assertThat(line).contains("round=3 ");
+    assertThat(line).contains("player=Germans ");
+  }
+
+  @Test
+  void format_fieldOrder_timestampLevelTagMatchRoundPlayerMessage() {
+    AiTraceLogger.setMatchId("m1");
+    AiTraceLogger.setRound(1);
+    AiTraceLogger.setPlayer("Italians");
+    final String line = formatter.format(record(Level.INFO, "payload"));
+
+    // Verify ordering by checking index positions.
+    final int tsIdx = line.indexOf("T"); // ISO timestamp starts with date "T" separator
+    final int infoIdx = line.indexOf(" INFO ");
+    final int tagIdx = line.indexOf(" [ai-sidecar] ");
+    final int matchIdx = line.indexOf(" match=");
+    final int roundIdx = line.indexOf(" round=");
+    final int playerIdx = line.indexOf(" player=");
+    final int msgIdx = line.indexOf(" payload");
+
+    assertThat(tsIdx).isLessThan(infoIdx);
+    assertThat(infoIdx).isLessThan(tagIdx);
+    assertThat(tagIdx).isLessThan(matchIdx);
+    assertThat(matchIdx).isLessThan(roundIdx);
+    assertThat(roundIdx).isLessThan(playerIdx);
+    assertThat(playerIdx).isLessThan(msgIdx);
+  }
+
+  // -------------------------------------------------------------------------
+  // Timestamp format
+  // -------------------------------------------------------------------------
+
+  @Test
+  void format_timestamp_hasExactlyThreeFractionalDigitsAndZSuffix() {
+    // Use a known epoch millis (fractional part = .482)
+    final LogRecord rec = new LogRecord(Level.INFO, "msg");
+    rec.setInstant(Instant.parse("2026-05-17T14:03:21.482Z"));
+    final String line = formatter.format(rec);
+
+    assertThat(line).startsWith("2026-05-17T14:03:21.482Z ");
+  }
+
+  @Test
+  void format_timestamp_zeroMillis_stillEmitsThreeFractionalDigits() {
+    final LogRecord rec = new LogRecord(Level.INFO, "msg");
+    rec.setInstant(Instant.parse("2026-05-17T14:03:21.000Z"));
+    final String line = formatter.format(rec);
+
+    // Instant.toString() would emit "2026-05-17T14:03:21Z" (no millis) — formatter must pad.
+    assertThat(line).startsWith("2026-05-17T14:03:21.000Z ");
+  }
+
+  // -------------------------------------------------------------------------
+  // Level mapping
+  // -------------------------------------------------------------------------
+
+  @Test
+  void mapLevel_severe_mapsToError() {
+    assertThat(SidecarLogFormatter.mapLevel(Level.SEVERE)).isEqualTo("ERROR");
+  }
+
+  @Test
+  void mapLevel_warning_mapsToWarn() {
+    assertThat(SidecarLogFormatter.mapLevel(Level.WARNING)).isEqualTo("WARN");
+  }
+
+  @Test
+  void mapLevel_info_mapsToInfo() {
+    assertThat(SidecarLogFormatter.mapLevel(Level.INFO)).isEqualTo("INFO");
+  }
+
+  @Test
+  void mapLevel_fine_mapsToDebug() {
+    assertThat(SidecarLogFormatter.mapLevel(Level.FINE)).isEqualTo("DEBUG");
+  }
+
+  @Test
+  void mapLevel_finest_mapsToDebug() {
+    assertThat(SidecarLogFormatter.mapLevel(Level.FINEST)).isEqualTo("DEBUG");
+  }
+
+  // -------------------------------------------------------------------------
+  // Tag
+  // -------------------------------------------------------------------------
+
+  @Test
+  void format_containsSidecarTag() {
+    assertThat(formatter.format(record(Level.INFO, "x"))).contains("[ai-sidecar]");
+  }
+
+  // -------------------------------------------------------------------------
+  // Exception handling
+  // -------------------------------------------------------------------------
+
+  @Test
+  void format_thrownException_appendedOnSameLine() {
+    final LogRecord rec = record(Level.SEVERE, "boom");
+    rec.setThrown(new IllegalStateException("bad state"));
+    final String line = formatter.format(rec);
+
+    assertThat(line).contains("IllegalStateException");
+    assertThat(line).contains("bad state");
+    assertThat(line).endsWith("\n");
+    // Single line — no embedded newlines before the trailing \n.
+    assertThat(line.substring(0, line.length() - 1)).doesNotContain("\n");
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private static LogRecord record(final Level level, final String message) {
+    return new LogRecord(level, message);
+  }
+}

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
@@ -102,7 +102,7 @@ class DecisionHandlerTest {
               throw new AssertionError();
             });
 
-    AiTraceLogger.clearMatchId();
+    AiTraceLogger.clearAll();
     final FakeHttpExchange ex = new FakeHttpExchange("POST", "/decision", body("purchase"));
     h.handle(ex);
 
@@ -111,7 +111,7 @@ class DecisionHandlerTest {
     assertEquals("Germans:r1", seenInExecutor.get());
     // After dispatch the per-thread context is cleared so a thread-pool worker reused for the
     // next request doesn't leak the previous matchID.
-    assertEquals("unknown", AiTraceLogger.currentMatchId());
+    assertEquals(AiTraceLogger.SENTINEL, AiTraceLogger.currentMatchId());
   }
 
   @Test
@@ -126,13 +126,13 @@ class DecisionHandlerTest {
               throw new AssertionError();
             });
 
-    AiTraceLogger.clearMatchId();
+    AiTraceLogger.clearAll();
     final FakeHttpExchange ex = new FakeHttpExchange("POST", "/decision", body("purchase"));
     h.handle(ex);
 
     assertEquals(400, ex.responseCode());
     // finally block must clear the matchID even when the executor throws.
-    assertEquals("unknown", AiTraceLogger.currentMatchId());
+    assertEquals(AiTraceLogger.SENTINEL, AiTraceLogger.currentMatchId());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- **`SidecarLogFormatter`**: single-line JUL `Formatter` emitting the shared [#2549](https://github.com/map-room/map-room/issues/2549) convention: `<ISO8601-ms-UTC> <LEVEL> [ai-sidecar] match=<id> round=<n> player=<nation> <message>`. Always 3 fractional ms digits for lexical sort. `-` sentinel for unbound fields.
- **`SidecarStdoutHandler`**: `StreamHandler` writing to `System.out` with flush-per-record. Replaces `ConsoleHandler` (stderr) so Docker sees a single ordered stream.
- **`logging.properties`**: switched from `ConsoleHandler+SimpleFormatter` to `SidecarStdoutHandler`.
- **`AiTraceLogger`**: added `SENTINEL`, `round`/`player` `ThreadLocal`s; `setRound`/`setPlayer`/`clearAll`; deprecated `clearMatchId()` in favour of `clearAll()`.
- **`DecisionHandler`**: sets `round` + `player` from `WireState` at request boundary; clears via `clearAll()` in finally.
- **`SidecarMain`**: replaced 3 raw `System.out.printf`/`System.err.println` bypass sites with JUL `Logger` calls.
- **`SidecarLogFormatterTest`**: field ordering, `-` sentinel, ISO-ms-UTC (incl. `.000Z` padding), level mapping, exception single-line appending.

> ⚠️ **Blocked on #2549**: the exact format string carries a TODO and must be byte-verified against alpha's TS implementation before merge. Once alpha comments on map-room#2551 with the frozen format, update `SidecarLogFormatter` to match byte-for-byte.

## Test plan

- [x] `SidecarLogFormatterTest` — formatter fields, sentinel, timestamp, level mapping, exception line
- [x] `AiTraceLoggerTest` — round/player ThreadLocals, `clearAll`, thread isolation
- [x] `DecisionHandlerTest` — context cleared in finally; sentinel after dispatch
- [x] Full `:game-app:ai-sidecar:test` suite — green (52m run, all tests pass)

Closes map-room/map-room#2551
References map-room/map-room#2549