### PR TITLE
fix(ai-sidecar): use real bgio matchId in logs, not synthetic player:r{round}

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/NoncombatMoveRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/NoncombatMoveRequest.java
@@ -1,6 +1,8 @@
 package org.triplea.ai.sidecar.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.triplea.ai.sidecar.wire.WireState;
 
 /**
@@ -13,10 +15,28 @@ import org.triplea.ai.sidecar.wire.WireState;
  * org.triplea.ai.sidecar.exec.NoncombatMoveExecutor#execute(org.triplea.ai.sidecar.session.Session,
  * NoncombatMoveRequest)} reseeds {@code proData.getRng()} and the battle calculator from this value
  * at the start of every call so ProAi behaviour is deterministic given {@code (gamestate, seed)}.
+ *
+ * <p>{@code matchId} is the boardgame.io match ID for cross-process log correlation (#2555). Older
+ * callers that omit it receive {@code null}; the log formatter substitutes the {@code -} sentinel.
  */
 @JsonIgnoreProperties("kind")
-public record NoncombatMoveRequest(WireState state, long seed) implements DecisionRequest {
+public record NoncombatMoveRequest(WireState state, long seed, String matchId)
+    implements DecisionRequest {
   public String kind() {
     return "noncombat-move";
+  }
+
+  /** Backwards-compat: call sites that don't supply a matchId get null → sentinel in logs. */
+  public NoncombatMoveRequest(final WireState state, final long seed) {
+    this(state, seed, null);
+  }
+
+  /** Jackson deserialisation — {@code matchId} absent in old payloads defaults to null. */
+  @JsonCreator
+  public static NoncombatMoveRequest fromJson(
+      @JsonProperty("state") final WireState state,
+      @JsonProperty("seed") final long seed,
+      @JsonProperty("matchId") final String matchId) {
+    return new NoncombatMoveRequest(state, seed, matchId);
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchaseRequest.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/dto/PurchaseRequest.java
@@ -1,6 +1,8 @@
 package org.triplea.ai.sidecar.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.triplea.ai.sidecar.wire.WireState;
 
 /**
@@ -13,10 +15,28 @@ import org.triplea.ai.sidecar.wire.WireState;
  * org.triplea.ai.sidecar.exec.PurchaseExecutor#execute(org.triplea.ai.sidecar.session.Session,
  * PurchaseRequest)} reseeds {@code proData.getRng()} and the battle calculator from this value at
  * the start of every call so ProAi behaviour is deterministic given {@code (gamestate, seed)}.
+ *
+ * <p>{@code matchId} is the boardgame.io match ID for cross-process log correlation (#2555). Older
+ * callers that omit it receive {@code null}; the log formatter substitutes the {@code -} sentinel.
  */
 @JsonIgnoreProperties("kind")
-public record PurchaseRequest(WireState state, long seed) implements DecisionRequest {
+public record PurchaseRequest(WireState state, long seed, String matchId)
+    implements DecisionRequest {
   public String kind() {
     return "purchase";
+  }
+
+  /** Backwards-compat: call sites that don't supply a matchId get null → sentinel in logs. */
+  public PurchaseRequest(final WireState state, final long seed) {
+    this(state, seed, null);
+  }
+
+  /** Jackson deserialisation — {@code matchId} absent in old payloads defaults to null. */
+  @JsonCreator
+  public static PurchaseRequest fromJson(
+      @JsonProperty("state") final WireState state,
+      @JsonProperty("seed") final long seed,
+      @JsonProperty("matchId") final String matchId) {
+    return new PurchaseRequest(state, seed, matchId);
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/http/DecisionHandler.java
@@ -112,15 +112,19 @@ public final class DecisionHandler implements HttpHandler {
   }
 
   /**
-   * Best-effort match-id extraction for trace logging. Stateless requests don't carry an explicit
-   * gameId; fall back to "currentPlayer:r{round}" as the trace tag.
+   * Extract the bgio match ID for log correlation. Returns the real match ID when the wire envelope
+   * includes one; falls back to {@link AiTraceLogger#SENTINEL} when absent. Never synthesises a
+   * composite like {@code player:r{round}} — that would break {@code grep 'match=<bgioId>'} across
+   * server, bot-worker, and sidecar logs.
    */
   private static String matchIdFor(final DecisionRequest request) {
-    return switch (request) {
-      case PurchaseRequest pr -> pr.state().currentPlayer() + ":r" + pr.state().round();
-      case NoncombatMoveRequest nm -> nm.state().currentPlayer() + ":r" + nm.state().round();
-      case OtherOffensiveRequest oo -> "kind=" + oo.kind();
-    };
+    final String id =
+        switch (request) {
+          case PurchaseRequest pr -> pr.matchId();
+          case NoncombatMoveRequest nm -> nm.matchId();
+          case OtherOffensiveRequest ignored -> null;
+        };
+    return (id != null && !id.isBlank()) ? id : AiTraceLogger.SENTINEL;
   }
 
   private static void setRoundAndPlayer(final DecisionRequest request) {

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/http/DecisionHandlerTest.java
@@ -32,6 +32,16 @@ class DecisionHandlerTest {
     return "{\"kind\":\"" + kind + "\"," + EMPTY_STATE + ",\"seed\":42}";
   }
 
+  private static String bodyWithMatchId(final String kind, final String matchId) {
+    return "{\"kind\":\""
+        + kind
+        + "\","
+        + EMPTY_STATE
+        + ",\"seed\":42,\"matchId\":\""
+        + matchId
+        + "\"}";
+  }
+
   private static DecisionHandler stubHandler() {
     return new DecisionHandler(
         canonical,
@@ -89,7 +99,34 @@ class DecisionHandlerTest {
   // ---------------------------------------------------------------------
 
   @Test
-  void matchIdIsBoundDuringDispatchAndClearedAfter() throws Exception {
+  void matchId_fromEnvelope_usedDirectly() throws Exception {
+    // Regression for #2555: when the wire envelope carries a real bgio matchId,
+    // it must appear verbatim in the log context — never a synthetic composite.
+    final AtomicReference<String> seenInExecutor = new AtomicReference<>();
+    final DecisionHandler h =
+        new DecisionHandler(
+            canonical,
+            (canonical, req) -> {
+              seenInExecutor.set(AiTraceLogger.currentMatchId());
+              return new PurchasePlan(List.of(), List.of(), List.of());
+            },
+            (canonical, req) -> {
+              throw new AssertionError();
+            });
+
+    AiTraceLogger.clearAll();
+    final FakeHttpExchange ex =
+        new FakeHttpExchange("POST", "/decision", bodyWithMatchId("purchase", "bgio-abc123"));
+    h.handle(ex);
+
+    assertEquals("bgio-abc123", seenInExecutor.get());
+    assertEquals(AiTraceLogger.SENTINEL, AiTraceLogger.currentMatchId());
+  }
+
+  @Test
+  void matchId_absentFromEnvelope_usesSentinel() throws Exception {
+    // Regression for #2555: when matchId is absent, the log context must use '-',
+    // never a synthetic player:r{round} fallback.
     final AtomicReference<String> seenInExecutor = new AtomicReference<>();
     final DecisionHandler h =
         new DecisionHandler(
@@ -106,11 +143,7 @@ class DecisionHandlerTest {
     final FakeHttpExchange ex = new FakeHttpExchange("POST", "/decision", body("purchase"));
     h.handle(ex);
 
-    // During dispatch the executor saw a request-scoped matchID derived from
-    // currentPlayer:r{round}.
-    assertEquals("Germans:r1", seenInExecutor.get());
-    // After dispatch the per-thread context is cleared so a thread-pool worker reused for the
-    // next request doesn't leak the previous matchID.
+    assertEquals(AiTraceLogger.SENTINEL, seenInExecutor.get());
     assertEquals(AiTraceLogger.SENTINEL, AiTraceLogger.currentMatchId());
   }
 


### PR DESCRIPTION
## Summary

Fixes `match=Germans:r1` in sidecar logs — a synthetic composite that broke `grep 'match=<bgioId>'` cross-process correlation.

**Root cause:** `DecisionHandler.matchIdFor()` fell back to `currentPlayer + ":r" + round` when the wire envelope had no explicit matchId field. This value flowed through `AiTraceLogger.MATCH_ID → SidecarLogFormatter` as the `match=` field, producing lines the server/bot logs could never correlate against.

**Fix:**
- `PurchaseRequest` / `NoncombatMoveRequest`: added optional `matchId` field (backwards-compat 2-arg constructor + `@JsonCreator` factory so absent payloads default to `null`).
- `DecisionHandler.matchIdFor()`: reads `matchId` directly from the envelope; falls back to `AiTraceLogger.SENTINEL` (`-`) when absent. Synthetic composite removed entirely.
- Two regression tests: envelope with `matchId` → `match=<thatId>`; envelope without → `match=-`.

**Wire compat:** existing payloads without `matchId` continue to deserialise — they get `match=-` in logs, which is correct per `docs/logging-convention.md`. Once the TS side sends `matchId` in the request body (companion work), sidecar logs will carry the real bgio match ID.

## Test plan

- [x] `matchId_fromEnvelope_usedDirectly` — `"matchId":"bgio-abc123"` in body → executor sees `"bgio-abc123"`
- [x] `matchId_absentFromEnvelope_usesSentinel` — no `matchId` in body → executor sees `"-"`
- [x] `matchIdIsClearedEvenWhenExecutorThrows` — context cleared in finally still works
- [x] Full `:game-app:ai-sidecar:test` — green

Closes map-room/map-room#2555
References docs/logging-convention.md (map-room PR #2552 / #2549)