### PR TITLE
perf(ai): skip Monte Carlo for lopsided NCM territory-hold checks

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -519,7 +519,7 @@ class ProNonCombatMoveAi {
           CollectionUtils.getMatches(
               patd.getCantMoveUnits(), Matches.unitIsAaForAnything().negate());
       final ProBattleResult minResult =
-          calc.calculateBattleResults(
+          calc.estimateAttackBattleResults(
               proData,
               t,
               enemyAttackingUnits,
@@ -551,7 +551,7 @@ class ProNonCombatMoveAi {
       final List<Unit> defendingUnitsAndNotAa =
           CollectionUtils.getMatches(defendingUnits, Matches.unitIsAaForAnything().negate());
       final ProBattleResult result =
-          calc.calculateBattleResults(
+          calc.estimateDefendBattleResults(
               proData,
               t,
               enemyAttackingUnits,
@@ -2129,7 +2129,7 @@ class ProNonCombatMoveAi {
         final Collection<Unit> defendingUnits = proTerritory.getAllDefenders();
         defendingUnits.add(u);
         proTerritory.setBattleResultIfNull(
-            () -> calc.calculateBattleResults(proData, proTerritory, defendingUnits));
+            () -> calc.estimateAttackBattleResults(proData, proTerritory, defendingUnits));
         final ProBattleResult result = proTerritory.getBattleResult();
         ProLogger.trace(
             String.format(
@@ -2149,7 +2149,7 @@ class ProNonCombatMoveAi {
         final List<Unit> myDefenders =
             CollectionUtils.getMatches(defendingUnits, Matches.unitIsOwnedBy(player));
         final ProBattleResult result2 =
-            calc.calculateBattleResults(proData, proTerritory, myDefenders);
+            calc.estimateDefendBattleResults(proData, proTerritory, myDefenders);
         int cantHoldWithoutAllies = 0;
         if (result2.getWinPercentage() >= proData.getMinWinPercentage()
             || result2.getTuvSwing() > 0) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
@@ -108,6 +108,16 @@ public class ProOddsCalculator {
         proTerritory.getMaxEnemyBombardUnits());
   }
 
+  public ProBattleResult estimateAttackBattleResults(
+      final ProData proData, final ProTerritory proTerritory, final Collection<Unit> defenders) {
+    return estimateAttackBattleResults(
+        proData,
+        proTerritory.getTerritory(),
+        proTerritory.getMaxEnemyUnits(),
+        defenders,
+        proTerritory.getMaxEnemyBombardUnits());
+  }
+
   public ProBattleResult calculateBattleResultsNoSubmerge(
       final ProData proData,
       final Territory t,

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProOddsCalculatorFastPathTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProOddsCalculatorFastPathTest.java
@@ -1,0 +1,134 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
+import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.ProTerritory;
+import games.strategy.triplea.odds.calculator.AggregateResults;
+import games.strategy.triplea.odds.calculator.IBattleCalculator;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link ProOddsCalculator#estimateAttackBattleResults} and {@link
+ * ProOddsCalculator#estimateDefendBattleResults} skip the expensive Monte Carlo simulation when the
+ * strength difference is decisive in either direction. These fast paths are the key optimisation
+ * for the O(territories × trials) cliff in {@code
+ * ProNonCombatMoveAi.determineIfMoveTerritoriesCanBeHeld} (see map-room/map-room#2561).
+ */
+class ProOddsCalculatorFastPathTest {
+
+  private GameData data;
+  private GamePlayer germans;
+  private GamePlayer russians;
+  private Territory germany;
+  private AtomicInteger simCalls;
+  private ProOddsCalculator calc;
+  private ProData proData;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    germany = territory("Germany", data);
+    germans = data.getPlayerList().getPlayerId("Germans");
+    russians = data.getPlayerList().getPlayerId("Russians");
+
+    simCalls = new AtomicInteger();
+    calc = new ProOddsCalculator(countingCalc(simCalls));
+    proData = proDataWithGameData(data);
+  }
+
+  @Test
+  void estimateAttackBattleResults_noSimWhenDefendersDominate() {
+    // 1 attacker vs 20 defenders — strength difference << 45, so fast-path must fire.
+    final List<Unit> attackers = infantry(data).create(1, russians);
+    final List<Unit> defenders = infantry(data).create(20, germans);
+
+    calc.estimateAttackBattleResults(proData, germany, attackers, defenders, List.of());
+
+    assertThat(simCalls.get())
+        .as("estimateAttackBattleResults must skip simulation when defenders dominate")
+        .isEqualTo(0);
+  }
+
+  @Test
+  void estimateDefendBattleResults_noSimWhenAttackersDominate() {
+    // 20 attackers vs 1 defender — strength difference >> 55, so fast-path must fire.
+    final List<Unit> attackers = infantry(data).create(20, russians);
+    final List<Unit> defenders = infantry(data).create(1, germans);
+
+    calc.estimateDefendBattleResults(proData, germany, attackers, defenders, List.of());
+
+    assertThat(simCalls.get())
+        .as("estimateDefendBattleResults must skip simulation when attackers dominate")
+        .isEqualTo(0);
+  }
+
+  @Test
+  void estimateAttackBattleResults_proTerritoryOverload_noSimWhenDefendersDominate() {
+    // Mirrors the ProTerritory overload added for the NCM "Move air units" section (line 2132).
+    final List<Unit> attackers = infantry(data).create(1, russians);
+    final List<Unit> defenders = infantry(data).create(20, germans);
+
+    final ProTerritory proTerritory = new ProTerritory(germany, new ProData());
+    proTerritory.setMaxEnemyUnits(attackers);
+
+    calc.estimateAttackBattleResults(proData, proTerritory, defenders);
+
+    assertThat(simCalls.get())
+        .as(
+            "estimateAttackBattleResults (ProTerritory overload) must skip simulation when defenders dominate")
+        .isEqualTo(0);
+  }
+
+  @Test
+  void estimateDefendBattleResults_proTerritoryOverload_noSimWhenAttackersDominate() {
+    // Mirrors the ProTerritory overload used in the NCM "Move air units" section (line 2152).
+    final List<Unit> attackers = infantry(data).create(20, russians);
+    final List<Unit> defenders = infantry(data).create(1, germans);
+
+    final ProTerritory proTerritory = new ProTerritory(germany, new ProData());
+    proTerritory.setMaxEnemyUnits(attackers);
+
+    calc.estimateDefendBattleResults(proData, proTerritory, defenders);
+
+    assertThat(simCalls.get())
+        .as(
+            "estimateDefendBattleResults (ProTerritory overload) must skip simulation when attackers dominate")
+        .isEqualTo(0);
+  }
+
+  private static ProData proDataWithGameData(final GameData data) throws Exception {
+    final ProData proData = new ProData();
+    final Field f = ProData.class.getDeclaredField("data");
+    f.setAccessible(true);
+    f.set(proData, data);
+    return proData;
+  }
+
+  /** Returns an {@link IBattleCalculator} that increments {@code counter} on each call. */
+  private static IBattleCalculator countingCalc(final AtomicInteger counter) {
+    return (attacker,
+        defender,
+        location,
+        attacking,
+        defending,
+        bombarding,
+        territoryEffects,
+        retreatWhenOnlyAirLeft,
+        runCount) -> {
+      counter.incrementAndGet();
+      return new AggregateResults(0);
+    };
+  }
+}


### PR DESCRIPTION
## Summary

`ProNonCombatMoveAi.determineIfMoveTerritoriesCanBeHeld()` called `calculateBattleResults()` (full Monte Carlo simulation) for every territory with enemy attack options — up to 332 in late-game Global 1940, up to twice per territory. In deterministic (seeded) mode the `ConcurrentBattleCalculator` runs all trials in a single thread; at ~1.4 s/call this caused the 929 s cliff logged at R8+ (map-room/map-room#2561).

**Root cause** confirmed by profiling: `callBattleCalc` is O(trials) sequential in seeded mode, and `runCount = max(16, 100 − minArmySize)` — a small static garrison (3–5 units) produces ~95 trials. 332 territories × 2 calls × ~1.4 s = ~929 s.

**Fix**: replace the four hot `calculateBattleResults` call sites in `ProNonCombatMoveAi` with the existing estimate variants in `ProOddsCalculator` that short-circuit via `estimateStrengthDifference` before spawning any simulation:

| Site | Replacement | Fast-path condition |
|------|-------------|---------------------|
| Line 522, min-defenders check | `estimateAttackBattleResults` | strengthDiff < 45 → defenders clearly win → 0 ms |
| Line 554, max-defenders check | `estimateDefendBattleResults` | strengthDiff > 55 → attackers overwhelm even max defenders → 0 ms |
| Line 2132, air-unit safety (`setBattleResultIfNull`) | `estimateAttackBattleResults` (new ProTerritory overload) | same |
| Line 2152, air-unit own-only check | `estimateDefendBattleResults` | same |

Borderline cases (45 ≤ strengthDiff ≤ 55) still run the full simulation — exactly the contested territories where accuracy matters. All other `ProOddsCalculator` semantics are unchanged; these methods fall through to `callBattleCalc` when the outcome isn't clear.

Also adds `ProOddsCalculatorFastPathTest` with 4 tests asserting that lopsided matchups (1v20 and 20v1 infantry) trigger 0 simulation calls.

## Test plan

- [x] `ProOddsCalculatorFastPathTest` — 4 new tests pass: both estimate variants + both ProTerritory overloads skip simulation for lopsided matchups
- [x] `./gradlew :game-app:game-core:test --tests "games.strategy.triplea.ai.pro.*"` — all ProAi tests pass
- [x] `./gradlew :game-app:ai-sidecar:test` — all sidecar integration tests pass
- [x] Spotless applied
- [ ] 🧑 Manual: replay the R8 Americans decision from match `fVdLtCOYdj9` and confirm wall-clock drops from 15+ min to < 60 s

Closes map-room/map-room#2561

🤖 Generated with [Claude Code](https://claude.com/claude-code)