### PR TITLE
obs(ai): purchase-budget reconciliation logging — fix IntegerMap render + PURCHASE-BUDGET summary

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/AiTraceLogger.java
@@ -142,6 +142,43 @@ public final class AiTraceLogger {
         transportId);
   }
 
+  /**
+   * Log the purchase-budget reconciliation summary once per nation per purchase phase (#2576).
+   *
+   * <p>Grep anchor: {@code PURCHASE-BUDGET}. Paired with the bot-side {@code
+   * kind=purchase-budget-reconciliation} line, these two lines together reconstruct ProAI's plan vs
+   * the per-pool execution for any match/round/player.
+   *
+   * @param startPUs total resources before factory repair (== PUsRemaining at repair start)
+   * @param repairCost total IPC spent on factory repair this phase
+   * @param availableAfterRepair {@code startPUs - repairCost}
+   * @param plannedSpend sum of the populated production-rule map cost (pre-trim)
+   * @param overspend true when {@code plannedSpend > availableAfterRepair}
+   * @param overBy {@code max(0, plannedSpend - availableAfterRepair)}
+   */
+  public static void logPurchaseBudget(
+      final String nation,
+      final int startPUs,
+      final int repairCost,
+      final int availableAfterRepair,
+      final int plannedSpend,
+      final boolean overspend,
+      final int overBy) {
+    LOG.log(
+        System.Logger.Level.INFO,
+        "[AI-TRACE] matchID={0} side=sidecar nation={1} phase=purchase kind=PURCHASE-BUDGET"
+            + " startPUs={2} repairCost={3} availableAfterRepair={4}"
+            + " plannedSpend={5} overspend={6} overBy={7}",
+        currentMatchId(),
+        nation,
+        startPUs,
+        repairCost,
+        availableAfterRepair,
+        plannedSpend,
+        overspend,
+        overBy);
+  }
+
   /** Log a single purchase order (call once per order in the trimmed plan). */
   public static void logPurchaseOrder(final String nation, final String unitType, final int count) {
     LOG.log(

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
@@ -173,6 +173,21 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
     }
     final List<RepairOrder> repairs = toRepairOrders(recorder.capturedRepair(), data);
 
+    // Emit PURCHASE-BUDGET reconciliation line (#2576). Uses pre-trim capturedPurchase so
+    // plannedSpend reflects ProAI's actual plan, not the trim-to-fit backstop output.
+    final int repairCost = totalRepairCost(recorder.capturedRepair(), pus);
+    final int availableAfterRepair = pusToSpend - repairCost;
+    final int plannedSpend = totalPuCost(recorder.capturedPurchase(), pus);
+    final int overBy = Math.max(0, plannedSpend - availableAfterRepair);
+    AiTraceLogger.logPurchaseBudget(
+        player.getName(),
+        pusToSpend,
+        repairCost,
+        availableAfterRepair,
+        plannedSpend,
+        overBy > 0,
+        overBy);
+
     final List<PoliticalActionAttachment> storedActions = proAi.getStoredPoliticalActions();
     final List<WarDeclaration> politicalActions;
     if (storedActions != null && !storedActions.isEmpty()) {
@@ -272,6 +287,17 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
     int sum = 0;
     for (final ProductionRule rule : map.keySet()) {
       sum += rule.getCosts().getInt(pus) * map.getInt(rule);
+    }
+    return sum;
+  }
+
+  private static int totalRepairCost(
+      final Map<Unit, IntegerMap<RepairRule>> repairMap, final Resource pus) {
+    int sum = 0;
+    for (final IntegerMap<RepairRule> ruleMap : repairMap.values()) {
+      for (final RepairRule rule : ruleMap.keySet()) {
+        sum += rule.getCosts().getInt(pus) * ruleMap.getInt(rule);
+      }
     }
     return sum;
   }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceLoggerTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/AiTraceLoggerTest.java
@@ -355,6 +355,56 @@ class AiTraceLoggerTest {
     assertThat(AiTraceLogger.scrambleReason(List.of(f1, f2), List.of(f1, f2))).isEqualTo("all");
   }
 
+  // ---------------------------------------------------------------------------
+  // purchase-budget reconciliation (#2576)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void logPurchaseBudget_normalScenario_emitsLineWithOverspendFalse() {
+    AiTraceLogger.setMatchId("match-pb-001");
+    final AiTraceCapture cap = AiTraceCapture.attach();
+    try {
+      // startPUs=40, repairCost=7, available=33, plannedSpend=30 → no overspend
+      AiTraceLogger.logPurchaseBudget("Germans", 40, 7, 33, 30, false, 0);
+    } finally {
+      cap.detach();
+    }
+
+    assertThat(cap.formatted()).hasSize(1);
+    assertThat(cap.formatted().get(0))
+        .startsWith("[AI-TRACE] matchID=match-pb-001 side=sidecar nation=Germans")
+        .contains("phase=purchase kind=PURCHASE-BUDGET")
+        .contains("startPUs=40")
+        .contains("repairCost=7")
+        .contains("availableAfterRepair=33")
+        .contains("plannedSpend=30")
+        .contains("overspend=false")
+        .contains("overBy=0");
+  }
+
+  @Test
+  void logPurchaseBudget_overBudgetScenario_emitsLineWithOverspendTrue() {
+    AiTraceLogger.setMatchId("match-pb-002");
+    final AiTraceCapture cap = AiTraceCapture.attach();
+    try {
+      // startPUs=40, repairCost=7, available=33, plannedSpend=46 → overBy=13
+      AiTraceLogger.logPurchaseBudget("British", 40, 7, 33, 46, true, 13);
+    } finally {
+      cap.detach();
+    }
+
+    assertThat(cap.formatted()).hasSize(1);
+    assertThat(cap.formatted().get(0))
+        .startsWith("[AI-TRACE] matchID=match-pb-002 side=sidecar nation=British")
+        .contains("phase=purchase kind=PURCHASE-BUDGET")
+        .contains("startPUs=40")
+        .contains("repairCost=7")
+        .contains("availableAfterRepair=33")
+        .contains("plannedSpend=46")
+        .contains("overspend=true")
+        .contains("overBy=13");
+  }
+
   @Test
   void logScrambleDecision_emitsLineWithExpectedKeysAndMatchId() {
     final var gd = canonical.cloneForSession();

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/PurchaseExecutorTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.AiTraceCapture;
 import org.triplea.ai.sidecar.CanonicalGameData;
 import org.triplea.ai.sidecar.dto.PlacementGroup;
 import org.triplea.ai.sidecar.dto.PurchaseOrder;
@@ -283,6 +284,45 @@ class PurchaseExecutorTest {
     // Both fields together must be non-empty — Germans always have moves on turn 1.
     final int totalMoves = plan.combatMoves().size() + plan.sbrMoves().size();
     assertThat(totalMoves).as("combined combat + sbr moves must be non-empty").isGreaterThan(0);
+  }
+
+  /**
+   * Real-state integration test for the PURCHASE-BUDGET structured log (#2576). Verifies that
+   * exactly one {@code kind=PURCHASE-BUDGET} line is emitted per purchase run, with all required
+   * fields present and arithmetically consistent: {@code availableAfterRepair == startPUs -
+   * repairCost} and {@code overspend=false} for a turn-1 Germans plan (no factory damage, ample
+   * budget).
+   */
+  @Test
+  void purchaseBudgetLineEmittedOnceWithConsistentFieldsForNormalRun() {
+    final GameData data = canonical.cloneForSession();
+    final Resource pus = data.getResourceList().getResourceOrThrow(Constants.PUS);
+    final int startPUs =
+        data.getPlayerList().getPlayerId("Germans").getResources().getQuantity(pus);
+
+    final AiTraceCapture cap = AiTraceCapture.attach();
+    try {
+      new PurchaseExecutor().executeOn(data, purchaseRequestFor("Germans"));
+    } finally {
+      cap.detach();
+    }
+
+    final List<String> budgetLines =
+        cap.formatted().stream().filter(l -> l.contains("kind=PURCHASE-BUDGET")).toList();
+    assertThat(budgetLines)
+        .as("exactly one PURCHASE-BUDGET line must be emitted per purchase run")
+        .hasSize(1);
+
+    final String line = budgetLines.get(0);
+    assertThat(line).contains("side=sidecar");
+    assertThat(line).contains("nation=Germans");
+    assertThat(line).contains("phase=purchase");
+    assertThat(line).contains("startPUs=" + startPUs);
+    // Turn-1 Germans: no factory damage, so repairCost must be 0.
+    assertThat(line).contains("repairCost=0");
+    assertThat(line).contains("availableAfterRepair=" + startPUs);
+    // No overspend on a normal turn-1 Germans run.
+    assertThat(line).contains("overspend=false").contains("overBy=0");
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProResourceTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProResourceTracker.java
@@ -97,7 +97,17 @@ public class ProResourceTracker {
 
   @Override
   public String toString() {
-    return getRemaining().toString().replaceAll("\n", " ");
+    // Render as "Resource=N ..." — IntegerMap.toString() is multi-line and breaks structured log
+    // lines when embedded verbatim. (#2576)
+    final IntegerMap<Resource> remaining = getRemaining();
+    final StringBuilder sb = new StringBuilder();
+    for (final Resource r : remaining.keySet()) {
+      if (sb.length() > 0) {
+        sb.append(' ');
+      }
+      sb.append(r.getName()).append('=').append(remaining.getInt(r));
+    }
+    return sb.isEmpty() ? "empty" : sb.toString();
   }
 
   private IntegerMap<Resource> getRemaining() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProSplitResourceTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProSplitResourceTracker.java
@@ -127,7 +127,12 @@ public class ProSplitResourceTracker extends ProResourceTracker {
 
   @Override
   public String toString() {
-    return "europe=" + poolRemaining(Pool.EUROPE) + " pacific=" + poolRemaining(Pool.PACIFIC);
+    // Extract int values directly — IntegerMap.toString() is multi-line and breaks structured log
+    // lines when embedded verbatim. (#2576)
+    return "europe="
+        + poolRemaining(Pool.EUROPE).getInt(pusResource)
+        + " pacific="
+        + poolRemaining(Pool.PACIFIC).getInt(pusResource);
   }
 
   // --- Helpers ---

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/data/ProSplitResourceTrackerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/data/ProSplitResourceTrackerTest.java
@@ -142,4 +142,15 @@ final class ProSplitResourceTrackerTest {
     assertThat(s).contains("europe");
     assertThat(s).contains("pacific");
   }
+
+  @Test
+  void toStringProducesSingleLineWithActualPuValues() {
+    // Fix #2576: toString() must not embed IntegerMap.toString() newlines — each pool must show
+    // its actual PU amount so the line is usable in structured logs.
+    final ProSplitResourceTracker t = new ProSplitResourceTracker(33, 17, poolByTerritory, data);
+    final String s = t.toString();
+    assertThat(s).doesNotContain("\n");
+    assertThat(s).contains("33");
+    assertThat(s).contains("17");
+  }
 }


### PR DESCRIPTION
Closes map-room/map-room#2576 (Part A — sidecar changes).

## What

Three changes for purchase-budget observability:

### 1. Fix multi-line IntegerMap render in resource tracker logs

`ProResourceTracker.toString()` delegated to `IntegerMap.toString()`, which emits `IntegerMap:\nResource -> N\n` — a multi-line string. When embedded in a log line, the logging framework truncates at the first newline, making the actual budget invisible (`europe=IntegerMap:` with no values).

- **`ProResourceTracker.toString()`** — now renders `Resource=N ...` inline
- **`ProSplitResourceTracker.toString()`** — now renders `europe=N pacific=M` by extracting `getInt(pusResource)` directly instead of concatenating `IntegerMap` objects

This fixes all 9 `"Starting/Purchase X with resources:"` log lines in `ProPurchaseAi` without touching that file.

### 2. Emit `PURCHASE-BUDGET` structured summary

Added `AiTraceLogger.logPurchaseBudget()` and called it from `PurchaseExecutor.executeOn()` after `invokePurchaseForSidecar()` returns. One line per nation per purchase phase:

\`\`\`
[AI-TRACE] matchID=... side=sidecar nation=Germans phase=purchase kind=PURCHASE-BUDGET
  startPUs=40 repairCost=7 availableAfterRepair=33 plannedSpend=30 overspend=false overBy=0
\`\`\`

Uses `recorder.capturedPurchase()` (pre-trim) so `plannedSpend` reflects ProAI's actual plan, and `totalRepairCost()` helper computing PU cost from `recorder.capturedRepair()`.

## Upstream divergences from triplea-game/triplea

Each edit has an inline `// (#2576)` comment:

| File | Change | Rationale |
|------|--------|-----------|
| `ProResourceTracker.toString()` | Inline `Resource=N` format | Multi-line IntegerMap breaks structured logs |
| `ProSplitResourceTracker.toString()` | Extract `getInt(pusResource)` per pool | Same: `IntegerMap.toString()` embeds newlines |
| `PurchaseExecutor.executeOn()` | PURCHASE-BUDGET emit + `totalRepairCost` helper | Observability; no equivalent in upstream |
| `AiTraceLogger.logPurchaseBudget()` | New method | Observability; no equivalent in upstream |

## Tests

- `ProSplitResourceTrackerTest.toStringProducesSingleLineWithActualPuValues` (game-core) — asserts no newlines + correct values
- `AiTraceLoggerTest.logPurchaseBudget_normalScenario_emitsLineWithOverspendFalse` — asserts all fields for normal run
- `AiTraceLoggerTest.logPurchaseBudget_overBudgetScenario_emitsLineWithOverspendTrue` — asserts overspend fields
- `PurchaseExecutorTest.purchaseBudgetLineEmittedOnceWithConsistentFieldsForNormalRun` — real-state integration: real GLOBAL1940 game data, verifies exactly one PURCHASE-BUDGET line, arithmetic consistency (availableAfterRepair == startPUs - repairCost), overspend=false for turn-1 Germans

## Test plan

- [x] `./gradlew :game-app:game-core:spotlessApply :game-app:ai-sidecar:spotlessApply` — clean
- [x] `./gradlew :game-app:game-core:test :game-app:ai-sidecar:test` — all pass
- [x] New toString tests verify single-line output with actual values
- [x] PURCHASE-BUDGET integration test verifies exactly one line per purchase run

Part B (map-room/map-room — ai-bot.ts enrichment) is a separate PR.