### PR TITLE
fix(ai): deduct factory-repair PUs from British split pools before tracker is seeded (map-room#2608)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -207,6 +207,24 @@ public abstract class AbstractProAi extends AbstractAi {
   }
 
   /**
+   * Deducts factory-repair PU costs from {@link #britishEuropePus} or {@link #britishPacificPus}
+   * according to the pool each repaired territory maps to. Must be called after {@link
+   * ProPurchaseAi#repair} and before {@link #createResourceTracker} so the split tracker is seeded
+   * with post-repair balances (#2608).
+   */
+  private void deductRepairsFromBritishPools(final Map<Territory, Integer> repairCostByTerritory) {
+    for (final Map.Entry<Territory, Integer> entry : repairCostByTerritory.entrySet()) {
+      final ProSplitResourceTracker.Pool pool =
+          britishPoolByTerritory.getOrDefault(entry.getKey(), ProSplitResourceTracker.Pool.EUROPE);
+      if (pool == ProSplitResourceTracker.Pool.EUROPE) {
+        britishEuropePus -= entry.getValue();
+      } else {
+        britishPacificPus -= entry.getValue();
+      }
+    }
+  }
+
+  /**
    * Some implementations of {@link IBattleCalculator} do require setting a GameData instance before
    * actually being able to run properly. This method should take care of that.
    */
@@ -269,8 +287,15 @@ public abstract class AbstractProAi extends AbstractAi {
       prepareData(data);
       storedPurchaseTerritories = purchaseAi.bid(pusToSpend, purchaseDelegate, data);
     } else {
-      // Repair factories
-      purchaseAi.repair(pusToSpend, purchaseDelegate, data, player);
+      // Repair factories; deduct from the British split pools so createResourceTracker() seeds
+      // the correct per-pool budget (#2608 — repair PUs were charged to a pool-mapped territory
+      // but britishEuropePus/britishPacificPus were never decremented, causing the planner to
+      // over-allocate the europe pool).
+      final Map<Territory, Integer> repairCostByTerritory =
+          purchaseAi.repair(pusToSpend, purchaseDelegate, data, player);
+      if (britishSplitEconomyActive && "British".equals(player.getName())) {
+        deductRepairsFromBritishPools(repairCostByTerritory);
+      }
 
       // Check if any place territories exist
       final Map<Territory, ProPurchaseTerritory> purchaseTerritories =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -73,13 +73,21 @@ class ProPurchaseAi {
     this.proData = ai.getProData();
   }
 
-  void repair(
+  /**
+   * Repairs all damaged friendly factories and returns the PU cost charged per territory. The
+   * returned map is used by the caller to deduct repair spending from per-pool budgets (e.g.,
+   * {@link AbstractProAi#deductRepairsFromBritishPools}) before the resource tracker is seeded.
+   * Returns an empty map when repairs are disabled or no factories needed repair.
+   */
+  Map<Territory, Integer> repair(
       final int initialPusRemaining,
       final IPurchaseDelegate purchaseDelegate,
       final GameData data,
       final GamePlayer player) {
     int pusRemaining = initialPusRemaining;
     ProLogger.info("Repairing factories with PUsRemaining=" + pusRemaining);
+
+    final Map<Territory, Integer> repairCostByTerritory = new HashMap<>();
 
     // Current data at the start of combat move
     this.data = data;
@@ -120,9 +128,10 @@ class ProPurchaseAi {
           if (fixUnit == null || !fixUnit.getType().equals(repairRule.getAnyResultKey())) {
             continue;
           }
+          final Territory fixTerr = unitsThatCanProduceNeedingRepair.get(fixUnit);
           if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(
                   player, Matches.unitCanProduceUnitsAndCanBeDamaged())
-              .test(unitsThatCanProduceNeedingRepair.get(fixUnit))) {
+              .test(fixTerr)) {
             continue;
           }
           final int diff = fixUnit.getUnitDamage();
@@ -135,10 +144,12 @@ class ProPurchaseAi {
             ProLogger.debug(
                 "Repairing factory=" + fixUnit + ", damage=" + diff + ", repairRule=" + repairRule);
             purchaseDelegate.purchaseRepair(repair);
+            repairCostByTerritory.merge(fixTerr, diff, Integer::sum);
           }
         }
       }
     }
+    return repairCostByTerritory;
   }
 
   /**

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPurchaseAiSplitEconomyTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPurchaseAiSplitEconomyTest.java
@@ -2,14 +2,18 @@ package games.strategy.triplea.ai.pro;
 
 import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.player.PlayerBridge;
+import games.strategy.triplea.ai.pro.data.ProResourceTracker;
 import games.strategy.triplea.ai.pro.data.ProSplitResourceTracker;
+import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.PurchaseDelegate;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.xml.TestMapGameData;
@@ -65,5 +69,55 @@ public class ProPurchaseAiSplitEconomyTest {
     // the underlying IntegerMap operations would misbehave and the purchase
     // delegate would reject the plan. assertDoesNotThrow is the invariant.
     assertDoesNotThrow(() -> proAi.purchase(false, 18, purchaseDelegate, gameData, british));
+  }
+
+  /**
+   * Regression test for #2608: factory-repair PUs charged to the europe pool must be deducted from
+   * britishEuropePus before ProSplitResourceTracker is seeded. Without the fix, the tracker was
+   * seeded with the pre-repair balance, causing the planner to over-allocate the europe pool by the
+   * repair amount and triggering a soft-reject at dispatch (observed in match WBZMQ5Niegt, round
+   * 6).
+   *
+   * <p>Scenario: europe pool = repairCost (6 PUs); UK factory damaged by 6 PUs. After repair the
+   * europe pool is fully consumed; the tracker must be seeded with 0 so the planner does not plan
+   * any additional europe buys.
+   */
+  @Test
+  void europeBudgetDeductedByRepairBeforeTrackerSeeded() {
+    // G40 has "Damage From Bombing Done To Units Instead Of Territories" = true, so factory-repair
+    // is enabled. Damage the UK factory by repairCost PUs to trigger the repair path.
+    final int repairCost = 6;
+    final Territory uk = gameData.getMap().getTerritoryOrThrow("United Kingdom");
+    final Unit ukFactory =
+        uk.getUnitCollection().stream()
+            .filter(
+                u ->
+                    u.getOwner().equals(british)
+                        && Matches.unitCanProduceUnits().test(u)
+                        && Matches.unitIsInfrastructure().test(u))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("UK factory unit not found in United Kingdom"));
+    ukFactory.setUnitDamage(repairCost);
+
+    // Set europe pool = exactly the repair cost so the deduction should leave it at 0.
+    final Territory india = gameData.getMap().getTerritoryOrThrow("India");
+    final Map<Territory, ProSplitResourceTracker.Pool> poolByTerritory = new HashMap<>();
+    poolByTerritory.put(uk, ProSplitResourceTracker.Pool.EUROPE);
+    poolByTerritory.put(india, ProSplitResourceTracker.Pool.PACIFIC);
+    proAi.setBritishEconomySplit(repairCost, 16, poolByTerritory);
+
+    // Run the full purchase phase: repair fires first (spending repairCost from the europe pool),
+    // then the planner runs against the corrected tracker.
+    assertDoesNotThrow(
+        () -> proAi.purchase(false, repairCost + 16, purchaseDelegate, gameData, british));
+
+    // After the fix: britishEuropePus was decremented by repairCost before createResourceTracker()
+    // was called, so a new tracker seeded from britishEuropePus shows europe=0.
+    // Without the fix: britishEuropePus would still equal repairCost and the tracker would show
+    // europe=6, meaning the planner incorrectly believed it had 6 more PUs to spend on europe buys.
+    final ProResourceTracker tracker = proAi.createResourceTracker(british, gameData);
+    assertTrue(
+        tracker.toString().contains("europe=0"),
+        "Expected europe pool to be 0 after repair deduction, but got: " + tracker);
   }
 }


### PR DESCRIPTION
## Summary

Fixes map-room/map-room#2608 — British AI over-allocates europe pool when a factory repair is charged to it.

- `ProPurchaseAi.repair()` now returns `Map<Territory, Integer>` (PU cost per repaired territory) instead of `void`
- `AbstractProAi.purchase()` calls new `deductRepairsFromBritishPools()` between the repair call and the subsequent `createResourceTracker()` invocation
- `createResourceTracker()` is now seeded with the correct post-repair balances

**Root cause:** `setBritishEconomySplit()` sets `britishEuropePus`/`britishPacificPus` before repair runs; `repair()` spends the PUs but never updated those fields. The unified `ProResourceTracker(player)` self-corrects by reading live PUs; this fix mirrors that behavior for the split path.

**Evidence (match WBZMQ5Niegt, round 6):** europe avail=23, repair=11, planned=32, overBy=24 — cruiser pair soft-rejected at dispatch.

## Test plan

- [x] `europeBudgetDeductedByRepairBeforeTrackerSeeded`: damages UK factory by 6 PUs, sets `britishEuropePus=6`, verifies tracker shows `europe=0` after purchase
- [x] Existing `splitTrackerPurchaseCompletesWithoutOverDraft` still passes
- [x] All ProAI tests pass: `./gradlew :game-app:game-core:test --tests 'games.strategy.triplea.ai.pro.*'`
- [x] spotless applied before commit

Closes map-room/map-room#2608