### PR TITLE
test(ai-sidecar): make ProPurchaseAiSplitEconomyTest pool assertion robust

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProSplitResourceTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProSplitResourceTracker.java
@@ -135,6 +135,13 @@ public class ProSplitResourceTracker extends ProResourceTracker {
         + poolRemaining(Pool.PACIFIC).getInt(pusResource);
   }
 
+  // --- Numeric accessors ---
+
+  /** Returns the remaining PUs in the given pool (net of any pending temp purchases). */
+  public int poolPUs(final Pool pool) {
+    return poolRemaining(pool).getInt(pusResource);
+  }
+
   // --- Helpers ---
 
   private Pool poolFor(final Territory t) {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPurchaseAiSplitEconomyTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPurchaseAiSplitEconomyTest.java
@@ -2,7 +2,7 @@ package games.strategy.triplea.ai.pro;
 
 import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
@@ -11,7 +11,6 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.player.PlayerBridge;
-import games.strategy.triplea.ai.pro.data.ProResourceTracker;
 import games.strategy.triplea.ai.pro.data.ProSplitResourceTracker;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.PurchaseDelegate;
@@ -115,9 +114,11 @@ public class ProPurchaseAiSplitEconomyTest {
     // was called, so a new tracker seeded from britishEuropePus shows europe=0.
     // Without the fix: britishEuropePus would still equal repairCost and the tracker would show
     // europe=6, meaning the planner incorrectly believed it had 6 more PUs to spend on europe buys.
-    final ProResourceTracker tracker = proAi.createResourceTracker(british, gameData);
-    assertTrue(
-        tracker.toString().contains("europe=0"),
+    final ProSplitResourceTracker tracker =
+        (ProSplitResourceTracker) proAi.createResourceTracker(british, gameData);
+    assertEquals(
+        0,
+        tracker.poolPUs(ProSplitResourceTracker.Pool.EUROPE),
         "Expected europe pool to be 0 after repair deduction, but got: " + tracker);
   }
 }


### PR DESCRIPTION
## Summary

- Adds `poolPUs(Pool)` — a public numeric accessor on `ProSplitResourceTracker` — so callers can query pool balances as integers rather than parsing `toString()`.
- Replaces the `tracker.toString().contains("europe=0")` substring assertion in `europeBudgetDeductedByRepairBeforeTrackerSeeded` with `assertEquals(0, tracker.poolPUs(EUROPE))`. The test now discriminates on the integer value, not the string format.
- Removes the now-unused `ProResourceTracker` import from the test file.

Follow-up to triplea#101 / map-room/map-room#2608 (foxtrot review nit).

Closes map-room/map-room#2609

## Test plan

- [x] `ProPurchaseAiSplitEconomyTest` — both tests pass (`splitTrackerPurchaseCompletesWithoutOverDraft` and `europeBudgetDeductedByRepairBeforeTrackerSeeded`)
- [x] `ProSplitResourceTrackerTest` — no regressions
- [x] Build: `./gradlew :game-app:game-core:test --tests "games.strategy.triplea.ai.pro.ProPurchaseAiSplitEconomyTest"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)