### PR TITLE
feat(ai): apply bonusProduction bonus to territory production before ProAI

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -12,6 +12,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.attachments.TechAttachment;
+import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import java.lang.System.Logger;
@@ -94,10 +95,45 @@ public final class WireStateApplier {
     applyConqueredThisTurn(gameData, wire);
     applyOperationalDamage(gameData, wire, unitIdMap);
     applyUnitProperties(gameData, wire, unitIdMap);
+    // Bonus production from national objectives and victory cities. Runs after the main
+    // CompositeChange so territory ownership is live when we read TerritoryAttachment.
+    applyProductionBonuses(gameData, wire);
     // Round/step last — GameSequence mutation has no interaction with the earlier branches,
     // but keeping it at the tail means nothing downstream can overwrite it.
     applyRoundAndStep(gameData, wire);
     WireStateVerifier.verifyApply(gameData, wire, unitIdMap);
+  }
+
+  /**
+   * Apply {@code bonusProduction} from the wire to each territory's {@link TerritoryAttachment}.
+   * When present, the bonus is added to the territory's current static production value so that
+   * ProAI territory-selection weighs national-objective clusters and victory cities more heavily.
+   *
+   * <p>Each AI request operates on a freshly cloned {@link GameData} (see {@code
+   * ExecutorSupport.cloneForSession}), so there is no need to reset the production value between
+   * calls — the next request starts from the canonical unmodified clone.
+   */
+  private static void applyProductionBonuses(final GameData gameData, final WireState wire) {
+    final CompositeChange changes = new CompositeChange();
+    for (final WireTerritory wt : wire.territories()) {
+      if (wt.bonusProduction() == null || wt.bonusProduction() <= 0) {
+        continue;
+      }
+      final Territory t = gameData.getMap().getTerritoryOrNull(wt.territoryId());
+      if (t == null) {
+        continue;
+      }
+      final TerritoryAttachment ta = TerritoryAttachment.get(t).orElse(null);
+      if (ta == null) {
+        continue;
+      }
+      final int newProduction = ta.getProduction() + wt.bonusProduction();
+      changes.add(
+          ChangeFactory.attachmentPropertyChange(ta, String.valueOf(newProduction), "production"));
+    }
+    if (!changes.isEmpty()) {
+      gameData.performChange(changes);
+    }
   }
 
   /**

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireTerritory.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireTerritory.java
@@ -12,30 +12,39 @@ import javax.annotation.Nullable;
  * "europe"} or {@code "pacific"} — and is consumed by {@link
  * org.triplea.ai.sidecar.exec.PurchaseExecutor} to build the split-resource tracker's per-territory
  * pool map. Absent for non-British territories and for ambiguous/unmapped sea zones.
+ *
+ * <p>The {@code bonusProduction} field is set by Map Room when incomplete national objectives or a
+ * victory-city bump make a territory more valuable to the active player than its static production
+ * implies. {@link org.triplea.ai.sidecar.wire.WireStateApplier} adds this bonus to the territory's
+ * {@link games.strategy.triplea.attachments.TerritoryAttachment} production before running ProAI,
+ * so territory-selection logic prices captures more accurately.
  */
 public record WireTerritory(
     String territoryId,
     String owner,
     List<WireUnit> units,
     boolean conqueredThisTurn,
-    @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable String economy) {
+    @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable String economy,
+    @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable Integer bonusProduction) {
   @JsonCreator
   public WireTerritory(
       @JsonProperty("territoryId") final String territoryId,
       @JsonProperty("owner") final String owner,
       @JsonProperty("units") final List<WireUnit> units,
       @JsonProperty("conqueredThisTurn") final Boolean conqueredThisTurn,
-      @JsonProperty("economy") final String economy) {
+      @JsonProperty("economy") final String economy,
+      @JsonProperty("bonusProduction") final Integer bonusProduction) {
     this(
         territoryId,
         owner,
         units == null ? List.of() : units,
         Boolean.TRUE.equals(conqueredThisTurn),
-        economy);
+        economy,
+        bonusProduction);
   }
 
   public WireTerritory(final String territoryId, final String owner, final List<WireUnit> units) {
-    this(territoryId, owner, units, false, null);
+    this(territoryId, owner, units, false, null, null);
   }
 
   public WireTerritory(
@@ -43,6 +52,6 @@ public record WireTerritory(
       final String owner,
       final List<WireUnit> units,
       final boolean conqueredThisTurn) {
-    this(territoryId, owner, units, conqueredThisTurn, null);
+    this(territoryId, owner, units, conqueredThisTurn, null, null);
   }
 }


### PR DESCRIPTION
## Summary

**Commit 1 — `bonusProduction` wire field:**
- `WireTerritory.java`: adds `@Nullable Integer bonusProduction` record component (Jackson `@JsonInclude(NON_NULL)` — absent when zero). Updates `@JsonCreator` and convenience constructors.
- `WireStateApplier.java`: adds `applyProductionBonuses()` which adds `bonusProduction` to each territory's `TerritoryAttachment` production via `ChangeFactory.attachmentPropertyChange`. Runs after the main `CompositeChange` in `apply()`. Safe to leave without reset since `GameData` is cloned fresh per session.

**Commit 2 — island territory floor in `findLandValue`:**
- `ProTerritoryValueUtils.java`: when `landMassSize == 1` (no land-accessible neighbors within 6 hops), use `max(proximityValue, production * 0.5)` as a floor.
- Root cause: `findLandValue` uses land-only routing for all distance math. Islands score 0 regardless of their actual production, causing them to be discarded before amphibious planning even considers them. Celebes (`production=3`) was getting `value=0.0` every round. The floor gives it `1.5`, keeping it in the hold-value map.

**Paired TypeScript PR:** map-room/map-room#2614

## Test plan

- [x] `./gradlew :game-app:game-core:test --tests "games.strategy.triplea.ai.pro.util.ProTerritoryValueUtilsTest"` — passes
- [x] `./gradlew :game-app:ai-sidecar:test` — passes (47 tests)
- [x] `./gradlew spotlessApply` on both modules — no formatting changes after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)