### PR TITLE
fix(ai): add production floor for island territories in findLandValue

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -326,6 +326,14 @@ public final class ProTerritoryValueUtils {
       value *= 1.1; // prefer territories with factories
     }
 
+    // Island territories (no land-accessible neighbors within 6 hops) produce value=0 from
+    // the proximity math regardless of their production, because all distance calculations
+    // use land-only routing. Apply a production-based floor so islands aren't silently zeroed
+    // in the hold-value map and discarded before amphibious planning considers them.
+    if (landMassSize == 1) {
+      value = Math.max(value, TerritoryAttachment.getProduction(t) * 0.5);
+    }
+
     return value;
   }
 


### PR DESCRIPTION
## Summary

`ProTerritoryValueUtils.findLandValue()` uses land-only routing for all distance calculations. Islands with no land-accessible neighbors (`landMassSize == 1`) always score `value=0.0` in the hold-value map, regardless of their actual production. This caused the ProAI to silently discard them before amphibious planning could consider them.

**Observed symptom:** Celebes (`production=3`) logged `value=0.0, averageAttackFromValue=NaN` every round for Japan — it was being dropped from the priority list repeatedly despite being a viable and strategically important amphibious target.

**Fix:** when `landMassSize == 1`, clamp `value` to `max(proximityValue, production * 0.5)`. Celebes goes from `value=0.0` to `value=1.5`, keeping it in the hold-value map. The 0.5 discount keeps it below well-connected mainland territories of equal production.

Relates to map-room/map-room#2614

## Test plan

- [x] `./gradlew :game-app:game-core:test --tests "games.strategy.triplea.ai.pro.util.ProTerritoryValueUtilsTest"` — passes
- [x] `./gradlew :game-app:ai-sidecar:test` — 47 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)