### PR TITLE
fix(ai): include pre-loaded transports in amphibAttackOptions

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -1078,6 +1078,15 @@ public class ProTerritoryManager {
             final Set<Territory> loadFromTerritories = new HashSet<>();
             if (!transport.getTransporting(transportTerritory).isEmpty()) {
               haveUnitsToTransport = true;
+              // Pre-loaded transport: cargo is already aboard from a prior round.
+              // Use 'from' (the current sea zone) as the load territory so that
+              // addTerritories(unloadTerritories, loadFromTerritories) produces a non-empty
+              // value set, preventing the entry from being pruned by
+              // transportMap.values().removeIf(Collection::isEmpty). The sea zone is also
+              // added to seaTransportMap so the downstream sea-staging check can match it.
+              // getUnitsToTransportFromTerritories ignores loadFromTerritories for pre-loaded
+              // transports (it returns transport.getTransporting() early) so this is safe.
+              loadFromTerritories.add(from);
             } else if (Matches.territoryHasEnemySeaUnits(player).negate().test(from)) {
               int capacity = transport.getUnitAttachment().getTransportCapacity();
               Predicate<Unit> canFitOnTransport =

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/data/ProTerritoryManagerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/data/ProTerritoryManagerTest.java
@@ -13,6 +13,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.player.PlayerBridge;
 import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
@@ -91,5 +92,66 @@ class ProTerritoryManagerTest {
             "Bulgaria (Friendly_Neutral) must be a defend-option destination when a German unit"
                 + " can reach it from Romania (regression: map-room#2195)")
         .containsKey(bulgaria);
+  }
+
+  /**
+   * Regression test for #2615: a transport that was pre-loaded with cargo in an earlier round must
+   * still appear in amphibAttackOptions so the planner can emit an unloadFromTransport step.
+   *
+   * <p>Without the fix, {@code findAmphibMoveOptions} builds {@code transportMap} entries like
+   * {@code {Japan → {}}} (empty loadFromTerritories for pre-loaded transports), which are then
+   * pruned by {@code transportMap.values().removeIf(Collection::isEmpty)}. Japan never enters
+   * {@code amphibAttackOptions} and {@code amphibChainsValid=0}.
+   *
+   * <p>With the fix, the current sea zone ({@code from}) is added to {@code loadFromTerritories} as
+   * a sentinel, keeping the entry alive. {@link
+   * games.strategy.triplea.ai.pro.util.ProTransportUtils#getUnitsToTransportFromTerritories}
+   * short-circuits for pre-loaded transports and ignores the sentinel value.
+   */
+  @Test
+  void preLoadedTransportInAdjacentSeaZoneIsIncludedInAmphibAttackOptions() {
+    // Germans start at War with British in G40 turn 1 — Scotland is a valid enemy target.
+    // 109 Sea Zone is adjacent to Scotland (British) and is a plausible staging sea zone.
+    final Territory sz109 = gameData.getMap().getTerritoryOrThrow("109 Sea Zone");
+    final Territory scotland = gameData.getMap().getTerritoryOrThrow("Scotland");
+
+    // Precondition: 109 Sea Zone must be adjacent to Scotland on the Global 1940 map.
+    assertThat(gameData.getMap().getNeighbors(sz109))
+        .as("109 Sea Zone must be adjacent to Scotland in Global 1940")
+        .contains(scotland);
+
+    // 109 Sea Zone starts with British ships — clear them so the German transport can operate.
+    final List<Unit> britishShips = sz109.getMatches(Matches.unitIsEnemyOf(germans));
+    gameData.performChange(ChangeFactory.removeUnits(sz109, britishShips));
+
+    // Pre-load a German transport with infantry: place both in 109 Sea Zone and mark the
+    // infantry as transported (simulating a unit loaded in a prior round and not yet unloaded).
+    final UnitType transportType = gameData.getUnitTypeList().getUnitTypeOrThrow("transport");
+    final UnitType infantryType = gameData.getUnitTypeList().getUnitTypeOrThrow("infantry");
+    final Unit germanTransport = transportType.create(1, germans).get(0);
+    final Unit germanInfantry2 = infantryType.create(1, germans).get(0);
+    gameData.performChange(
+        ChangeFactory.addUnits(sz109, List.of(germanTransport, germanInfantry2)));
+    germanInfantry2.setTransportedBy(germanTransport);
+
+    // Re-initialize the Germans ProAi so proData picks up the unit changes above.
+    proAi.getProData().initialize(proAi);
+
+    final ProTerritoryManager manager =
+        new ProTerritoryManager(proAi.getCalc(), proAi.getProData());
+    manager.populateAttackOptions();
+
+    // The pre-loaded transport must contribute Scotland to the attack territory map.
+    // maxAmphibUnits non-empty means findAmphibMoveOptions recognised the pre-loaded
+    // transport as a valid amphib option (regression: map-room#2615).
+    final ProTerritory scotlandOptions = manager.getAttackOptions().getTerritoryMap().get(scotland);
+    assertThat(scotlandOptions)
+        .as(
+            "Scotland must appear in attack options when a pre-loaded German transport is in"
+                + " 109 Sea Zone (Germans at war with British from G40 turn 1)")
+        .isNotNull();
+    assertThat(scotlandOptions.getMaxAmphibUnits())
+        .as("maxAmphibUnits for Scotland must contain the pre-loaded infantry (regression: #2615)")
+        .contains(germanInfantry2);
   }
 }


### PR DESCRIPTION
## Summary

- `findAmphibMoveOptions` builds empty `loadFromTerritories` for pre-loaded transports (cargo from prior rounds), producing `transportMap` entries like `{Scotland → {}}` that are immediately pruned by `removeIf(Collection::isEmpty)`.
- Pre-loaded transports never entered `amphibAttackOptions` → `amphibChainsValid=0` for those chains (observed in match WBZMQ5Niegt).
- Fix: when a transport already carries cargo, add the current sea zone (`from`) to `loadFromTerritories` as a sentinel so the entry survives pruning. `getUnitsToTransportFromTerritories` short-circuits for pre-loaded transports and ignores the sentinel — no change to load logic needed.

Closes #2615

## Test plan

- [x] `ProTerritoryManagerTest.preLoadedTransportInAdjacentSeaZoneIsIncludedInAmphibAttackOptions` — Germans G40 turn 1: pre-loaded transport in 109 SZ, Scotland appears in attackOptions with infantry in `maxAmphibUnits`. Passes with fix, fails without (`git stash` verified).
- [x] Full `game-core` test suite passes (`./gradlew :game-app:game-core:test`)
- [x] Spotless applied (`./gradlew :game-app:game-core:spotlessApply`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)