### PR TITLE
test(ai): add ProLogCapture helper and harden amphib regression tests (#108)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogUi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogUi.java
@@ -31,6 +31,11 @@ public final class ProLogUi {
     externalHandler = handler;
   }
 
+  /** Returns the current external log sink, or {@code null} if none is set. */
+  public static Consumer<String> getExternalHandler() {
+    return externalHandler;
+  }
+
   public static List<AiPlayerDebugOption> buildDebugOptions(final Frame frame) {
     Util.ensureOnEventDispatchThread();
     if (settingsWindow == null) {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProAmphibPenaltyPlayerAwareTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProAmphibPenaltyPlayerAwareTest.java
@@ -15,6 +15,8 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.player.PlayerBridge;
+import games.strategy.triplea.ai.pro.logging.ProLogCapture;
+import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.remote.IMoveDelegate;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.xml.TestMapGameData;
@@ -110,12 +112,16 @@ public class ProAmphibPenaltyPlayerAwareTest {
     data.performChange(
         ChangeFactory.removeUnits(germanCoastalTerritory, germanCoastalTerritory.getUnits()));
 
-    // Clear the staging sea zone and ALL adjacent sea zones so the transport is not exposed to
-    // enemy counter-attack (removeTerritoriesWhereTransportsAreExposed cancels the attack if
-    // any enemy naval unit can reach the transport).
-    data.performChange(ChangeFactory.removeUnits(stagingSeaZone, stagingSeaZone.getUnits()));
-    for (final Territory adj : data.getMap().getNeighbors(stagingSeaZone, Territory::isWater)) {
-      data.performChange(ChangeFactory.removeUnits(adj, adj.getUnits()));
+    // Remove all non-American units from every territory (land and sea) so
+    // removeTerritoriesWhereTransportsAreExposed doesn't cancel the attack.
+    // The planner treats all non-allied players as potential enemies (#2625), including neutral
+    // British. Clearing only declared-war enemies is insufficient: British air units on land have
+    // the range to reach the staging sea zone and count as threat units in the exposure check.
+    // Clearing all non-American units everywhere keeps enemyTUVSwing=0 at the staging sea zone
+    // while preserving German territory ownership (the actual attack target).
+    for (final Territory t : data.getMap().getTerritories()) {
+      data.performChange(
+          ChangeFactory.removeUnits(t, t.getMatches(Matches.unitIsOwnedBy(americans).negate())));
     }
 
     // Place a US destroyer (naval support) and a pre-loaded transport in the staging sea zone.
@@ -143,7 +149,14 @@ public class ProAmphibPenaltyPlayerAwareTest {
               return Optional.empty();
             });
 
-    proAi.invokeCombatMoveForSidecar(moveDelegate, data, americans);
+    try (ProLogCapture log = new ProLogCapture()) {
+      proAi.invokeCombatMoveForSidecar(moveDelegate, data, americans);
+
+      // The planner must enter island-power mode (all options are amphib → penalty suppressed).
+      assertThat(log.getLines())
+          .as("planner must detect island-power mode (all attack options are amphib)")
+          .anyMatch(l -> l.contains("island-power mode") && l.contains("true"));
+    }
 
     // Assert: at least one sea→land (amphib unload) move dispatched.
     // Before fix: 0 (penalty halved territory value, isEmptyLand bonus hidden).
@@ -195,7 +208,14 @@ public class ProAmphibPenaltyPlayerAwareTest {
               return Optional.empty();
             });
 
-    proAi.invokeCombatMoveForSidecar(moveDelegate, data, germans);
+    try (ProLogCapture log = new ProLogCapture()) {
+      proAi.invokeCombatMoveForSidecar(moveDelegate, data, germans);
+
+      // Germany has land options → must NOT enter island-power mode.
+      assertThat(log.getLines())
+          .as("German planner must NOT enter island-power mode (has land attack options)")
+          .anyMatch(l -> l.contains("island-power mode") && l.contains("false"));
+    }
 
     // Germany must produce land-to-land attacks against Soviet territory.
     // If isIslandPower were wrongly set to true for Germany (regression), the planner's

--- a/game-app/game-core/src/testFixtures/java/games/strategy/triplea/ai/pro/logging/ProLogCapture.java
+++ b/game-app/game-core/src/testFixtures/java/games/strategy/triplea/ai/pro/logging/ProLogCapture.java
@@ -1,0 +1,67 @@
+package games.strategy.triplea.ai.pro.logging;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Test helper that redirects ProAI planner log output to an in-memory list and {@code System.out}.
+ *
+ * <p>Use try-with-resources to ensure the external handler is always restored:
+ *
+ * <pre>{@code
+ * try (ProLogCapture log = new ProLogCapture()) {
+ *     proAi.invokeCombatMoveForSidecar(moveDelegate, data, player);
+ *     log.printAll();   // dump to stdout while debugging; remove before committing
+ * }
+ *
+ * // Or assert on specific planner decisions:
+ * try (ProLogCapture log = new ProLogCapture()) {
+ *     proAi.invokeCombatMoveForSidecar(moveDelegate, data, player);
+ *     assertThat(log.getLines()).anyMatch(l -> l.contains("island-power mode: true"));
+ * }
+ * }</pre>
+ *
+ * <p>Restores the prior external handler on close so nested captures work correctly.
+ */
+public final class ProLogCapture implements AutoCloseable {
+
+  private final List<String> lines = new ArrayList<>();
+  private final Consumer<String> previousHandler;
+  private final ProLogSettings settings;
+
+  public ProLogCapture() {
+    previousHandler = ProLogUi.getExternalHandler();
+    settings = ProLogSettings.loadSettings();
+    settings.setLogEnabled(true);
+    settings.setLogLevel(java.util.logging.Level.FINEST);
+    ProLogUi.setExternalHandler(
+        msg -> {
+          synchronized (lines) {
+            lines.add(msg);
+          }
+          System.out.println("[ProAI] " + msg);
+        });
+  }
+
+  /** Returns a snapshot of all captured log lines at the time of the call. */
+  public List<String> getLines() {
+    synchronized (lines) {
+      return Collections.unmodifiableList(new ArrayList<>(lines));
+    }
+  }
+
+  /** Prints all captured lines to {@code System.out}. Useful during debugging. */
+  public void printAll() {
+    synchronized (lines) {
+      lines.forEach(l -> System.out.println("[ProAI] " + l));
+    }
+  }
+
+  /** Restores the previous external handler. */
+  @Override
+  public void close() {
+    ProLogUi.setExternalHandler(previousHandler);
+  }
+}


### PR DESCRIPTION
## Summary

Implements `ProLogCapture` (testFixtures) — a try-with-resources helper that taps `ProLogUi.setExternalHandler` to redirect ProAI planner log lines to an in-memory list and stdout during tests. Previously all `ProLogger.info/debug/trace` calls were silently dropped in tests.

Closes map-room/map-room#108

## Changes

- **`ProLogCapture`** (new testFixtures class): captures planner output via `ProLogUi.setExternalHandler`, restores previous handler on `close()`, thread-safe.
- **`ProLogUi.getExternalHandler()`**: new accessor so `ProLogCapture` can save/restore nested handlers.
- **`ProAmphibPenaltyPlayerAwareTest`**: wrapped `invokeCombatMoveForSidecar` calls in `ProLogCapture`; both tests now assert on specific `island-power mode` log lines:
  - Americans test: asserts `island-power mode: true`
  - Germans counter-regression: asserts `island-power mode: false`
- **Test setup hardened**: changed sea-zone clearing to remove ALL non-American units from ALL territories (land and sea). Clearing only sea zones was insufficient — British/Italian air units based on land have the range to reach the staging sea zone and were counted as 12 threat units, causing `removeTerritoriesWhereTransportsAreExposed` to cancel the attack. This is a symptom of the broader `findEnemyAttackOptions` flaw tracked in #2625.

## Test plan

- [x] `ProAmphibPenaltyPlayerAwareTest::americansAmphibCombatPlanEmittedAgainstGermanCoast` — PASSED
- [x] `ProAmphibPenaltyPlayerAwareTest::germanyGeneratesLandAttacksWithPenaltyIntact` — PASSED
- [x] spotlessApply — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)