### PR TITLE
fix(ai): add airfield and naval base bonus to territory value scoring

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -29,6 +29,29 @@ import org.triplea.java.collections.CollectionUtils;
 public final class ProTerritoryValueUtils {
   static final int MIN_FACTORY_CHECK_DISTANCE = 9;
 
+  /** Bonus added to territory value when an airfield is present. */
+  public static final double AIRFIELD_BONUS = 5.0;
+
+  /** Bonus added to territory value when a naval base is present. */
+  public static final double NAVAL_BASE_BONUS = 5.0;
+
+  // G40 represents bases as placed units: airfield (isAirBase=true) and harbour (givesMovement).
+  // TerritoryAttachment.hasAirBase/hasNavalBase cover maps that use territory-attribute flags
+  // instead, so we check both to be game-agnostic.
+  private static boolean territoryHasAirBase(final Territory t) {
+    return TerritoryAttachment.hasAirBase(t)
+        || t.getUnits().stream().anyMatch(Matches.unitIsAirBase());
+  }
+
+  private static boolean territoryHasNavalBase(final Territory t) {
+    return TerritoryAttachment.hasNavalBase(t)
+        // Airfields also have givesMovement (to air units); exclude them so we match only
+        // harbour-type units that give movement to naval units.
+        || t.getUnits().stream()
+            .filter(Matches.unitIsAirBase().negate())
+            .anyMatch(u -> !u.getUnitAttachment().getGivesMovement().isEmpty());
+  }
+
   /**
    * Returns the relative value of attacking the specified territory compared to other territories.
    */
@@ -37,6 +60,12 @@ public final class ProTerritoryValueUtils {
     final int isEnemyFactory =
         ProMatches.territoryHasInfraFactoryAndIsEnemyLand(player).test(t) ? 1 : 0;
     double value = 3.0 * TerritoryAttachment.getProduction(t) * (isEnemyFactory + 1);
+    if (territoryHasAirBase(t)) {
+      value += AIRFIELD_BONUS;
+    }
+    if (territoryHasNavalBase(t)) {
+      value += NAVAL_BASE_BONUS;
+    }
     if (ProUtils.isNeutralLand(t)) {
       final double strength =
           ProBattleUtils.estimateStrength(
@@ -332,6 +361,17 @@ public final class ProTerritoryValueUtils {
     // in the hold-value map and discarded before amphibious planning considers them.
     if (landMassSize == 1) {
       value = Math.max(value, TerritoryAttachment.getProduction(t) * 0.5);
+    }
+
+    // Prefer base-bearing territories: airfields extend fighter/bomber range; naval bases
+    // extend fleet range and enable faster repairs. A 5-IPC bonus makes these competitive
+    // with a modest production-territory advantage without overriding a substantially richer
+    // industrial target.
+    if (territoryHasAirBase(t)) {
+      value += AIRFIELD_BONUS;
+    }
+    if (territoryHasNavalBase(t)) {
+      value += NAVAL_BASE_BONUS;
     }
 
     return value;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProBaseValueTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProBaseValueTest.java
@@ -1,0 +1,164 @@
+package games.strategy.triplea.ai.pro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.ai.pro.util.ProTerritoryValueUtils;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for #2633: ProTerritoryValueUtils ignores airfields and naval bases.
+ *
+ * <p>Root cause: {@code findTerritoryAttackValue} and {@code findLandValue} used only IPC
+ * production to score territories, ignoring the strategic value of airfields (extend fighter/bomber
+ * range) and naval bases (extend fleet range, enable repairs). This caused the planner to
+ * deprioritise or discard base-bearing islands entirely.
+ *
+ * <p>Fix: add {@code AIRFIELD_BONUS = 5.0} and {@code NAVAL_BASE_BONUS = 5.0} to both value
+ * functions. Bases are detected via unit presence ({@code UnitAttachment.isAirBase()} for
+ * airfields; non-empty {@code UnitAttachment.getGivesMovement()} for harbours), covering the G40
+ * unit-model and also maps that use territory-attachment flags.
+ *
+ * <p>Test anchor: G40 Pacific island cluster.
+ *
+ * <ul>
+ *   <li>Midway: production=0, airfield only → value=5 (bonus exceeds Iwo Jima production=1,
+ *       value=3)
+ *   <li>Caroline Islands: production=0, airfield + harbour → value=10 (bonus well above Iwo Jima)
+ *   <li>Borneo: production=4, no base → value=12 (substantially higher IPC still wins over Caroline
+ *       Islands=10 — base is a nudge, not an override)
+ * </ul>
+ */
+public class ProBaseValueTest {
+
+  private static final String CAROLINE_ISLANDS = "Caroline Islands";
+  private static final String IWO_JIMA = "Iwo Jima";
+  private static final String MIDWAY = "Midway";
+  private static final String BORNEO = "Borneo";
+
+  private GameData data;
+  private GamePlayer americans;
+  private ProData proData;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    proData = proDataFor(data);
+  }
+
+  /**
+   * Acceptance criterion 1: airfield bonus must outweigh a modest production advantage.
+   *
+   * <p>Midway (production=0, airfield) → {@code findTerritoryAttackValue} = 5.0 Iwo Jima
+   * (production=1, no base) → {@code findTerritoryAttackValue} = 3.0 Midway must score higher.
+   */
+  @Test
+  void airfieldBonusOutweighsLowerProduction() {
+    final Territory midway = data.getMap().getTerritoryOrThrow(MIDWAY);
+    final Territory iwoJima = data.getMap().getTerritoryOrThrow(IWO_JIMA);
+
+    final double midwayValue =
+        ProTerritoryValueUtils.findTerritoryAttackValue(proData, americans, midway);
+    final double iwoJimaValue =
+        ProTerritoryValueUtils.findTerritoryAttackValue(proData, americans, iwoJima);
+
+    assertThat(midwayValue)
+        .as("Midway (airfield, prod=0) must outvalue Iwo Jima (no base, prod=1)")
+        .isGreaterThan(iwoJimaValue);
+    assertThat(midwayValue)
+        .as("Midway attack value must include the AIRFIELD_BONUS")
+        .isEqualTo(ProTerritoryValueUtils.AIRFIELD_BONUS);
+  }
+
+  /**
+   * Acceptance criterion 2: both-base bonus must clearly outweigh a 1-production territory.
+   *
+   * <p>Caroline Islands (production=0, airfield + harbour) → value = 10.0 Iwo Jima (production=1,
+   * no base) → value = 3.0
+   */
+  @Test
+  void bothBasesBonusClearlyOutweighsLowProduction() {
+    final Territory carolineIslands = data.getMap().getTerritoryOrThrow(CAROLINE_ISLANDS);
+    final Territory iwoJima = data.getMap().getTerritoryOrThrow(IWO_JIMA);
+
+    final double carolineValue =
+        ProTerritoryValueUtils.findTerritoryAttackValue(proData, americans, carolineIslands);
+    final double iwoJimaValue =
+        ProTerritoryValueUtils.findTerritoryAttackValue(proData, americans, iwoJima);
+
+    assertThat(carolineValue)
+        .as("Caroline Islands (airfield+harbour, prod=0) must outscore Iwo Jima (no base, prod=1)")
+        .isGreaterThan(iwoJimaValue);
+    assertThat(carolineValue)
+        .as("Caroline Islands value must include both base bonuses")
+        .isEqualTo(ProTerritoryValueUtils.AIRFIELD_BONUS + ProTerritoryValueUtils.NAVAL_BASE_BONUS);
+  }
+
+  /**
+   * Counter-regression: substantially higher production must still dominate even with no base.
+   *
+   * <p>Borneo (production=4, no base) → value = 12.0 Caroline Islands (production=0,
+   * airfield+harbour) → value = 10.0 High-production territory without a base must still win.
+   */
+  @Test
+  void counterRegression_substantialProductionBeatsBaseWithoutProduction() {
+    final Territory borneo = data.getMap().getTerritoryOrThrow(BORNEO);
+    final Territory carolineIslands = data.getMap().getTerritoryOrThrow(CAROLINE_ISLANDS);
+
+    final double borneoValue =
+        ProTerritoryValueUtils.findTerritoryAttackValue(proData, americans, borneo);
+    final double carolineValue =
+        ProTerritoryValueUtils.findTerritoryAttackValue(proData, americans, carolineIslands);
+
+    assertThat(borneoValue)
+        .as(
+            "Borneo (prod=4, no base, value=12) must outscore Caroline Islands (prod=0, both"
+                + " bases, value=10) — base bonus is a nudge, not an override")
+        .isGreaterThan(carolineValue);
+  }
+
+  /**
+   * Land value (hold-value) test: base-bearing islands score higher than bare islands via {@code
+   * findTerritoryValues}.
+   *
+   * <p>Caroline Islands (prod=0, airfield+harbour) island-floor=0 → land value = 0 + 10 = 10.0 Iwo
+   * Jima (prod=1, no base) island-floor=0.5 → land value = 0.5 Caroline Islands must rank higher.
+   */
+  @Test
+  void landValueBonusAppliedToBaseIslands() {
+    final Set<Territory> toCheck =
+        Set.of(
+            data.getMap().getTerritoryOrThrow(CAROLINE_ISLANDS),
+            data.getMap().getTerritoryOrThrow(IWO_JIMA));
+
+    final Map<Territory, Double> values =
+        ProTerritoryValueUtils.findTerritoryValues(
+            proData, americans, List.of(), List.of(), toCheck);
+
+    final double carolineValue = values.get(data.getMap().getTerritoryOrThrow(CAROLINE_ISLANDS));
+    final double iwoJimaValue = values.get(data.getMap().getTerritoryOrThrow(IWO_JIMA));
+
+    assertThat(carolineValue)
+        .as(
+            "Caroline Islands (airfield+harbour, prod=0) land value must exceed Iwo Jima (no base,"
+                + " prod=1)")
+        .isGreaterThan(iwoJimaValue);
+  }
+
+  private static ProData proDataFor(final GameData gameData) throws Exception {
+    final ProData proData = new ProData();
+    final Field f = ProData.class.getDeclaredField("data");
+    f.setAccessible(true);
+    f.set(proData, gameData);
+    return proData;
+  }
+}


### PR DESCRIPTION
## Summary

Closes map-room/map-room#2633

`ProTerritoryValueUtils` scored territories by IPC production alone. Airfields (extend fighter/bomber range) and naval bases/harbours (extend fleet range, repair capital ships) were completely invisible to the planner. Base-bearing islands with production=0 ranked below any 1-production territory, causing the AI to skip Midway, Caroline Islands, Wake Island, Malta, Gibraltar, etc.

## Fix

- `AIRFIELD_BONUS = 5.0` and `NAVAL_BASE_BONUS = 5.0` added to:
  - `findTerritoryAttackValue` — prioritises base-bearing attack targets
  - `findLandValue` — ensures hold/defence value reflects base presence

- **Detection**: unit presence (G40 unit model), with territory-attachment fallback for other maps:
  - Airfield: `Matches.unitIsAirBase()` (`UnitAttachment.isAirBase=true`)
  - Harbour: non-empty `getGivesMovement()` AND not `isAirBase` — exclusion required because airfields also carry `givesMovement` (to fighters/bombers)

## Tests (`ProBaseValueTest.java`)

| Test | Scenario | Result |
|---|---|---|
| `airfieldBonusOutweighsLowerProduction` | Midway (prod=0, airfield) vs Iwo Jima (prod=1, no base) | Midway 5.0 > Iwo Jima 3.0 ✓ |
| `bothBasesBonusClearlyOutweighsLowProduction` | Caroline Islands (prod=0, airfield+harbour) vs Iwo Jima | Caroline 10.0 > Iwo Jima 3.0 ✓ |
| `counterRegression_substantialProductionBeatsBaseWithoutProduction` | Borneo (prod=4, no base) vs Caroline Islands (prod=0, both bases) | Borneo 12.0 > Caroline 10.0 ✓ — bonus is a nudge, not an override |
| `landValueBonusAppliedToBaseIslands` | `findTerritoryValues` Caroline Islands vs Iwo Jima | Caroline 10.0 > Iwo Jima 0.5 ✓ |

## Spot-check: sidecar XML vs Map Room TS setup

| Territory | Sidecar XML | Map Room TS |
|---|---|---|
| Caroline Islands | airfield + harbour ✓ | airfield + harbour ✓ |
| Hawaiian Islands | airfield + harbour ✓ | airfield + harbour ✓ |
| Gibraltar | harbour only ✓ | harbour only ✓ |
| Malta | none | none |
| Iwo Jima | none | none |

Both data sources agree. No divergence found.

## Test plan

- [x] `ProBaseValueTest` — all 4 acceptance criteria pass
- [x] Full `game-core` test suite passes — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)