### PR TITLE
fix(ai): reduce base bonus to 2.0 and gate on production ≤ 1 (#2639)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -672,11 +672,10 @@ class ProNonCombatMoveAi {
         }
       }
 
-      // Base bonuses: airfields extend fighter/bomber range; naval bases extend fleet range.
-      // Same detection and constants as ProTerritoryValueUtils (landed in #2633).
-      final double baseBonus =
-          (territoryHasAirBase(t) ? ProTerritoryValueUtils.AIRFIELD_BONUS : 0.0)
-              + (territoryHasNavalBase(t) ? ProTerritoryValueUtils.NAVAL_BASE_BONUS : 0.0);
+      // Base bonuses: airfields/naval bases on low-IPC territories (production ≤ 1) get a bonus.
+      // Delegates to ProTerritoryValueUtils.computeBaseBonus — single source of truth for gate
+      // logic and constants shared with findTerritoryAttackValue and findLandValue.
+      final double baseBonus = ProTerritoryValueUtils.computeBaseBonus(t);
 
       // Calculate defense value for prioritization.
       // Note: the old formula included `+ 0.5 * cantMoveUnitValue`, which created a
@@ -2785,22 +2784,5 @@ class ProNonCombatMoveAi {
         ProLogger.trace("    " + printMap4.get(key) + " " + key);
       }
     }
-  }
-
-  /** Returns true if {@code t} contains an airbase unit or a territory-attachment airfield flag. */
-  private static boolean territoryHasAirBase(final Territory t) {
-    return TerritoryAttachment.hasAirBase(t)
-        || t.getUnits().stream().anyMatch(Matches.unitIsAirBase());
-  }
-
-  /**
-   * Returns true if {@code t} contains a naval-base unit (givesMovement, non-airfield) or a
-   * territory-attachment naval-base flag. Excludes airfield units that also carry givesMovement.
-   */
-  private static boolean territoryHasNavalBase(final Territory t) {
-    return TerritoryAttachment.hasNavalBase(t)
-        || t.getUnits().stream()
-            .filter(Matches.unitIsAirBase().negate())
-            .anyMatch(u -> !u.getUnitAttachment().getGivesMovement().isEmpty());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -29,11 +29,20 @@ import org.triplea.java.collections.CollectionUtils;
 public final class ProTerritoryValueUtils {
   static final int MIN_FACTORY_CHECK_DISTANCE = 9;
 
-  /** Bonus added to territory value when an airfield is present. */
-  public static final double AIRFIELD_BONUS = 5.0;
+  /**
+   * Bonus added to territory value when an airfield is present and production {@code <=} 1.
+   *
+   * <p>Tuned so bases differentiate marginal low-IPC territories (Midway, Caroline Islands) without
+   * adding noise to higher-IPC mainland scoring where raw IPC math dominates.
+   */
+  public static final double AIRFIELD_BONUS = 2.0;
 
-  /** Bonus added to territory value when a naval base is present. */
-  public static final double NAVAL_BASE_BONUS = 5.0;
+  /**
+   * Bonus added to territory value when a naval base is present and production {@code <=} 1.
+   *
+   * @see #AIRFIELD_BONUS
+   */
+  public static final double NAVAL_BASE_BONUS = 2.0;
 
   // G40 represents bases as placed units: airfield (isAirBase=true) and harbour (givesMovement).
   // TerritoryAttachment.hasAirBase/hasNavalBase cover maps that use territory-attribute flags
@@ -53,6 +62,24 @@ public final class ProTerritoryValueUtils {
   }
 
   /**
+   * Returns the combined airfield/naval-base bonus for {@code t}, or 0 if its production exceeds 1.
+   *
+   * <p>The production gate ensures the bonus only differentiates marginal low-IPC territories
+   * (Midway, Caroline Islands) and does not distort scoring for mainland territories where raw IPC
+   * math already provides sufficient discrimination.
+   *
+   * <p>Single source of truth — called from {@link #findTerritoryAttackValue}, {@link
+   * #findLandValue}, and {@code ProNonCombatMoveAi.prioritizeDefendOptions}.
+   */
+  public static double computeBaseBonus(final Territory t) {
+    if (TerritoryAttachment.getProduction(t) > 1) {
+      return 0.0;
+    }
+    return (territoryHasAirBase(t) ? AIRFIELD_BONUS : 0.0)
+        + (territoryHasNavalBase(t) ? NAVAL_BASE_BONUS : 0.0);
+  }
+
+  /**
    * Returns the relative value of attacking the specified territory compared to other territories.
    */
   public static double findTerritoryAttackValue(
@@ -60,12 +87,7 @@ public final class ProTerritoryValueUtils {
     final int isEnemyFactory =
         ProMatches.territoryHasInfraFactoryAndIsEnemyLand(player).test(t) ? 1 : 0;
     double value = 3.0 * TerritoryAttachment.getProduction(t) * (isEnemyFactory + 1);
-    if (territoryHasAirBase(t)) {
-      value += AIRFIELD_BONUS;
-    }
-    if (territoryHasNavalBase(t)) {
-      value += NAVAL_BASE_BONUS;
-    }
+    value += computeBaseBonus(t);
     if (ProUtils.isNeutralLand(t)) {
       final double strength =
           ProBattleUtils.estimateStrength(
@@ -363,16 +385,11 @@ public final class ProTerritoryValueUtils {
       value = Math.max(value, TerritoryAttachment.getProduction(t) * 0.5);
     }
 
-    // Prefer base-bearing territories: airfields extend fighter/bomber range; naval bases
-    // extend fleet range and enable faster repairs. A 5-IPC bonus makes these competitive
-    // with a modest production-territory advantage without overriding a substantially richer
-    // industrial target.
-    if (territoryHasAirBase(t)) {
-      value += AIRFIELD_BONUS;
-    }
-    if (territoryHasNavalBase(t)) {
-      value += NAVAL_BASE_BONUS;
-    }
+    // Prefer base-bearing low-IPC territories (e.g. Midway, Caroline Islands): airfields extend
+    // fighter/bomber range; naval bases extend fleet range and enable repairs. The production gate
+    // (production <= 1) ensures the bonus only differentiates marginal islands without distorting
+    // mainland scoring where raw IPC math already provides sufficient discrimination.
+    value += computeBaseBonus(t);
 
     return value;
   }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProBaseValueTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProBaseValueTest.java
@@ -15,26 +15,30 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Regression tests for #2633: ProTerritoryValueUtils ignores airfields and naval bases.
+ * Regression tests for #2633 (base detection) and calibration fix in #2637.
  *
- * <p>Root cause: {@code findTerritoryAttackValue} and {@code findLandValue} used only IPC
- * production to score territories, ignoring the strategic value of airfields (extend fighter/bomber
- * range) and naval bases (extend fleet range, enable repairs). This caused the planner to
- * deprioritise or discard base-bearing islands entirely.
+ * <p>#2633 root cause: {@code findTerritoryAttackValue} and {@code findLandValue} ignored airfields
+ * and naval bases, causing the planner to deprioritise base-bearing islands entirely.
  *
- * <p>Fix: add {@code AIRFIELD_BONUS = 5.0} and {@code NAVAL_BASE_BONUS = 5.0} to both value
- * functions. Bases are detected via unit presence ({@code UnitAttachment.isAirBase()} for
- * airfields; non-empty {@code UnitAttachment.getGivesMovement()} for harbours), covering the G40
- * unit-model and also maps that use territory-attachment flags.
+ * <p>#2637 calibration: bonuses reduced from 5.0 → 2.0 each and gated behind a production threshold
+ * ({@code production ≤ 1}). At 5.0 the bonuses added noise to higher-IPC mainland scoring; the gate
+ * restricts them to marginal low-IPC territories where base presence is the primary discriminator.
  *
- * <p>Test anchor: G40 Pacific island cluster.
+ * <p>All three formula call sites share a single helper {@link
+ * ProTerritoryValueUtils#computeBaseBonus} so gate logic and constants stay in sync.
+ *
+ * <p>Test anchor: G40 Pacific island cluster + mainland sanity checks.
  *
  * <ul>
- *   <li>Midway: production=0, airfield only → value=5 (bonus exceeds Iwo Jima production=1,
- *       value=3)
- *   <li>Caroline Islands: production=0, airfield + harbour → value=10 (bonus well above Iwo Jima)
- *   <li>Borneo: production=4, no base → value=12 (substantially higher IPC still wins over Caroline
- *       Islands=10 — base is a nudge, not an override)
+ *   <li>Midway (prod=0, airfield): base contribution = 2.0
+ *   <li>Caroline Islands (prod=0, airfield + harbour): base contribution = 4.0
+ *   <li>Iwo Jima (prod=1, no base): base contribution = 0.0
+ *   <li>Hawaiian Islands (prod=1, airfield + harbour): base contribution = 4.0 (gate boundary —
+ *       prod=1 IS within threshold)
+ *   <li>Philippines (prod=2, airfield + harbour): base contribution = 0.0 (gate boundary — prod=2
+ *       EXCEEDS threshold)
+ *   <li>Eastern United States (prod=20, airfield + harbour): base contribution = 0.0 (high-IPC
+ *       mainland)
  * </ul>
  */
 public class ProBaseValueTest {
@@ -43,6 +47,9 @@ public class ProBaseValueTest {
   private static final String IWO_JIMA = "Iwo Jima";
   private static final String MIDWAY = "Midway";
   private static final String BORNEO = "Borneo";
+  private static final String HAWAIIAN_ISLANDS = "Hawaiian Islands";
+  private static final String PHILIPPINES = "Philippines";
+  private static final String EASTERN_UNITED_STATES = "Eastern United States";
 
   private GameData data;
   private GamePlayer americans;
@@ -56,58 +63,102 @@ public class ProBaseValueTest {
   }
 
   /**
-   * Acceptance criterion 1: airfield bonus must outweigh a modest production advantage.
+   * Midway (prod=0, airfield only) → base contribution = AIRFIELD_BONUS = 2.0.
    *
-   * <p>Midway (production=0, airfield) → {@code findTerritoryAttackValue} = 5.0 Iwo Jima
-   * (production=1, no base) → {@code findTerritoryAttackValue} = 3.0 Midway must score higher.
+   * <p>Attack value = 3×prod×factory_mult + baseBonus = 0 + 2.0 = 2.0.
    */
   @Test
-  void airfieldBonusOutweighsLowerProduction() {
+  void midwayBaseContributionMatchesAirfieldBonus() {
     final Territory midway = data.getMap().getTerritoryOrThrow(MIDWAY);
-    final Territory iwoJima = data.getMap().getTerritoryOrThrow(IWO_JIMA);
 
-    final double midwayValue =
-        ProTerritoryValueUtils.findTerritoryAttackValue(proData, americans, midway);
-    final double iwoJimaValue =
-        ProTerritoryValueUtils.findTerritoryAttackValue(proData, americans, iwoJima);
+    assertThat(ProTerritoryValueUtils.computeBaseBonus(midway))
+        .as("Midway (prod=0, airfield) base contribution must equal AIRFIELD_BONUS")
+        .isEqualTo(ProTerritoryValueUtils.AIRFIELD_BONUS);
 
-    assertThat(midwayValue)
-        .as("Midway (airfield, prod=0) must outvalue Iwo Jima (no base, prod=1)")
-        .isGreaterThan(iwoJimaValue);
-    assertThat(midwayValue)
-        .as("Midway attack value must include the AIRFIELD_BONUS")
+    assertThat(ProTerritoryValueUtils.findTerritoryAttackValue(proData, americans, midway))
+        .as("Midway attack value = 0 (prod) + AIRFIELD_BONUS (base)")
         .isEqualTo(ProTerritoryValueUtils.AIRFIELD_BONUS);
   }
 
   /**
-   * Acceptance criterion 2: both-base bonus must clearly outweigh a 1-production territory.
-   *
-   * <p>Caroline Islands (production=0, airfield + harbour) → value = 10.0 Iwo Jima (production=1,
-   * no base) → value = 3.0
+   * Caroline Islands (prod=0, airfield + harbour) → base contribution = AIRFIELD_BONUS +
+   * NAVAL_BASE_BONUS = 4.0.
    */
   @Test
-  void bothBasesBonusClearlyOutweighsLowProduction() {
+  void carolineIslandsBaseContributionMatchesBothBonuses() {
     final Territory carolineIslands = data.getMap().getTerritoryOrThrow(CAROLINE_ISLANDS);
+
+    assertThat(ProTerritoryValueUtils.computeBaseBonus(carolineIslands))
+        .as("Caroline Islands (prod=0, airfield+harbour) base contribution must equal both bonuses")
+        .isEqualTo(ProTerritoryValueUtils.AIRFIELD_BONUS + ProTerritoryValueUtils.NAVAL_BASE_BONUS);
+
+    assertThat(ProTerritoryValueUtils.findTerritoryAttackValue(proData, americans, carolineIslands))
+        .as("Caroline Islands attack value = 0 (prod) + AIRFIELD_BONUS + NAVAL_BASE_BONUS")
+        .isEqualTo(ProTerritoryValueUtils.AIRFIELD_BONUS + ProTerritoryValueUtils.NAVAL_BASE_BONUS);
+  }
+
+  /** Iwo Jima (prod=1, no base) → base contribution = 0. Attack value = 3.0. */
+  @Test
+  void iwoJimaHasNoBaseContribution() {
     final Territory iwoJima = data.getMap().getTerritoryOrThrow(IWO_JIMA);
 
-    final double carolineValue =
-        ProTerritoryValueUtils.findTerritoryAttackValue(proData, americans, carolineIslands);
-    final double iwoJimaValue =
-        ProTerritoryValueUtils.findTerritoryAttackValue(proData, americans, iwoJima);
+    assertThat(ProTerritoryValueUtils.computeBaseBonus(iwoJima))
+        .as("Iwo Jima (prod=1, no base) must have zero base contribution")
+        .isEqualTo(0.0);
+  }
 
-    assertThat(carolineValue)
-        .as("Caroline Islands (airfield+harbour, prod=0) must outscore Iwo Jima (no base, prod=1)")
-        .isGreaterThan(iwoJimaValue);
-    assertThat(carolineValue)
-        .as("Caroline Islands value must include both base bonuses")
+  /**
+   * Gate boundary (inclusive): Hawaiian Islands has prod=1 and both airfield + harbour. Production
+   * threshold is {@code > 1}, so prod=1 IS within the gate — the bonus must be applied.
+   *
+   * <p>Expected: computeBaseBonus = AIRFIELD_BONUS + NAVAL_BASE_BONUS = 4.0.
+   */
+  @Test
+  void prod1WithBothBasesGetsFullBonus() {
+    final Territory hawaii = data.getMap().getTerritoryOrThrow(HAWAIIAN_ISLANDS);
+
+    assertThat(ProTerritoryValueUtils.computeBaseBonus(hawaii))
+        .as(
+            "Hawaiian Islands (prod=1, airfield+harbour) must receive full bonus — prod=1 is at"
+                + " the gate boundary (threshold is >1, not >=1)")
         .isEqualTo(ProTerritoryValueUtils.AIRFIELD_BONUS + ProTerritoryValueUtils.NAVAL_BASE_BONUS);
   }
 
   /**
-   * Counter-regression: substantially higher production must still dominate even with no base.
+   * Gate boundary (exclusive): Philippines has prod=2 and both airfield + harbour. Production
+   * exceeds the threshold — base bonus must NOT be applied.
    *
-   * <p>Borneo (production=4, no base) → value = 12.0 Caroline Islands (production=0,
-   * airfield+harbour) → value = 10.0 High-production territory without a base must still win.
+   * <p>Expected: computeBaseBonus = 0.0.
+   */
+  @Test
+  void prod2WithBothBasesGetsNoBonus() {
+    final Territory philippines = data.getMap().getTerritoryOrThrow(PHILIPPINES);
+
+    assertThat(ProTerritoryValueUtils.computeBaseBonus(philippines))
+        .as(
+            "Philippines (prod=2, airfield+harbour) must receive zero bonus — production exceeds"
+                + " the gate threshold (>1)")
+        .isEqualTo(0.0);
+  }
+
+  /**
+   * High-IPC mainland sanity: Eastern United States (prod=20, airfield + harbour) receives zero
+   * base contribution. Confirms the gate suppresses the bonus across all mainland territories.
+   */
+  @Test
+  void highIpcMainlandGetsNoBaseBonus() {
+    final Territory easternUs = data.getMap().getTerritoryOrThrow(EASTERN_UNITED_STATES);
+
+    assertThat(ProTerritoryValueUtils.computeBaseBonus(easternUs))
+        .as("Eastern United States (prod=20) must have zero base contribution")
+        .isEqualTo(0.0);
+  }
+
+  /**
+   * Counter-regression: substantially higher production must still dominate over base-only islands.
+   *
+   * <p>Borneo (prod=4, no base) → attack value = 12.0. Caroline Islands (prod=0, both bases) →
+   * attack value = 4.0. Production wins decisively.
    */
   @Test
   void counterRegression_substantialProductionBeatsBaseWithoutProduction() {
@@ -121,17 +172,17 @@ public class ProBaseValueTest {
 
     assertThat(borneoValue)
         .as(
-            "Borneo (prod=4, no base, value=12) must outscore Caroline Islands (prod=0, both"
-                + " bases, value=10) — base bonus is a nudge, not an override")
+            "Borneo (prod=4, no base) must outscore Caroline Islands (prod=0, both bases)"
+                + " — base bonus is a nudge for marginal islands, not a production override")
         .isGreaterThan(carolineValue);
   }
 
   /**
-   * Land value (hold-value) test: base-bearing islands score higher than bare islands via {@code
-   * findTerritoryValues}.
+   * Land value (hold-value) test: Caroline Islands scores higher than Iwo Jima via {@code
+   * findTerritoryValues}, confirming the base bonus is applied to the land-value formula too.
    *
-   * <p>Caroline Islands (prod=0, airfield+harbour) island-floor=0 → land value = 0 + 10 = 10.0 Iwo
-   * Jima (prod=1, no base) island-floor=0.5 → land value = 0.5 Caroline Islands must rank higher.
+   * <p>Caroline Islands (prod=0, airfield+harbour) → land value ≈ 4.0. Iwo Jima (prod=1, no base) →
+   * land value ≈ 0.5 (island floor). Caroline Islands must rank higher.
    */
   @Test
   void landValueBonusAppliedToBaseIslands() {


### PR DESCRIPTION
## Summary

Calibration follow-up to #111 (#2633) and #113 (#2637).

`AIRFIELD_BONUS = NAVAL_BASE_BONUS = 5.0` (landed in #111) added too much noise to higher-IPC mainland scoring — the bonuses were distorting attack/defend priorities for territories where raw IPC math already provides sufficient discrimination.

Empirical calibration from cwolfinger after observing actual game behavior:

| Constant | Before | After |
|----------|--------|-------|
| `AIRFIELD_BONUS` | 5.0 | 2.0 |
| `NAVAL_BASE_BONUS` | 5.0 | 2.0 |

**Production gate**: bonus is only applied when `TerritoryAttachment.getProduction(t) <= 1`. Mainland territories with prod ≥ 2 use raw IPC math exclusively.

### Single source of truth

Introduces `ProTerritoryValueUtils.computeBaseBonus(Territory t)` — the gate logic and constants now live in one place. All three call sites delegate to it:
1. `findTerritoryAttackValue`
2. `findLandValue`
3. `ProNonCombatMoveAi.prioritizeDefendOptions` (added in #113)

### Updated tests (`ProBaseValueTest`)

Replaced the 5.0-era assertions with gate-aware boundary tests:

| Territory | prod | bases | expected `computeBaseBonus` |
|-----------|------|-------|----------------------------|
| Midway | 0 | airfield | 2.0 |
| Caroline Islands | 0 | airfield + harbour | 4.0 |
| Iwo Jima | 1 | none | 0.0 |
| Hawaiian Islands | 1 | airfield + harbour | 4.0 (prod=1 ≤ threshold) |
| Philippines | 2 | airfield + harbour | 0.0 (prod=2 > threshold) |
| Eastern United States | 20 | airfield + harbour | 0.0 (high-IPC mainland) |

Counter-regression: Borneo (prod=4) still outscores Caroline Islands (prod=0, both bases) since 12.0 > 4.0.

## Test plan

- [x] `ProBaseValueTest` — all 7 tests pass
- [x] Full `game-core` test suite passes
- [x] PMD clean — main + test
- [x] Spotless applied

Closes map-room/map-room#2639. Cross-links: map-room/map-room#2633, map-room/map-room#2637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)