### PR TITLE
feat(wire): add embarked/embarkedThisTurn to WireUnit, amphibiousMovementEnabled to WireState (Phase 2.1)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireState.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireState.java
@@ -10,25 +10,44 @@ public record WireState(
     int round,
     String phase,
     String currentPlayer,
-    List<WireRelationship> relationships) {
+    List<WireRelationship> relationships,
+    boolean amphibiousMovementEnabled) {
 
   /**
-   * Backwards-compat constructor: TS clients shipped before the relationships field exists may omit
-   * it. Treat absent field as empty list (not null) so downstream walks are safe.
+   * Jackson deserializer. Uses a static factory so we can accept {@code @Nullable Boolean} for
+   * {@code amphibiousMovementEnabled} and {@code relationships} (absent implies false / empty-list)
+   * while keeping the canonical record constructor strictly typed.
    */
   @JsonCreator
-  public WireState(
+  public static WireState of(
       @JsonProperty("territories") final List<WireTerritory> territories,
       @JsonProperty("players") final List<WirePlayer> players,
       @JsonProperty("round") final int round,
       @JsonProperty("phase") final String phase,
       @JsonProperty("currentPlayer") final String currentPlayer,
-      @JsonProperty("relationships") final List<WireRelationship> relationships) {
-    this.territories = territories;
-    this.players = players;
-    this.round = round;
-    this.phase = phase;
-    this.currentPlayer = currentPlayer;
-    this.relationships = relationships == null ? List.of() : relationships;
+      @JsonProperty("relationships") final List<WireRelationship> relationships,
+      @JsonProperty("amphibiousMovementEnabled") final Boolean amphibiousMovementEnabled) {
+    return new WireState(
+        territories,
+        players,
+        round,
+        phase,
+        currentPlayer,
+        relationships == null ? List.of() : relationships,
+        amphibiousMovementEnabled != null && amphibiousMovementEnabled);
+  }
+
+  /**
+   * Backward-compat constructor for callers that pre-date {@code amphibiousMovementEnabled}.
+   * Defaults the toggle to {@code false}.
+   */
+  public WireState(
+      final List<WireTerritory> territories,
+      final List<WirePlayer> players,
+      final int round,
+      final String phase,
+      final String currentPlayer,
+      final List<WireRelationship> relationships) {
+    this(territories, players, round, phase, currentPlayer, relationships, false);
   }
 }

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireUnit.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireUnit.java
@@ -23,7 +23,9 @@ public record WireUnit(
     @Nullable Integer maxScrambleCount,
     @Nullable List<String> unloaded,
     @Nullable String unloadedTo,
-    boolean wasLoadedAfterCombat) {
+    boolean wasLoadedAfterCombat,
+    boolean embarked,
+    boolean embarkedThisTurn) {
   @JsonCreator
   public static WireUnit of(
       @JsonProperty("unitId") final String unitId,
@@ -43,7 +45,9 @@ public record WireUnit(
       @JsonProperty("maxScrambleCount") final Integer maxScrambleCount,
       @JsonProperty("unloaded") final List<String> unloaded,
       @JsonProperty("unloadedTo") final String unloadedTo,
-      @JsonProperty("wasLoadedAfterCombat") final Boolean wasLoadedAfterCombat) {
+      @JsonProperty("wasLoadedAfterCombat") final Boolean wasLoadedAfterCombat,
+      @JsonProperty("embarked") final Boolean embarked,
+      @JsonProperty("embarkedThisTurn") final Boolean embarkedThisTurn) {
     return new WireUnit(
         unitId,
         unitType,
@@ -62,7 +66,55 @@ public record WireUnit(
         maxScrambleCount,
         unloaded,
         unloadedTo,
-        wasLoadedAfterCombat != null && wasLoadedAfterCombat);
+        wasLoadedAfterCombat != null && wasLoadedAfterCombat,
+        embarked != null && embarked,
+        embarkedThisTurn != null && embarkedThisTurn);
+  }
+
+  /**
+   * Backward-compat factory for callers that pre-date {@code embarked} / {@code embarkedThisTurn}.
+   * Defaults both to {@code false}.
+   */
+  public static WireUnit of(
+      final String unitId,
+      final String unitType,
+      final Integer hitsTaken,
+      final Integer movesUsed,
+      final Integer bombingDamage,
+      final String owner,
+      final String transportedBy,
+      final Boolean submerged,
+      final Boolean wasInCombat,
+      final Boolean wasLoadedThisTurn,
+      final Boolean wasUnloadedInCombatPhase,
+      final Integer bonusMovement,
+      final Boolean wasAmphibious,
+      final Boolean wasScrambled,
+      final Integer maxScrambleCount,
+      final List<String> unloaded,
+      final String unloadedTo,
+      final Boolean wasLoadedAfterCombat) {
+    return WireUnit.of(
+        unitId,
+        unitType,
+        hitsTaken,
+        movesUsed,
+        bombingDamage,
+        owner,
+        transportedBy,
+        submerged,
+        wasInCombat,
+        wasLoadedThisTurn,
+        wasUnloadedInCombatPhase,
+        bonusMovement,
+        wasAmphibious,
+        wasScrambled,
+        maxScrambleCount,
+        unloaded,
+        unloadedTo,
+        wasLoadedAfterCombat,
+        null,
+        null);
   }
 
   /**
@@ -101,6 +153,8 @@ public record WireUnit(
         null,
         null,
         null,
+        false,
+        false,
         false);
   }
 
@@ -109,7 +163,7 @@ public record WireUnit(
       final String unitId, final String unitType, final int hitsTaken, final int movesUsed) {
     this(
         unitId, unitType, hitsTaken, movesUsed, 0, null, null, false, false, false, false, 0, false,
-        false, null, null, null, false);
+        false, null, null, null, false, false, false);
   }
 
   /** Backward-compat constructor for tests that specify bombingDamage but not owner. */
@@ -137,6 +191,8 @@ public record WireUnit(
         null,
         null,
         null,
+        false,
+        false,
         false);
   }
 
@@ -166,6 +222,8 @@ public record WireUnit(
         null,
         null,
         null,
+        false,
+        false,
         false);
   }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateJsonFieldsTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateJsonFieldsTest.java
@@ -36,4 +36,51 @@ class WireStateJsonFieldsTest {
     WireUnit u = mapper.readValue(json, WireUnit.class);
     assertEquals(3, u.bombingDamage());
   }
+
+  @Test
+  void wireUnitEmbarkedDefaultsFalse() throws Exception {
+    String json = "{\"unitId\":\"u1\",\"unitType\":\"infantry\"}";
+    WireUnit u = mapper.readValue(json, WireUnit.class);
+    assertFalse(u.embarked());
+  }
+
+  @Test
+  void wireUnitEmbarkedHonoured() throws Exception {
+    String json = "{\"unitId\":\"u1\",\"unitType\":\"infantry\",\"embarked\":true}";
+    WireUnit u = mapper.readValue(json, WireUnit.class);
+    assertTrue(u.embarked());
+  }
+
+  @Test
+  void wireUnitEmbarkedThisTurnDefaultsFalse() throws Exception {
+    String json = "{\"unitId\":\"u1\",\"unitType\":\"infantry\"}";
+    WireUnit u = mapper.readValue(json, WireUnit.class);
+    assertFalse(u.embarkedThisTurn());
+  }
+
+  @Test
+  void wireUnitEmbarkedThisTurnHonoured() throws Exception {
+    String json = "{\"unitId\":\"u1\",\"unitType\":\"infantry\",\"embarkedThisTurn\":true}";
+    WireUnit u = mapper.readValue(json, WireUnit.class);
+    assertTrue(u.embarkedThisTurn());
+  }
+
+  @Test
+  void wireStateAmphibiousMovementEnabledDefaultsFalse() throws Exception {
+    String json =
+        "{\"territories\":[],\"players\":[],\"round\":1,\"phase\":\"combat-move\","
+            + "\"currentPlayer\":\"Germans\",\"relationships\":[]}";
+    WireState s = mapper.readValue(json, WireState.class);
+    assertFalse(s.amphibiousMovementEnabled());
+  }
+
+  @Test
+  void wireStateAmphibiousMovementEnabledHonoured() throws Exception {
+    String json =
+        "{\"territories\":[],\"players\":[],\"round\":1,\"phase\":\"combat-move\","
+            + "\"currentPlayer\":\"Germans\",\"relationships\":[],"
+            + "\"amphibiousMovementEnabled\":true}";
+    WireState s = mapper.readValue(json, WireState.class);
+    assertTrue(s.amphibiousMovementEnabled());
+  }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateRoundTripTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateRoundTripTest.java
@@ -1,6 +1,8 @@
 package org.triplea.ai.sidecar.wire;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -50,5 +52,65 @@ class WireStateRoundTripTest {
     final String json = om.writeValueAsString(parsed);
     final WireState reparsed = om.readValue(json, WireState.class);
     assertEquals(parsed, reparsed);
+  }
+
+  private static final String AMPHIB_SAMPLE =
+      "{"
+          + "\"territories\":["
+          + "  {\"territoryId\":\"SZ 110\",\"owner\":\"Neutral\","
+          + "   \"units\":["
+          + "     {\"unitId\":\"inf-1\",\"unitType\":\"infantry\","
+          + "      \"embarked\":true,\"embarkedThisTurn\":false},"
+          + "     {\"unitId\":\"inf-2\",\"unitType\":\"infantry\","
+          + "      \"embarked\":true,\"embarkedThisTurn\":true}"
+          + "   ]}"
+          + "],"
+          + "\"players\":["
+          + "  {\"playerId\":\"Americans\",\"pus\":52,\"tech\":[],\"capitalCaptured\":false}"
+          + "],"
+          + "\"round\":2,"
+          + "\"phase\":\"noncombat-move\","
+          + "\"currentPlayer\":\"Americans\","
+          + "\"relationships\":[],"
+          + "\"amphibiousMovementEnabled\":true"
+          + "}";
+
+  @Test
+  void deserializeAmphib() throws Exception {
+    final ObjectMapper om = new ObjectMapper();
+    final WireState s = om.readValue(AMPHIB_SAMPLE, WireState.class);
+    assertTrue(s.amphibiousMovementEnabled());
+    assertEquals(1, s.territories().size());
+    assertEquals(2, s.territories().get(0).units().size());
+    final WireUnit staged = s.territories().get(0).units().get(0);
+    assertTrue(staged.embarked());
+    assertFalse(staged.embarkedThisTurn());
+    final WireUnit freshlyEmbarked = s.territories().get(0).units().get(1);
+    assertTrue(freshlyEmbarked.embarked());
+    assertTrue(freshlyEmbarked.embarkedThisTurn());
+  }
+
+  @Test
+  void amphibRoundTripPreservesEmbarkedFields() throws Exception {
+    final ObjectMapper om = new ObjectMapper();
+    final WireState parsed = om.readValue(AMPHIB_SAMPLE, WireState.class);
+    final String json = om.writeValueAsString(parsed);
+    final WireState reparsed = om.readValue(json, WireState.class);
+    assertEquals(parsed, reparsed);
+    assertTrue(reparsed.amphibiousMovementEnabled());
+    assertTrue(reparsed.territories().get(0).units().get(0).embarked());
+    assertFalse(reparsed.territories().get(0).units().get(0).embarkedThisTurn());
+    assertTrue(reparsed.territories().get(0).units().get(1).embarkedThisTurn());
+  }
+
+  @Test
+  void legacyStateWithoutAmphFieldsDeserializesWithDefaults() throws Exception {
+    final ObjectMapper om = new ObjectMapper();
+    final WireState s = om.readValue(SAMPLE, WireState.class);
+    assertFalse(s.amphibiousMovementEnabled());
+    for (final var unit : s.territories().get(0).units()) {
+      assertFalse(unit.embarked());
+      assertFalse(unit.embarkedThisTurn());
+    }
   }
 }

--- a/game-app/ai-sidecar/src/test/resources/wire-contract/wire-state-with-relationships.json
+++ b/game-app/ai-sidecar/src/test/resources/wire-contract/wire-state-with-relationships.json
@@ -20,5 +20,6 @@
     "a" : "Germans",
     "b" : "Russians",
     "kind" : "neutral"
-  } ]
+  } ],
+  "amphibiousMovementEnabled" : false
 }


### PR DESCRIPTION
## Summary

- Adds `embarked` and `embarkedThisTurn` boolean fields to `WireUnit` (defaults `false` when absent — legacy JSON round-trips cleanly)
- Adds `amphibiousMovementEnabled` boolean toggle to `WireState` (defaults `false` when absent)
- Backward-compat 18-arg `WireUnit.of(...)` factory so existing callers compile without change
- Adds `WireStateJsonFieldsTest` tests for all three new fields (default + honoured)
- Adds `WireStateRoundTripTest` amphib fixture: two embarked infantry, toggle true, full round-trip

No AI decision logic changed — wire/DTO layer only.

## Test plan

- [x] `./gradlew :game-app:ai-sidecar:test` — all tests pass
- [x] `WireStateJsonFieldsTest` — 6 new field-default tests pass
- [x] `WireStateRoundTripTest` — 3 new amphib round-trip tests pass
- [x] Legacy JSON (no amphib fields) still deserializes with `false` defaults

Closes map-room/map-room#2694 · TS side: map-room/map-room#2695

🤖 Generated with [Claude Code](https://claude.com/claude-code)