### PR TITLE
feat(amphib-ai): Phase 2.2 — AmphContext from wire, threaded through executors

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
@@ -3,6 +3,7 @@ package org.triplea.ai.sidecar.exec;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.ai.pro.data.AmphContext;
 import games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge;
 import java.util.HashMap;
 import java.util.List;
@@ -65,7 +66,7 @@ public final class NoncombatMoveExecutor
    */
   NoncombatMovePlan executeOn(final GameData data, final NoncombatMoveRequest request) {
     final ConcurrentMap<String, UUID> unitIdMap = new ConcurrentHashMap<>();
-    WireStateApplier.apply(data, request.state(), unitIdMap);
+    final AmphContext amphCtx = WireStateApplier.apply(data, request.state(), unitIdMap);
 
     final GamePlayer player = data.getPlayerList().getPlayerId(request.state().currentPlayer());
     if (player == null) {
@@ -94,6 +95,9 @@ public final class NoncombatMoveExecutor
     recorder.initialize("move", "Move");
     recorder.setDelegateBridgeAndPlayer(new ProDummyDelegateBridge(proAi, player, data));
     proAi.reinitializeProDataForSidecar();
+    // Gate: set context AFTER reinitialize so it survives proData re-initialization.
+    // Phase 2.5 NCM embark logic reads this; toggle-off means AmphContext.DISABLED (no-op).
+    proAi.getProData().setAmphContext(amphCtx);
     proAi.invokeNonCombatMoveForSidecar(recorder, data, player);
 
     // Build reverse map: UUID → wireId

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
@@ -12,6 +12,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegate;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.ai.pro.data.AmphContext;
 import games.strategy.triplea.ai.pro.data.ProPlaceTerritory;
 import games.strategy.triplea.ai.pro.data.ProPurchaseTerritory;
 import games.strategy.triplea.ai.pro.data.ProSessionSnapshot;
@@ -108,7 +109,7 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
    */
   PurchasePlan executeOn(final GameData data, final PurchaseRequest request) {
     final ConcurrentMap<String, UUID> unitIdMap = new ConcurrentHashMap<>();
-    WireStateApplier.apply(data, request.state(), unitIdMap);
+    final AmphContext amphCtx = WireStateApplier.apply(data, request.state(), unitIdMap);
 
     final GamePlayer player = data.getPlayerList().getPlayerId(request.state().currentPlayer());
     if (player == null) {
@@ -241,6 +242,9 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
     combatRecorder.initialize("move", "Move");
     combatRecorder.setDelegateBridgeAndPlayer(new ProDummyDelegateBridge(proAi, player, data));
     proAi.reinitializeProDataForSidecar();
+    // Restore context after reinitialize — the combat-move projection reads the same
+    // amphib state as the purchase that preceded it. Toggle-off = AmphContext.DISABLED (no-op).
+    proAi.getProData().setAmphContext(amphCtx);
     proAi.invokeCombatMoveForSidecar(combatRecorder, data, player);
 
     final List<WireMoveDescription> nonBombingMoves =

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -11,6 +11,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.triplea.ai.pro.data.AmphContext;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
@@ -67,7 +68,7 @@ public final class WireStateApplier {
    *     resource that does not exist on the canonical map — those indicate a caller bug, not a
    *     recoverable condition.
    */
-  public static void apply(
+  public static AmphContext apply(
       final GameData gameData, final WireState wire, final ConcurrentMap<String, UUID> unitIdMap) {
     final CompositeChange changes = new CompositeChange();
 
@@ -102,6 +103,37 @@ public final class WireStateApplier {
     // but keeping it at the tail means nothing downstream can overwrite it.
     applyRoundAndStep(gameData, wire);
     WireStateVerifier.verifyApply(gameData, wire, unitIdMap);
+    return buildAmphContext(wire, unitIdMap);
+  }
+
+  private static AmphContext buildAmphContext(
+      final WireState wire, final ConcurrentMap<String, UUID> unitIdMap) {
+    if (!wire.amphibiousMovementEnabled()) {
+      return AmphContext.DISABLED;
+    }
+    final Set<UUID> embarked = new HashSet<>();
+    final Set<UUID> embarkedThisTurn = new HashSet<>();
+    for (final WireTerritory wt : wire.territories()) {
+      for (final WireUnit wu : wt.units()) {
+        if (!wu.embarked() && !wu.embarkedThisTurn()) {
+          continue;
+        }
+        final UUID uuid = unitIdMap.get(wu.unitId());
+        if (uuid == null) {
+          LOG.log(
+              Level.WARNING,
+              () -> "embarked unit '" + wu.unitId() + "' not in unitIdMap — skipping");
+          continue;
+        }
+        if (wu.embarked()) {
+          embarked.add(uuid);
+        }
+        if (wu.embarkedThisTurn()) {
+          embarkedThisTurn.add(uuid);
+        }
+      }
+    }
+    return new AmphContext(true, embarked, embarkedThisTurn);
   }
 
   /**

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierAmphTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierAmphTest.java
@@ -1,0 +1,187 @@
+package org.triplea.ai.sidecar.wire;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.triplea.ai.pro.data.AmphContext;
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+
+/**
+ * Phase 2.1 / 2.2 wire-protocol tests for {@link WireStateApplier#apply} returning {@link
+ * AmphContext}. Covers: toggle on/off reflected in the returned context; per-unit embarked and
+ * embarkedThisTurn read back correctly; toggle-off leaves existing GameData unchanged.
+ */
+class WireStateApplierAmphTest {
+
+  private static CanonicalGameData canonical;
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+  }
+
+  private GameData fresh() {
+    return canonical.cloneForSession();
+  }
+
+  private ConcurrentMap<String, UUID> freshIdMap() {
+    return new ConcurrentHashMap<>();
+  }
+
+  // ---- toggle reflection ----
+
+  @Test
+  void toggleOffReturnsDisabledContext() {
+    final WireState wire =
+        new WireState(List.of(), List.of(), 1, "combat-move", "Germans", List.of(), false);
+    final AmphContext ctx = WireStateApplier.apply(fresh(), wire, freshIdMap());
+    assertThat(ctx.isEnabled()).isFalse();
+    assertThat(ctx.embarkedUnitIds()).isEmpty();
+    assertThat(ctx.embarkedThisTurnUnitIds()).isEmpty();
+  }
+
+  @Test
+  void toggleOnNoUnitsReturnsEnabledEmptyContext() {
+    final WireState wire =
+        new WireState(List.of(), List.of(), 1, "noncombat-move", "Americans", List.of(), true);
+    final AmphContext ctx = WireStateApplier.apply(fresh(), wire, freshIdMap());
+    assertThat(ctx.isEnabled()).isTrue();
+    assertThat(ctx.embarkedUnitIds()).isEmpty();
+    assertThat(ctx.embarkedThisTurnUnitIds()).isEmpty();
+  }
+
+  // ---- per-unit embarked read-back ----
+
+  @Test
+  void embarkedUnitAppearsInContext() {
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    final WireUnit stagedInf =
+        WireUnit.of(
+            "inf-staged",
+            "infantry",
+            null,
+            null,
+            null,
+            "Americans",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            Boolean.TRUE,
+            Boolean.FALSE);
+    final WireTerritory sz = new WireTerritory("111 Sea Zone", "Neutral", List.of(stagedInf));
+    final WireState wire =
+        new WireState(List.of(sz), List.of(), 2, "noncombat-move", "Americans", List.of(), true);
+
+    final AmphContext ctx = WireStateApplier.apply(fresh(), wire, idMap);
+
+    assertThat(ctx.isEnabled()).isTrue();
+    final UUID unitUuid = idMap.get("inf-staged");
+    assertThat(unitUuid).isNotNull();
+    assertThat(ctx.embarkedUnitIds()).contains(unitUuid);
+    assertThat(ctx.embarkedThisTurnUnitIds()).doesNotContain(unitUuid);
+  }
+
+  @Test
+  void embarkedThisTurnUnitAppearsInBothSets() {
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    final WireUnit freshInf =
+        WireUnit.of(
+            "inf-fresh",
+            "infantry",
+            null,
+            null,
+            null,
+            "Americans",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            Boolean.TRUE,
+            Boolean.TRUE);
+    final WireTerritory sz = new WireTerritory("111 Sea Zone", "Neutral", List.of(freshInf));
+    final WireState wire =
+        new WireState(List.of(sz), List.of(), 2, "noncombat-move", "Americans", List.of(), true);
+
+    final AmphContext ctx = WireStateApplier.apply(fresh(), wire, idMap);
+
+    final UUID unitUuid = idMap.get("inf-fresh");
+    assertThat(unitUuid).isNotNull();
+    assertThat(ctx.embarkedUnitIds()).contains(unitUuid);
+    assertThat(ctx.embarkedThisTurnUnitIds()).contains(unitUuid);
+  }
+
+  @Test
+  void nonEmbarkedUnitAbsentFromBothSets() {
+    final ConcurrentMap<String, UUID> idMap = freshIdMap();
+    final WireUnit landInf =
+        WireUnit.of(
+            "inf-land",
+            "infantry",
+            null,
+            null,
+            null,
+            "Germans",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            Boolean.FALSE,
+            Boolean.FALSE);
+    final WireTerritory germany = new WireTerritory("Germany", "Germans", List.of(landInf));
+    final WireState wire =
+        new WireState(List.of(germany), List.of(), 1, "noncombat-move", "Germans", List.of(), true);
+
+    final AmphContext ctx = WireStateApplier.apply(fresh(), wire, idMap);
+
+    final UUID unitUuid = idMap.get("inf-land");
+    assertThat(unitUuid).isNotNull();
+    assertThat(ctx.embarkedUnitIds()).doesNotContain(unitUuid);
+    assertThat(ctx.embarkedThisTurnUnitIds()).doesNotContain(unitUuid);
+  }
+
+  // ---- toggle-off: GameData unchanged ----
+
+  @Test
+  void toggleOffDoesNotAlterTerritoryOwnership() {
+    final GameData gd = fresh();
+    final String owner = gd.getMap().getTerritoryOrThrow("Germany").getOwner().getName();
+    final WireState wire =
+        new WireState(List.of(), List.of(), 1, "combat-move", "Germans", List.of(), false);
+    WireStateApplier.apply(gd, wire, freshIdMap());
+    assertThat(gd.getMap().getTerritoryOrThrow("Germany").getOwner().getName()).isEqualTo(owner);
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.ai.pro.data.AmphContext;
 import games.strategy.triplea.ai.pro.data.ProPurchaseOption;
 import games.strategy.triplea.ai.pro.data.ProPurchaseOptionMap;
 import games.strategy.triplea.ai.pro.data.ProTerritory;
@@ -43,12 +44,23 @@ public final class ProData {
   private final Set<Unit> unitsToBeConsumed = new HashSet<>();
   private double minCostPerHitPoint = Double.MAX_VALUE;
 
+  /**
+   * Amphib-movement context delivered from the wire by the sidecar executor. Never null; defaults
+   * to {@link AmphContext#DISABLED} until an executor installs a live context via {@link
+   * #setAmphContext(AmphContext)}.
+   */
+  @Getter private AmphContext amphContext = AmphContext.DISABLED;
+
   /** Seeded RNG for deterministic AI decisions. Seeded via {@link #setSeed(long)}. */
   @Getter private Random rng = new Random();
 
   private AbstractProAi proAi;
   private GameData data;
   private GamePlayer player;
+
+  public void setAmphContext(final AmphContext ctx) {
+    this.amphContext = ctx != null ? ctx : AmphContext.DISABLED;
+  }
 
   /** Seeds the RNG used by AI subsystems for deterministic behaviour. */
   public void setSeed(final long seed) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/AmphContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/AmphContext.java
@@ -1,0 +1,53 @@
+package games.strategy.triplea.ai.pro.data;
+
+import games.strategy.engine.data.Unit;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Snapshot of the amphibious-movement state delivered from Map Room via the wire protocol.
+ *
+ * <p>Populated once per executor call from {@code WireStateApplier.apply()} and stored on {@link
+ * games.strategy.triplea.ai.pro.ProData} so Phase 2.4/2.5 AI subsystems can gate amphib planning on
+ * the toggle and query per-unit embarkation state without re-parsing the wire.
+ *
+ * <p>All sets are immutable. {@link #DISABLED} is the zero-cost sentinel for the toggle-off case —
+ * callers that only check {@link #isEnabled()} pay nothing when the rule is inactive.
+ */
+public final class AmphContext {
+
+  public static final AmphContext DISABLED = new AmphContext(false, Set.of(), Set.of());
+
+  private final boolean enabled;
+  private final Set<UUID> embarkedUnitIds;
+  private final Set<UUID> embarkedThisTurnUnitIds;
+
+  public AmphContext(
+      final boolean enabled,
+      final Set<UUID> embarkedUnitIds,
+      final Set<UUID> embarkedThisTurnUnitIds) {
+    this.enabled = enabled;
+    this.embarkedUnitIds = Set.copyOf(embarkedUnitIds);
+    this.embarkedThisTurnUnitIds = Set.copyOf(embarkedThisTurnUnitIds);
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public boolean isEmbarked(final Unit unit) {
+    return embarkedUnitIds.contains(unit.getId());
+  }
+
+  public boolean isEmbarkedThisTurn(final Unit unit) {
+    return embarkedThisTurnUnitIds.contains(unit.getId());
+  }
+
+  public Set<UUID> embarkedUnitIds() {
+    return embarkedUnitIds;
+  }
+
+  public Set<UUID> embarkedThisTurnUnitIds() {
+    return embarkedThisTurnUnitIds;
+  }
+}


### PR DESCRIPTION
Phase 2.2 of the amphib AI epic (map-room#2693) → triplea feat/amphib-no-transports. Closes map-room#2696.

(Replaces the misfired #118, which was accidentally opened from the already-merged 2.1 branch.)

- New `AmphContext` (game-core/pro/data): enabled toggle + immutable embarked/embarkedThisTurn UUID sets from the wire; DISABLED sentinel for toggle-off (zero behavior change).
- `ProData`: amphContext field (default DISABLED) + setAmphContext() so 2.4/2.5 can query embarkation without re-parsing wire.
- `WireStateApplier.apply()` returns AmphContext (buildAmphContext maps wire flags → UUID sets).
- PurchaseExecutor + NoncombatMoveExecutor install the AmphContext on proData after reinitialize (survives the ProData re-bind).
- WireStateApplierAmphTest: 5 cases (toggle on/off, staged-unit-in-embarked-only, freshly-embarked-in-both, non-embarked-in-neither, toggle-off doesn't alter GameData).

Local: full sidecar suite green. Awaiting triplea CI (authoritative).