### PR TITLE
fix(proai): apply harbor movement bonus in calculateAmphibRoutes

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -186,6 +186,11 @@ public final class ProMoveUtils {
       for (final Unit transport : amphibAttackMap.keySet()) {
         int movesLeft = transport.getMovementLeft().intValue();
         Territory transportTerritory = proData.getUnitTerritory(transport);
+        if (Matches.unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(
+                transportTerritory, player)
+            .test(transport)) {
+          movesLeft += 1;
+        }
         moves.newSequence();
 
         // Check if units are already loaded or not


### PR DESCRIPTION
## Root cause

`ProTerritoryManager.getUnitRange()` correctly adds +1 movement when a transport sits adjacent to a harbor facility. `calculateAmphibRoutes()` was reading `transport.getMovementLeft()` directly (raw = 2), producing a planning/execution mismatch:

- **Planner** saw movement = 3 → included Japan and Iwo Jima (3 hops from 26 SZ) in the attack set
- **Route executor** saw movement = 2 → `neighborDistanceFromEnd(25 SZ → Japan) = 3 > movesLeft = 2`, so no valid neighbor was selected, transport never moved
- **Unload guard** (from #94) then fired: `getNeighbors(26 SZ).contains(Japan)` = false → entire amphib plan silently dropped

## Fix

Mirror the same `unitCanBeGivenBonusMovementByFacilitiesInItsTerritory` check that `getUnitRange()` applies, immediately after the raw `movesLeft` read in `calculateAmphibRoutes`.

## Test

`ProHarborRangeTest` — both cases now pass:
- `transportInHarborSzCanReachJapanOrIwoJimaInOneTurn()` (was failing — now dispatches the unload at Japan)
- `transportWithoutHarborCannotReachJapanOrIwoJima()` (counter-regression — still passes)

Full `:game-app:game-core:test` green locally.

Closes map-room/map-room#2643

🤖 Generated with [Claude Code](https://claude.com/claude-code)