### PR TITLE
fix(proai): apply harbor movement bonus in calculateAmphibRoutes [integration]

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -186,6 +186,11 @@ public final class ProMoveUtils {
       for (final Unit transport : amphibAttackMap.keySet()) {
         int movesLeft = transport.getMovementLeft().intValue();
         Territory transportTerritory = proData.getUnitTerritory(transport);
+        if (Matches.unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(
+                transportTerritory, player)
+            .test(transport)) {
+          movesLeft += 1;
+        }
         moves.newSequence();
 
         // Check if units are already loaded or not


### PR DESCRIPTION
Cherry-pick of #120 into the amphib-no-transports integration branch so that Phase 2.2 PR #119 can pass CI.

See #120 for full description. The fix is identical — one-liner in `calculateAmphibRoutes` that mirrors `getUnitRange`'s harbor bonus check.

Full `:game-app:game-core:test` verified green locally on this commit.