### PR TITLE
feat(amphib-ai): Phase 2.3 — sea-bridging value flood for amphib staging zones

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProAmphUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProAmphUtils.java
@@ -1,0 +1,149 @@
+package games.strategy.triplea.ai.pro.util;
+
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.util.BreadthFirstSearch;
+import games.strategy.triplea.attachments.TerritoryAttachment;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Sea-bridging helpers for amphib-enabled value scoring (Phase 2.3).
+ *
+ * <p>Both methods are gated by the caller ({@link ProTerritoryValueUtils}) on {@code
+ * AmphContext.isEnabled()} — callers must not invoke these methods when the amphib toggle is off.
+ */
+@UtilityClass
+public final class ProAmphUtils {
+
+  /** Maximum sea-hop depth searched when scoring amphib reachability. */
+  static final int MAX_SEA_HOPS = 4;
+
+  /**
+   * Returns the maximum connected land-mass size when sea zones act as one-hop bridges between land
+   * territories. Canal-aware.
+   *
+   * <p>The BFS expands through both land and sea territories; only land territories are counted.
+   * Used as the normalisation denominator in {@link ProTerritoryValueUtils#findTerritoryValues} so
+   * that amphib value contributions scale consistently across different map sizes.
+   */
+  public static int findMaxLandMassSizeSeaBridging(final GamePlayer player) {
+    final Set<Territory> visitedLand = new HashSet<>();
+    int maxSize = 1;
+
+    for (final Territory t : player.getData().getMap().getTerritories()) {
+      if (!t.isWater() && !visitedLand.contains(t)) {
+        final int[] size = {0};
+        new BreadthFirstSearch(
+                List.of(t),
+                (from, to) -> {
+                  if (!to.isWater()) {
+                    return ProMatches.territoryCanPotentiallyMoveLandUnits(player).test(to);
+                  }
+                  // land→sea or sea→sea: allow passable sea zones, canal-aware
+                  return ProMatches.territoryCanMoveSeaUnits(player, true).test(to)
+                      && ProMatches.noCanalsBetweenTerritories(player).test(from, to);
+                })
+            .traverse(
+                (territory, distance) -> {
+                  if (!territory.isWater()) {
+                    visitedLand.add(territory);
+                    size[0]++;
+                  }
+                  return true; // no depth limit — full connectivity
+                });
+        if (size[0] > maxSize) {
+          maxSize = size[0];
+        }
+      }
+    }
+    return maxSize;
+  }
+
+  /**
+   * For a staging sea zone, returns the weighted value of enemy land territories reachable by
+   * amphib movement from that zone.
+   *
+   * <p>BFS expands through sea zones (canal-aware, up to {@link #MAX_SEA_HOPS}). For each enemy
+   * land territory adjacent to any visited sea zone the value is:
+   *
+   * <pre>landValue / 2^(seaHops + 1)</pre>
+   *
+   * where {@code seaHops} is the number of sea-zone hops from {@code seaZone} to the sea zone
+   * adjacent to the enemy land territory. The {@code +1} accounts for the final land-unload hop.
+   * Each enemy territory is counted at most once (nearest sea zone wins).
+   *
+   * @param seaZone starting staging sea zone
+   * @param player the moving player
+   * @param enemyCapitalsAndFactoriesMap pre-computed capital/factory values (from
+   *     ProTerritoryValueUtils)
+   * @param territoriesThatCantBeHeld territories excluded from the enemy check
+   * @param territoriesToAttack territories already committed to attack (excluded from scoring)
+   * @return raw weighted sum; caller is responsible for normalisation
+   */
+  public static double findAmphReachableLandValue(
+      final Territory seaZone,
+      final GamePlayer player,
+      final Map<Territory, Double> enemyCapitalsAndFactoriesMap,
+      final List<Territory> territoriesThatCantBeHeld,
+      final List<Territory> territoriesToAttack) {
+
+    if (!seaZone.isWater()) {
+      return 0.0;
+    }
+
+    final double[] totalValue = {0.0};
+    final Set<Territory> countedLand = new HashSet<>();
+
+    // BreadthFirstSearch never calls the visitor for the starting territory, so score land
+    // adjacent to seaZone itself (seaDistance = 0, formula = val / 2^1) manually.
+    for (final Territory adj : player.getData().getMap().getNeighbors(seaZone)) {
+      if (!adj.isWater()
+          && !countedLand.contains(adj)
+          && !territoriesToAttack.contains(adj)
+          && ProMatches.territoryIsEnemyOrCantBeHeld(player, territoriesThatCantBeHeld).test(adj)) {
+        final double val =
+            enemyCapitalsAndFactoriesMap.containsKey(adj)
+                ? enemyCapitalsAndFactoriesMap.get(adj)
+                : TerritoryAttachment.getProduction(adj);
+        if (val > 0) {
+          totalValue[0] += val / 2.0;
+          countedLand.add(adj);
+        }
+      }
+    }
+
+    new BreadthFirstSearch(
+            List.of(seaZone),
+            (from, to) ->
+                to.isWater()
+                    && ProMatches.territoryCanMoveSeaUnits(player, true).test(to)
+                    && ProMatches.noCanalsBetweenTerritories(player).test(from, to))
+        .traverse(
+            (territory, seaDistance) -> {
+              // Accumulate enemy land adjacent to this sea zone
+              for (final Territory adj : player.getData().getMap().getNeighbors(territory)) {
+                if (!adj.isWater()
+                    && !countedLand.contains(adj)
+                    && !territoriesToAttack.contains(adj)
+                    && ProMatches.territoryIsEnemyOrCantBeHeld(player, territoriesThatCantBeHeld)
+                        .test(adj)) {
+                  final double val =
+                      enemyCapitalsAndFactoriesMap.containsKey(adj)
+                          ? enemyCapitalsAndFactoriesMap.get(adj)
+                          : TerritoryAttachment.getProduction(adj);
+                  if (val > 0) {
+                    totalValue[0] += val / Math.pow(2, seaDistance + 1);
+                    countedLand.add(adj);
+                  }
+                }
+              }
+              return seaDistance < MAX_SEA_HOPS;
+            });
+
+    return totalValue[0];
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.util.BreadthFirstSearch;
 import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.AmphContext;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import java.util.ArrayList;
@@ -109,6 +110,12 @@ public final class ProTerritoryValueUtils {
       final List<Territory> territoriesToAttack,
       final Set<Territory> territoriesToCheck) {
     final int maxLandMassSize = findMaxLandMassSize(player);
+    final AmphContext amphContext = proData.getAmphContext();
+    // Compute the sea-bridging land-mass size once; used to normalise amphib contributions below.
+    final int seaBridgingMaxLandMassSize =
+        amphContext.isEnabled()
+            ? ProAmphUtils.findMaxLandMassSizeSeaBridging(player)
+            : maxLandMassSize; // won't be used when toggle is off
     final Map<Territory, Double> enemyCapitalsAndFactoriesMap =
         findEnemyCapitalsAndFactoriesValue(
             player, maxLandMassSize, territoriesThatCantBeHeld, territoriesToAttack);
@@ -137,6 +144,8 @@ public final class ProTerritoryValueUtils {
                 t,
                 player,
                 maxLandMassSize,
+                amphContext,
+                seaBridgingMaxLandMassSize,
                 enemyCapitalsAndFactoriesMap,
                 territoriesThatCantBeHeld,
                 territoriesToAttack,
@@ -399,6 +408,8 @@ public final class ProTerritoryValueUtils {
       final Territory t,
       final GamePlayer player,
       final int maxLandMassSize,
+      final AmphContext amphContext,
+      final int seaBridgingMaxLandMassSize,
       final Map<Territory, Double> enemyCapitalsAndFactoriesMap,
       final List<Territory> territoriesThatCantBeHeld,
       final List<Territory> territoriesToAttack,
@@ -484,6 +495,22 @@ public final class ProTerritoryValueUtils {
       }
     }
 
+    // Amphib extension: when the toggle is on, boost staging sea zones by the value of enemy land
+    // reachable via amphib movement (BFS through sea zones, canal-aware).  The raw value is
+    // normalised by seaBridgingMaxLandMassSize so it scales consistently with the land-mass ratios
+    // used elsewhere in the scoring.
+    if (amphContext.isEnabled()) {
+      final double amphLandValue =
+          ProAmphUtils.findAmphReachableLandValue(
+              t,
+              player,
+              enemyCapitalsAndFactoriesMap,
+              territoriesThatCantBeHeld,
+              territoriesToAttack);
+      return capitalOrFactoryValue / 100
+          + nearbyLandValue / 10
+          + amphLandValue / seaBridgingMaxLandMassSize;
+    }
     return capitalOrFactoryValue / 100 + nearbyLandValue / 10;
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphUtilsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphUtilsTest.java
@@ -1,0 +1,274 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.player.PlayerBridge;
+import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.ai.pro.data.AmphContext;
+import games.strategy.triplea.attachments.TerritoryAttachment;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Tests for {@link ProAmphUtils} — Phase 2.3 sea-bridging value helpers.
+ *
+ * <p>All tests use G40 Pacific geography (26 Sea Zone / Hawaiian Islands harbour / Japan).
+ */
+public class ProAmphUtilsTest {
+
+  private static final String SEA_ZONE_6 = "6 Sea Zone";
+  private static final String SEA_ZONE_26 = "26 Sea Zone";
+
+  /** Atlantic zone (east US coast) — no Japanese territory within MAX_SEA_HOPS. */
+  private static final String SEA_ZONE_101 = "101 Sea Zone";
+
+  private static final String JAPAN = "Japan";
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer japanese;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    japanese = data.getPlayerList().getPlayerId("Japanese");
+    declareWar(americans, japanese);
+  }
+
+  // --- findMaxLandMassSizeSeaBridging ---
+
+  @Test
+  void seaBridgingLandMassSizeAtLeastAsLargeAsLandOnly() {
+    final int landOnly = ProTerritoryValueUtils.findMaxLandMassSize(americans);
+    final int seaBridging = ProAmphUtils.findMaxLandMassSizeSeaBridging(americans);
+    assertThat(seaBridging)
+        .as("sea bridging connects island groups that are land-isolated, so result ≥ land-only")
+        .isGreaterThanOrEqualTo(landOnly);
+  }
+
+  @Test
+  void seaBridgingLandMassSizeIsPositive() {
+    assertThat(ProAmphUtils.findMaxLandMassSizeSeaBridging(americans)).isGreaterThan(0);
+  }
+
+  // --- findAmphReachableLandValue ---
+
+  @Test
+  void stagingZoneAdjacentToEnemyIslandScoresPositive() {
+    // 6 Sea Zone is directly adjacent to Japan; with Japan in the enemy map the score must be > 0.
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+
+    final Map<Territory, Double> enemyMap = Map.of(japan, 30.0);
+    final double value =
+        ProAmphUtils.findAmphReachableLandValue(sz6, americans, enemyMap, List.of(), List.of());
+
+    assertThat(value)
+        .as("6 Sea Zone adjacent to Japan must score > 0 when Japan is in the enemy map")
+        .isGreaterThan(0.0);
+  }
+
+  @Test
+  void stagingZoneAdjacentToEnemyIslandScoresHalfEnemyValue() {
+    // Japan is adjacent to 6 Sea Zone (seaDistance=0). The formula gives val/2^(0+1) = val/2.
+    // Other territories (Korea, Okinawa, etc.) contribute the same amount regardless of whether
+    // Japan uses the map value or the production fallback, so we isolate Japan's contribution
+    // by computing the DIFFERENCE between "Japan uses map value" and "Japan uses production".
+    // Expected delta = (japanMapValue - japanProd) / 2^1.
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+
+    final double japanMapValue = 20.0;
+    final double scoreWithMap =
+        ProAmphUtils.findAmphReachableLandValue(
+            sz6, americans, Map.of(japan, japanMapValue), List.of(), List.of());
+    final double scoreWithProduction =
+        ProAmphUtils.findAmphReachableLandValue(sz6, americans, Map.of(), List.of(), List.of());
+
+    final double expectedDelta = (japanMapValue - TerritoryAttachment.getProduction(japan)) / 2.0;
+    assertThat(scoreWithMap - scoreWithProduction)
+        .as(
+            "Japan's extra map-value contribution (map − production) / 2 must equal"
+                + " (%.1f − %d) / 2 = %.3f",
+            japanMapValue, TerritoryAttachment.getProduction(japan), expectedDelta)
+        .isCloseTo(expectedDelta, within(0.001));
+  }
+
+  @Test
+  void morDistantStagingZoneScoresLessOrEqualToAdjacentZone() {
+    // 26 Sea Zone is several hops from Japan; 6 Sea Zone is adjacent.
+    // The distant SZ can still score > 0 if Japan is within MAX_SEA_HOPS, but must be ≤ 6 SZ.
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory sz26 = data.getMap().getTerritoryOrThrow(SEA_ZONE_26);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+
+    final Map<Territory, Double> enemyMap = Map.of(japan, 30.0);
+    final double score6 =
+        ProAmphUtils.findAmphReachableLandValue(sz6, americans, enemyMap, List.of(), List.of());
+    final double score26 =
+        ProAmphUtils.findAmphReachableLandValue(sz26, americans, enemyMap, List.of(), List.of());
+
+    assertThat(score6)
+        .as("6 Sea Zone (adjacent to Japan) must score more than 26 Sea Zone (3+ hops)")
+        .isGreaterThan(score26);
+  }
+
+  @Test
+  void distantStagingZoneScoresPositiveWhenEnemyWithinMaxHops() {
+    // 26 SZ to Japan is 3 sea hops + 1 land hop = 4 total; MAX_SEA_HOPS=4, so Japan is reachable.
+    final Territory sz26 = data.getMap().getTerritoryOrThrow(SEA_ZONE_26);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+
+    final Map<Territory, Double> enemyMap = Map.of(japan, 30.0);
+    final double score =
+        ProAmphUtils.findAmphReachableLandValue(sz26, americans, enemyMap, List.of(), List.of());
+
+    assertThat(score)
+        .as("26 Sea Zone must score > 0; Japan is within MAX_SEA_HOPS (3 sea hops from 26 SZ)")
+        .isGreaterThan(0.0);
+  }
+
+  @Test
+  void alreadyAttackedTerritoriesAreExcludedFromScore() {
+    // Japan is adjacent to 6 SZ (seaDistance=0), contributing japanValue/2.
+    // Excluding Japan via territoriesToAttack must reduce the score by exactly that amount.
+    // Other territories (Korea, Okinawa…) are unaffected, so the difference is precise.
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+
+    final double japanValue = 30.0;
+    final Map<Territory, Double> enemyMap = Map.of(japan, japanValue);
+    final double scoreAll =
+        ProAmphUtils.findAmphReachableLandValue(sz6, americans, enemyMap, List.of(), List.of());
+    final double scoreExcluded =
+        ProAmphUtils.findAmphReachableLandValue(
+            sz6, americans, enemyMap, List.of(), List.of(japan));
+
+    assertThat(scoreAll - scoreExcluded)
+        .as("excluding Japan from territoriesToAttack must reduce score by exactly japanValue/2")
+        .isCloseTo(japanValue / 2.0, within(0.001));
+  }
+
+  @Test
+  void landTerritoryInputReturnsZero() {
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+    final Map<Territory, Double> enemyMap = Map.of(japan, 30.0);
+    assertThat(
+            ProAmphUtils.findAmphReachableLandValue(
+                japan, americans, enemyMap, List.of(), List.of()))
+        .as("land territory input must return 0 (not a valid staging sea zone)")
+        .isEqualTo(0.0);
+  }
+
+  @Test
+  void atlanticZoneWithNoReachableEnemyLandScoresZero() {
+    // 101 Sea Zone is on the US east coast (Atlantic). No Japanese territory is reachable within
+    // MAX_SEA_HOPS sea hops, so score must be 0 regardless of enemyMap content.
+    final Territory sz101 = data.getMap().getTerritoryOrThrow(SEA_ZONE_101);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+    assertThat(
+            ProAmphUtils.findAmphReachableLandValue(
+                sz101, americans, Map.of(japan, 30.0), List.of(), List.of()))
+        .as("101 Sea Zone (Atlantic, east US coast) has no Japanese territory within MAX_SEA_HOPS")
+        .isEqualTo(0.0);
+  }
+
+  // --- integration: toggle gate in findTerritoryValues ---
+
+  @Test
+  void waterValueToggleOffMatchesBaselineWhenNoAmphib() {
+    // With AmphContext.DISABLED, findTerritoryValues must not add any amphib contribution.
+    // We verify by checking that the water territory value is identical when computed via
+    // ProAi (which seeds proData.amphContext = DISABLED by default).
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+
+    // Clear irrelevant units for a stable test state
+    for (final Territory t : data.getMap().getTerritories()) {
+      data.performChange(ChangeFactory.removeUnits(t, t.getUnits()));
+    }
+
+    final ProAi proAi = new ProAi("Test", "Americans AI");
+    final PlayerBridge bridge = mock(PlayerBridge.class);
+    proAi.initialize(bridge, americans);
+    when(bridge.getGameData()).thenReturn(data);
+    // proData.initialize() is called by game-phase methods, not by initialize() itself.
+    // Call reinitializeProDataForSidecar() to wire proData.data = game data before using proData.
+    proAi.reinitializeProDataForSidecar();
+
+    // amphContext defaults to DISABLED — no extra amphib contribution
+    assertThat(proAi.getProData().getAmphContext().isEnabled()).isFalse();
+
+    final Map<Territory, Double> disabledValues =
+        ProTerritoryValueUtils.findTerritoryValues(
+            proAi.getProData(), americans, List.of(), List.of(), Set.of(sz6));
+
+    // Now enable amphib and compute again
+    proAi.getProData().setAmphContext(new AmphContext(true, Set.of(), Set.of()));
+    final Map<Territory, Double> enabledValues =
+        ProTerritoryValueUtils.findTerritoryValues(
+            proAi.getProData(), americans, List.of(), List.of(), Set.of(sz6));
+
+    // With Japan as enemy, amphib-enabled value must be >= disabled value (never reduces)
+    assertThat(enabledValues.get(sz6))
+        .as("amphib-enabled water value must be >= disabled value")
+        .isGreaterThanOrEqualTo(disabledValues.get(sz6));
+  }
+
+  @Test
+  void waterValueAmphEnablingAddsPositiveContributionNearEnemyLand() {
+    // Verify that staging SZ adjacent to Japan scores strictly higher with amphib enabled.
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+
+    // Clear units for a clean slate
+    for (final Territory t : data.getMap().getTerritories()) {
+      data.performChange(ChangeFactory.removeUnits(t, t.getUnits()));
+    }
+
+    final ProAi proAi = new ProAi("Test", "Americans AI");
+    final PlayerBridge bridge = mock(PlayerBridge.class);
+    proAi.initialize(bridge, americans);
+    when(bridge.getGameData()).thenReturn(data);
+    proAi.reinitializeProDataForSidecar();
+
+    final Map<Territory, Double> disabledValues =
+        ProTerritoryValueUtils.findTerritoryValues(
+            proAi.getProData(), americans, List.of(), List.of(), Set.of(sz6));
+
+    proAi.getProData().setAmphContext(new AmphContext(true, Set.of(), Set.of()));
+    final Map<Territory, Double> enabledValues =
+        ProTerritoryValueUtils.findTerritoryValues(
+            proAi.getProData(), americans, List.of(), List.of(), Set.of(sz6));
+
+    assertThat(enabledValues.get(sz6))
+        .as(
+            "6 Sea Zone (adjacent to enemy Japan) must score strictly higher with amphib enabled"
+                + " than without — this is the linchpin of Phase 2.3")
+        .isGreaterThan(disabledValues.get(sz6));
+  }
+
+  // ---- helpers ----
+
+  private void declareWar(final GamePlayer p1, final GamePlayer p2) {
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            p1,
+            p2,
+            data.getRelationshipTracker().getRelationshipType(p1, p2),
+            data.getRelationshipTypeList().getRelationshipType("War")));
+  }
+}


### PR DESCRIPTION
## Summary

- **`ProAmphUtils` (new)**: `findAmphReachableLandValue` scores a staging sea zone by BFS-ing through sea zones (canal-aware, up to `MAX_SEA_HOPS=4`) and summing enemy land values weighted by `val / 2^(seaHops+1)`. The starting zone's land neighbours are scored manually at `seaDistance=0` since `BreadthFirstSearch.traverse()` never visits the starting territory. `findMaxLandMassSizeSeaBridging` extends the land-mass BFS to cross sea zones for normalisation.
- **`ProTerritoryValueUtils` (modified)**: `findWaterValue` gains a third term `amphLandValue / seaBridgingMaxLandMassSize` gated on `AmphContext.isEnabled()`; toggle-off path is byte-identical to baseline.
- **`ProAmphUtilsTest` (new)**: 11 tests — positive staging score, distance-halving formula (isolated via difference method), exclusion precision, Atlantic zero-score, sea-bridging land mass, and integration toggle gate.

## Key design note — seaDistance=0 manual pass

`BreadthFirstSearch.traverse()` calls the visitor for *neighbours* of the starting territory, not for the starting territory itself (documented in the class Javadoc). Land territories adjacent directly to the staging sea zone (`seaDistance=0`, formula `val/2`) must be scored in a separate pre-BFS loop.

## Test plan

- [x] `ProAmphUtilsTest` — 11/11 pass
- [x] Full `game-core:test` — BUILD SUCCESSFUL
- [x] `ai-sidecar:test` — BUILD SUCCESSFUL
- [x] `spotlessApply` — clean

Closes #2701

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>