### PR TITLE
feat(amphib-ai): Phase 2.4 — CM assault (1-hop adjacent-hostile invasion) + canal test

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.ai.pro.data.AmphContext;
 import games.strategy.triplea.ai.pro.data.ProBattleResult;
 import games.strategy.triplea.ai.pro.data.ProOtherMoveOptions;
 import games.strategy.triplea.ai.pro.data.ProPurchaseOption;
@@ -79,6 +80,25 @@ public class ProCombatMoveAi {
 
     // Find the maximum number of units that can attack each territory and max enemy defenders
     territoryManager.populateAttackOptions();
+
+    // With the amphib toggle on, inject embarked-unit assault targets that the normal transport
+    // pathway cannot discover (units are land units in sea zones, not on physical transports).
+    if (proData.getAmphContext().isEnabled()) {
+      final Map<Territory, List<Unit>> assaultOptions = findAmphAssaultOptions();
+      final Map<Territory, ProTerritory> attackMap =
+          territoryManager.getAttackOptions().getTerritoryMap();
+      final Map<Unit, Set<Territory>> unitMoveMap =
+          territoryManager.getAttackOptions().getUnitMoveMap();
+      for (final Map.Entry<Territory, List<Unit>> entry : assaultOptions.entrySet()) {
+        final Territory coast = entry.getKey();
+        final ProTerritory proT = proData.getProTerritory(attackMap, coast);
+        proT.addMaxUnits(entry.getValue());
+        for (final Unit u : entry.getValue()) {
+          unitMoveMap.computeIfAbsent(u, k -> new HashSet<>()).add(coast);
+        }
+      }
+    }
+
     territoryManager.populateEnemyDefenseOptions();
 
     // Remove territories that aren't worth attacking and prioritize the remaining ones
@@ -161,6 +181,8 @@ public class ProCombatMoveAi {
         proData, ProMoveUtils.calculateMoveRoutes(proData, player, attackMap, true), moveDel);
     ProMoveUtils.doMove(
         proData, ProMoveUtils.calculateAmphibRoutes(proData, player, attackMap, true), moveDel);
+    ProMoveUtils.doMove(
+        proData, ProMoveUtils.calculateAmphAssaultRoutes(proData, attackMap), moveDel);
     ProMoveUtils.doMove(
         proData, ProMoveUtils.calculateBombardMoveRoutes(proData, player, attackMap), moveDel);
     isBombing = true;
@@ -1608,128 +1630,132 @@ public class ProCombatMoveAi {
       }
     }
 
-    // Loop through all my transports and see which can make amphib attack
-    final Map<Unit, Set<Territory>> amphibAttackOptions = new HashMap<>();
-    for (final ProTransport proTransportData : transportMapList) {
+    // --- Transport-based amphib attack (disabled when AmphContext toggle is on) ---
+    if (!proData.getAmphContext().isEnabled()) {
+      // Loop through all my transports and see which can make amphib attack
+      final Map<Unit, Set<Territory>> amphibAttackOptions = new HashMap<>();
+      for (final ProTransport proTransportData : transportMapList) {
 
-      // If already used to attack then ignore
-      if (alreadyAttackedWithTransports.contains(proTransportData.getTransport())) {
-        continue;
-      }
+        // If already used to attack then ignore
+        if (alreadyAttackedWithTransports.contains(proTransportData.getTransport())) {
+          continue;
+        }
 
-      // Find number of attack options
-      final Set<Territory> canAmphibAttackTerritories = new HashSet<>();
-      for (final ProTerritory attackTerritoryData : prioritizedTerritories) {
-        if (proTransportData.getTransportMap().containsKey(attackTerritoryData.getTerritory())) {
-          canAmphibAttackTerritories.add(attackTerritoryData.getTerritory());
+        // Find number of attack options
+        final Set<Territory> canAmphibAttackTerritories = new HashSet<>();
+        for (final ProTerritory attackTerritoryData : prioritizedTerritories) {
+          if (proTransportData.getTransportMap().containsKey(attackTerritoryData.getTerritory())) {
+            canAmphibAttackTerritories.add(attackTerritoryData.getTerritory());
+          }
+        }
+        if (!canAmphibAttackTerritories.isEmpty()) {
+          amphibAttackOptions.put(proTransportData.getTransport(), canAmphibAttackTerritories);
         }
       }
-      if (!canAmphibAttackTerritories.isEmpty()) {
-        amphibAttackOptions.put(proTransportData.getTransport(), canAmphibAttackTerritories);
-      }
-    }
 
-    // Loop through transports with amphib attack options and determine if any land battle needs it
-    for (final Map.Entry<Unit, Set<Territory>> amphibAttackOptionsEntry :
-        amphibAttackOptions.entrySet()) {
-      final Unit transport = amphibAttackOptionsEntry.getKey();
-      // Find current land battle results for territories that unit can amphib attack
-      Territory minWinTerritory = null;
-      double minWinPercentage = proData.getWinPercentage();
-      List<Unit> minAmphibUnitsToAdd = null;
-      Territory minUnloadFromTerritory = null;
-      for (final Territory t : amphibAttackOptionsEntry.getValue()) {
-        final ProTerritory patd = attackMap.get(t);
-        if (!patd.isCurrentlyWins()) {
-          if (patd.getBattleResult() == null) {
-            patd.estimateBattleResult(calc, player);
-          }
-          final ProBattleResult result = patd.getBattleResult();
-          if (result.getWinPercentage() < minWinPercentage
-              || (!result.isHasLandUnitRemaining() && minWinTerritory == null)) {
+      // Loop through transports with amphib attack options and determine if any land battle needs
+      // it
+      for (final Map.Entry<Unit, Set<Territory>> amphibAttackOptionsEntry :
+          amphibAttackOptions.entrySet()) {
+        final Unit transport = amphibAttackOptionsEntry.getKey();
+        // Find current land battle results for territories that unit can amphib attack
+        Territory minWinTerritory = null;
+        double minWinPercentage = proData.getWinPercentage();
+        List<Unit> minAmphibUnitsToAdd = null;
+        Territory minUnloadFromTerritory = null;
+        for (final Territory t : amphibAttackOptionsEntry.getValue()) {
+          final ProTerritory patd = attackMap.get(t);
+          if (!patd.isCurrentlyWins()) {
+            if (patd.getBattleResult() == null) {
+              patd.estimateBattleResult(calc, player);
+            }
+            final ProBattleResult result = patd.getBattleResult();
+            if (result.getWinPercentage() < minWinPercentage
+                || (!result.isHasLandUnitRemaining() && minWinTerritory == null)) {
 
-            // Find units that haven't attacked and can be transported
-            final Set<Unit> alreadyAttackedWithUnits =
-                ProTransportUtils.getMovedUnits(alreadyMovedUnits, attackMap);
-            for (final ProTransport proTransportData : transportMapList) {
-              if (proTransportData.getTransport().equals(transport)) {
+              // Find units that haven't attacked and can be transported
+              final Set<Unit> alreadyAttackedWithUnits =
+                  ProTransportUtils.getMovedUnits(alreadyMovedUnits, attackMap);
+              for (final ProTransport proTransportData : transportMapList) {
+                if (proTransportData.getTransport().equals(transport)) {
 
-                // Find units to load
-                final Set<Territory> territoriesCanLoadFrom =
-                    proTransportData.getTransportMap().get(t);
-                final List<Unit> amphibUnitsToAdd =
-                    ProTransportUtils.getUnitsToTransportFromTerritories(
-                        player, transport, territoriesCanLoadFrom, alreadyAttackedWithUnits);
-                if (amphibUnitsToAdd.isEmpty()) {
-                  continue;
-                }
+                  // Find units to load
+                  final Set<Territory> territoriesCanLoadFrom =
+                      proTransportData.getTransportMap().get(t);
+                  final List<Unit> amphibUnitsToAdd =
+                      ProTransportUtils.getUnitsToTransportFromTerritories(
+                          player, transport, territoriesCanLoadFrom, alreadyAttackedWithUnits);
+                  if (amphibUnitsToAdd.isEmpty()) {
+                    continue;
+                  }
 
-                // Find the best territory to move transport
-                double minStrengthDifference = Double.POSITIVE_INFINITY;
-                minUnloadFromTerritory = null;
-                final Set<Territory> territoriesToMoveTransport =
-                    data.getMap()
-                        .getNeighbors(t, ProMatches.territoryCanMoveSeaUnits(player, false));
-                final Set<Territory> loadFromTerritories = new HashSet<>();
-                for (final Unit u : amphibUnitsToAdd) {
-                  loadFromTerritories.add(proData.getUnitTerritory(u));
-                }
-                for (final Territory destination : territoriesToMoveTransport) {
-                  if (proTransportData.getSeaTransportMap().containsKey(destination)
-                      && proTransportData
-                          .getSeaTransportMap()
-                          .get(destination)
-                          .containsAll(loadFromTerritories)) {
-                    Set<Unit> attackers = Set.of();
-                    if (enemyAttackOptions.getMax(destination) != null) {
-                      attackers = enemyAttackOptions.getMax(destination).getMaxUnits();
-                    }
-                    final List<Unit> defenders =
-                        destination.getMatches(Matches.isUnitAllied(player));
-                    defenders.add(transport);
-                    final double strengthDifference =
-                        ProBattleUtils.estimateStrengthDifference(
-                            destination, attackers, defenders);
-                    if (strengthDifference <= minStrengthDifference) {
-                      minStrengthDifference = strengthDifference;
-                      minUnloadFromTerritory = destination;
+                  // Find the best territory to move transport
+                  double minStrengthDifference = Double.POSITIVE_INFINITY;
+                  minUnloadFromTerritory = null;
+                  final Set<Territory> territoriesToMoveTransport =
+                      data.getMap()
+                          .getNeighbors(t, ProMatches.territoryCanMoveSeaUnits(player, false));
+                  final Set<Territory> loadFromTerritories = new HashSet<>();
+                  for (final Unit u : amphibUnitsToAdd) {
+                    loadFromTerritories.add(proData.getUnitTerritory(u));
+                  }
+                  for (final Territory destination : territoriesToMoveTransport) {
+                    if (proTransportData.getSeaTransportMap().containsKey(destination)
+                        && proTransportData
+                            .getSeaTransportMap()
+                            .get(destination)
+                            .containsAll(loadFromTerritories)) {
+                      Set<Unit> attackers = Set.of();
+                      if (enemyAttackOptions.getMax(destination) != null) {
+                        attackers = enemyAttackOptions.getMax(destination).getMaxUnits();
+                      }
+                      final List<Unit> defenders =
+                          destination.getMatches(Matches.isUnitAllied(player));
+                      defenders.add(transport);
+                      final double strengthDifference =
+                          ProBattleUtils.estimateStrengthDifference(
+                              destination, attackers, defenders);
+                      if (strengthDifference <= minStrengthDifference) {
+                        minStrengthDifference = strengthDifference;
+                        minUnloadFromTerritory = destination;
+                      }
                     }
                   }
+                  minWinTerritory = t;
+                  minWinPercentage = result.getWinPercentage();
+                  minAmphibUnitsToAdd = amphibUnitsToAdd;
+                  break;
                 }
-                minWinTerritory = t;
-                minWinPercentage = result.getWinPercentage();
-                minAmphibUnitsToAdd = amphibUnitsToAdd;
-                break;
               }
             }
           }
         }
+        if (minWinTerritory != null) {
+          if (minUnloadFromTerritory != null) {
+            attackMap
+                .get(minWinTerritory)
+                .getTransportTerritoryMap()
+                .put(transport, minUnloadFromTerritory);
+          }
+          attackMap.get(minWinTerritory).addUnits(minAmphibUnitsToAdd);
+          attackMap.get(minWinTerritory).putAmphibAttackMap(transport, minAmphibUnitsToAdd);
+          attackMap.get(minWinTerritory).setBattleResult(null);
+          for (final Unit unit : minAmphibUnitsToAdd) {
+            sortedUnitAttackOptions.remove(unit);
+          }
+          if (!minWinTerritory.equals(prevAmphibAssignments.get(transport))) {
+            ProLogger.trace(
+                "Adding amphibious attack to "
+                    + minWinTerritory
+                    + ", units="
+                    + minAmphibUnitsToAdd.size()
+                    + ", unloadFrom="
+                    + minUnloadFromTerritory);
+            prevAmphibAssignments.put(transport, minWinTerritory);
+          }
+        }
       }
-      if (minWinTerritory != null) {
-        if (minUnloadFromTerritory != null) {
-          attackMap
-              .get(minWinTerritory)
-              .getTransportTerritoryMap()
-              .put(transport, minUnloadFromTerritory);
-        }
-        attackMap.get(minWinTerritory).addUnits(minAmphibUnitsToAdd);
-        attackMap.get(minWinTerritory).putAmphibAttackMap(transport, minAmphibUnitsToAdd);
-        attackMap.get(minWinTerritory).setBattleResult(null);
-        for (final Unit unit : minAmphibUnitsToAdd) {
-          sortedUnitAttackOptions.remove(unit);
-        }
-        if (!minWinTerritory.equals(prevAmphibAssignments.get(transport))) {
-          ProLogger.trace(
-              "Adding amphibious attack to "
-                  + minWinTerritory
-                  + ", units="
-                  + minAmphibUnitsToAdd.size()
-                  + ", unloadFrom="
-                  + minUnloadFromTerritory);
-          prevAmphibAssignments.put(transport, minWinTerritory);
-        }
-      }
-    }
+    } // end !amphContext.isEnabled()
 
     // Get all units that have already moved
     final Set<Unit> alreadyAttackedWithUnits = new HashSet<>();
@@ -2060,5 +2086,48 @@ public class ProCombatMoveAi {
                 ProMatches.territoryCanMoveAirUnitsAndNoAa(data, player, true));
     final boolean usesMoreThanHalfOfRange = distance > range / 2;
     return isAdjacentToAlliedFactory || !usesMoreThanHalfOfRange;
+  }
+
+  /**
+   * Returns amphib assault candidates for the current player when {@link AmphContext} is enabled.
+   *
+   * <p>A unit qualifies as "staged" when it is: owned by the player, a land unit, marked as
+   * embarked in the current {@code AmphContext}, and NOT marked as embarked this turn. The
+   * "embarked this turn" guard ensures units that just loaded during NCM cannot immediately assault
+   * in the same CM phase.
+   *
+   * <p>Only ADJACENT hostile coasts are returned (1-hop = combat-legal unload range). No multi-hop
+   * CM moves are generated.
+   *
+   * @return map of coastal land territory → list of staged units that can assault it
+   */
+  private Map<Territory, List<Unit>> findAmphAssaultOptions() {
+    final AmphContext ctx = proData.getAmphContext();
+    final Map<Territory, List<Unit>> options = new HashMap<>();
+
+    for (final Territory sz : data.getMap().getTerritories()) {
+      if (!sz.isWater()) {
+        continue;
+      }
+      // Land units in this sea zone that are staged (embarked, not embarked this turn)
+      final List<Unit> staged =
+          sz.getMatches(
+              u ->
+                  u.isOwnedBy(player)
+                      && Matches.unitIsLand().test(u)
+                      && ctx.isEmbarked(u)
+                      && !ctx.isEmbarkedThisTurn(u));
+      if (staged.isEmpty()) {
+        continue;
+      }
+      // Collect adjacent hostile coasts (1 hop only)
+      for (final Territory adj : data.getMap().getNeighbors(sz)) {
+        if (!adj.isWater()
+            && ProMatches.territoryIsEnemyOrCantBeHeld(player, List.of()).test(adj)) {
+          options.computeIfAbsent(adj, k -> new ArrayList<>()).addAll(staged);
+        }
+      }
+    }
+    return options;
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
@@ -205,7 +205,7 @@ public class ProTerritory {
     this.maxUnits.add(unit);
   }
 
-  void addMaxUnits(final List<Unit> units) {
+  public void addMaxUnits(final List<Unit> units) {
     this.maxUnits.addAll(units);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -108,6 +108,24 @@ public final class ProBattleUtils {
   }
 
   /**
+   * Estimates the strength difference for an amphib landing on a coastal territory.
+   *
+   * <p>Semantically identical to {@link #estimateStrengthDifference} — the named overload makes
+   * call sites self-documenting when the attacking units are embarked land units.
+   *
+   * @param coastTerritory the target coastal land territory
+   * @param landingUnits the embarked land units assaulting the coast
+   * @param defendingUnits the enemy defenders in {@code coastTerritory}
+   * @return see {@link #estimateStrengthDifference}
+   */
+  public static double estimateLandingStrengthDifference(
+      final Territory coastTerritory,
+      final Collection<Unit> landingUnits,
+      final Collection<Unit> defendingUnits) {
+    return estimateStrengthDifference(coastTerritory, landingUnits, defendingUnits);
+  }
+
+  /**
    * Estimates the strength of {@code myUnits} relative to {@code enemyUnits}.
    *
    * @return The larger the result, the stronger {@code myUnits} are relative to {@code enemyUnits}.

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -335,6 +335,61 @@ public final class ProMoveUtils {
   }
 
   /**
+   * Calculates amphib-assault unload routes for units staged via {@link
+   * games.strategy.triplea.ai.pro.data.AmphContext} (no physical transport).
+   *
+   * <p>An eligible unit is a land unit whose current territory is a water zone, and whose {@code
+   * AmphContext} marks it as embarked but NOT embarked this turn (so it may assault in CM). Only
+   * 1-hop routes (sea zone → adjacent coast territory) are emitted.
+   *
+   * <p>Land units in water zones are skipped by {@link #calculateMoveRoutes} and are absent from
+   * the amphib-attack-map processed by {@link #calculateAmphibRoutes}. This method is the only
+   * routing path for them.
+   *
+   * @param proData AI state (used for {@code AmphContext} and unit-territory lookup)
+   * @param attackMap territories selected for attack; assault units are found in {@code getUnits()}
+   *     of coastal entries
+   * @return list of 1-hop unload moves, empty when {@code AmphContext} is disabled
+   */
+  public static List<MoveDescription> calculateAmphAssaultRoutes(
+      final ProData proData, final Map<Territory, ProTerritory> attackMap) {
+
+    final var ctx = proData.getAmphContext();
+    if (!ctx.isEnabled()) {
+      return List.of();
+    }
+
+    final var moves = new ArrayList<MoveDescription>();
+    final var map = proData.getData().getMap();
+
+    for (final Territory coast : attackMap.keySet()) {
+      if (coast.isWater()) {
+        continue;
+      }
+      for (final Unit u : attackMap.get(coast).getUnits()) {
+        if (!Matches.unitIsLand().test(u)) {
+          continue;
+        }
+        final Territory start = proData.getUnitTerritory(u);
+        if (start == null || !start.isWater()) {
+          continue;
+        }
+        // Only emit when the unit is embarked and may assault in CM (not embarked this turn).
+        if (!ctx.isEmbarked(u) || ctx.isEmbarkedThisTurn(u)) {
+          continue;
+        }
+        // 1-hop only — staging sea zone must be adjacent to the target coast.
+        if (!map.getNeighbors(start).contains(coast)) {
+          continue;
+        }
+        moves.add(new MoveDescription(List.of(u), new Route(start, coast)));
+        ProLogger.trace("Amphib assault route: " + start.getName() + " -> " + coast.getName());
+      }
+    }
+    return moves;
+  }
+
+  /**
    * Calculates bombardment movement routes.
    *
    * @param attackMap Specifies the territories to be attacked.

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProCombatMoveAmphTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProCombatMoveAmphTest.java
@@ -1,0 +1,230 @@
+package games.strategy.triplea.ai.pro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.MoveDescription;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.player.PlayerBridge;
+import games.strategy.triplea.ai.pro.data.AmphContext;
+import games.strategy.triplea.ai.pro.logging.ProLogCapture;
+import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.delegate.remote.IMoveDelegate;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Tests for Phase 2.4 CM assault generation.
+ *
+ * <p>Verifies that {@code ProCombatMoveAi.findAmphAssaultOptions} correctly generates (and
+ * correctly withholds) 1-hop amphib assault moves based on {@link AmphContext} embarkation state.
+ *
+ * <p>Test map: G40 Pacific. Americans vs Japanese at war.
+ *
+ * <ul>
+ *   <li>6 Sea Zone — directly adjacent to Japan. Infantry staged there with {@code isEmbarked=true,
+ *       isEmbarkedThisTurn=false} must produce an assault move to Japan.
+ *   <li>Same setup but {@code isEmbarkedThisTurn=true} — must NOT produce a CM assault.
+ *   <li>26 Sea Zone — 3 sea hops from Japan. Infantry staged there is NOT adjacent to Japan, so no
+ *       direct CM assault on Japan is produced (only adjacent coasts qualify).
+ *   <li>Toggle off ({@link AmphContext#DISABLED}) — the amphib system is not invoked; no assault
+ *       from the new pathway, normal transport flow unchanged.
+ * </ul>
+ */
+public class ProCombatMoveAmphTest {
+
+  private static final String SEA_ZONE_6 = "6 Sea Zone";
+  private static final String SEA_ZONE_26 = "26 Sea Zone";
+  private static final String JAPAN = "Japan";
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer japanese;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    japanese = data.getPlayerList().getPlayerId("Japanese");
+    declareWar(americans, japanese);
+
+    // Clear all units for a clean slate; individual tests re-add what they need.
+    for (final Territory t : data.getMap().getTerritories()) {
+      data.performChange(ChangeFactory.removeUnits(t, t.getUnits()));
+    }
+  }
+
+  // --- staged unit proposes adjacent-hostile assault ---
+
+  @Test
+  void stagedUnitProposesAssaultOnAdjacentHostileCoast() {
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+
+    // One US infantry staged in 6 SZ — embarked and NOT embarked this turn.
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+
+    final AmphContext ctx =
+        new AmphContext(true, Set.of(infantry.getId()), Set.of() /* not embarked this turn */);
+
+    final List<MoveDescription> dispatched = runCombatMove(americans, ctx);
+
+    final boolean assaultToJapan =
+        dispatched.stream()
+            .anyMatch(
+                m ->
+                    m.getRoute().getStart().equals(sz6)
+                        && m.getRoute().getEnd().equals(japan)
+                        && m.getUnits().contains(infantry));
+
+    assertThat(assaultToJapan)
+        .as(
+            "Infantry staged in 6 Sea Zone (adjacent to Japan) with isEmbarked=true and "
+                + "isEmbarkedThisTurn=false must produce a combat assault move to Japan. "
+                + "Dispatched: "
+                + dispatched)
+        .isTrue();
+  }
+
+  // --- embarkedThisTurn unit does NOT produce a CM assault ---
+
+  @Test
+  void embarkedThisTurnUnitDoesNotProposeCombatAssault() {
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+
+    // Same infantry but marked as embarked THIS turn — must not assault in CM.
+    final AmphContext ctx =
+        new AmphContext(
+            true, Set.of(infantry.getId()), Set.of(infantry.getId()) /* embarked this turn */);
+
+    final List<MoveDescription> dispatched = runCombatMove(americans, ctx);
+
+    final boolean assaultToJapan =
+        dispatched.stream()
+            .anyMatch(
+                m ->
+                    m.getRoute().getStart().equals(sz6)
+                        && m.getRoute().getEnd().equals(japan)
+                        && m.getUnits().contains(infantry));
+
+    assertThat(assaultToJapan)
+        .as(
+            "Infantry embarked THIS turn must not produce a CM assault move — "
+                + "embarkedThisTurn guard prevents same-turn attack. Dispatched: "
+                + dispatched)
+        .isFalse();
+  }
+
+  // --- no multi-hop CM assault ---
+
+  @Test
+  void noMultiHopCombatAssault() {
+    // 26 Sea Zone is 3 sea hops from Japan — NOT adjacent. Only a 1-hop assault is valid.
+    final Territory sz26 = data.getMap().getTerritoryOrThrow(SEA_ZONE_26);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz26, List.of(infantry)));
+
+    final AmphContext ctx = new AmphContext(true, Set.of(infantry.getId()), Set.of());
+
+    final List<MoveDescription> dispatched = runCombatMove(americans, ctx);
+
+    final boolean assaultToJapan =
+        dispatched.stream()
+            .anyMatch(m -> m.getRoute().getEnd().equals(japan) && m.getUnits().contains(infantry));
+
+    assertThat(assaultToJapan)
+        .as(
+            "Infantry in 26 Sea Zone (3 hops from Japan) must not be dispatched directly to Japan "
+                + "— only 1-hop adjacent coasts are valid CM assault targets. Dispatched: "
+                + dispatched)
+        .isFalse();
+  }
+
+  // --- toggle off: amphib system inactive, transport flow unchanged ---
+
+  @Test
+  void toggleOffDoesNotProduceAmphAssaultMoves() {
+    // With AmphContext.DISABLED the new assault pathway is never invoked.
+    // The transport pathway also produces nothing (no transports in game).
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+
+    // Toggle is OFF — infantry IDs in the context are irrelevant, the pathway is gated.
+    final AmphContext ctx = AmphContext.DISABLED;
+
+    final List<MoveDescription> dispatched = runCombatMove(americans, ctx);
+
+    final boolean assaultToJapan =
+        dispatched.stream()
+            .anyMatch(
+                m ->
+                    m.getRoute().getStart().equals(sz6)
+                        && m.getRoute().getEnd().equals(japan)
+                        && m.getUnits().contains(infantry));
+
+    assertThat(assaultToJapan)
+        .as(
+            "With AmphContext.DISABLED the new amphib assault pathway must not produce moves. "
+                + "Dispatched: "
+                + dispatched)
+        .isFalse();
+  }
+
+  // ---- helpers ----
+
+  private void declareWar(final GamePlayer p1, final GamePlayer p2) {
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            p1,
+            p2,
+            data.getRelationshipTracker().getRelationshipType(p1, p2),
+            data.getRelationshipTypeList().getRelationshipType("War")));
+  }
+
+  private List<MoveDescription> runCombatMove(final GamePlayer player, final AmphContext ctx) {
+    final ProAi proAi = new ProAi("Test " + player.getName(), player.getName() + " AI");
+    final PlayerBridge bridge = mock(PlayerBridge.class);
+    proAi.initialize(bridge, player);
+    when(bridge.getGameData()).thenReturn(data);
+    proAi.reinitializeProDataForSidecar();
+    proAi.getProData().setAmphContext(ctx);
+
+    final List<MoveDescription> dispatched = new ArrayList<>();
+    final IMoveDelegate moveDelegate = mock(IMoveDelegate.class);
+    when(moveDelegate.performMove(any()))
+        .then(
+            inv -> {
+              dispatched.add(inv.getArgument(0));
+              return Optional.empty();
+            });
+
+    try (ProLogCapture ignored = new ProLogCapture()) {
+      proAi.invokeCombatMoveForSidecar(moveDelegate, data, player);
+    }
+    return dispatched;
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphUtilsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphUtilsTest.java
@@ -261,6 +261,43 @@ public class ProAmphUtilsTest {
         .isGreaterThan(disabledValues.get(sz6));
   }
 
+  // --- canal-aware BFS ---
+
+  @Test
+  void blockedCanalExcludesPacificTargetFromValueFlood() {
+    // 89 Sea Zone (Caribbean) staging zone.  Ecuador (South American Pacific coast) is adjacent to
+    // 64 Sea Zone and only reachable from 89 SZ via the Panama Canal (89↔64 via Central America).
+    // When Central America = Japanese, the canal is blocked and the BFS cannot expand to 64 SZ.
+    // Ecuador's contribution must therefore be zero regardless of the value assigned to it.
+    //
+    // Isolation technique: measure the DIFFERENCE in score when Ecuador's map-value changes from
+    // HIGH to LOW.  If Ecuador is reached, the difference equals (HIGH - LOW) / 4.  If the canal
+    // is blocked the difference is 0 because Ecuador is never visited.
+
+    final Territory sz89 = data.getMap().getTerritoryOrThrow("89 Sea Zone");
+    final Territory ecuador = data.getMap().getTerritoryOrThrow("Ecuador");
+    final Territory centralAmerica = data.getMap().getTerritoryOrThrow("Central America");
+
+    // Make Ecuador Japanese so it's treated as enemy.
+    data.performChange(ChangeFactory.changeOwner(ecuador, japanese));
+    // Make Central America Japanese — this closes the Panama Canal for Americans.
+    data.performChange(ChangeFactory.changeOwner(centralAmerica, japanese));
+
+    final double scoreHigh =
+        ProAmphUtils.findAmphReachableLandValue(
+            sz89, americans, Map.of(ecuador, 1000.0), List.of(), List.of());
+    final double scoreLow =
+        ProAmphUtils.findAmphReachableLandValue(
+            sz89, americans, Map.of(ecuador, 1.0), List.of(), List.of());
+
+    assertThat(scoreHigh - scoreLow)
+        .as(
+            "Ecuador's map-value change must not affect the score from 89 Sea Zone when the "
+                + "Panama Canal is closed (Central America = Japanese). The BFS must respect the "
+                + "canal predicate and never reach 64 Sea Zone.")
+        .isEqualTo(0.0);
+  }
+
   // ---- helpers ----
 
   private void declareWar(final GamePlayer p1, final GamePlayer p2) {


### PR DESCRIPTION
Phase 2.4 of the amphib AI epic (map-room#2693) → triplea feat/amphib-no-transports. Closes map-room#2707.

(Replaces misfired #123, accidentally opened from the merged 2.1 branch.)

- ProCombatMoveAi.findAmphAssaultOptions: embarked + !embarkedThisTurn unit → invade an ADJACENT hostile coast (1 hop only). No multi-hop, no embark/transit in combat. Old transport amphib pathway gated off when AmphContext.enabled.
- ProBattleUtils.estimateStrength sea/land overload for landing valuation.
- ProCombatMoveAmphTest: 4 cases (staged unit proposes adjacent-hostile assault; embarkedThisTurn does NOT; no multi-hop CM; toggle-off unchanged).
- ProAmphUtilsTest: +1 canal-blockage test (value-flood route through a closed canal scores 0/excluded) — locks 2.3's canal-awareness.

Local: full game-core suite green. Awaiting triplea CI.