### PR TITLE
feat(ai/pro): Phase 2.5 — NCM embark move generation (amphib-no-transports)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -13,6 +13,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.util.BreadthFirstSearch;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.ai.pro.data.AmphContext;
 import games.strategy.triplea.ai.pro.data.ProBattleResult;
 import games.strategy.triplea.ai.pro.data.ProOtherMoveOptions;
 import games.strategy.triplea.ai.pro.data.ProPlaceTerritory;
@@ -22,6 +23,7 @@ import games.strategy.triplea.ai.pro.data.ProTerritory;
 import games.strategy.triplea.ai.pro.data.ProTerritoryManager;
 import games.strategy.triplea.ai.pro.data.ProTransport;
 import games.strategy.triplea.ai.pro.logging.ProLogger;
+import games.strategy.triplea.ai.pro.util.ProAmphUtils;
 import games.strategy.triplea.ai.pro.util.ProBattleUtils;
 import games.strategy.triplea.ai.pro.util.ProMatches;
 import games.strategy.triplea.ai.pro.util.ProMoveUtils;
@@ -217,6 +219,9 @@ class ProNonCombatMoveAi {
 
     // Calculate move routes and perform moves
     doMove(isCombatMove, moveMap, moveDel, data, player);
+
+    // Embark unmoved land units toward high-value amphib staging zones (Phase 2.5).
+    ProMoveUtils.doMove(proData, calculateAmphEmbarkMoves(), moveDel);
 
     // Log results
     ProLogger.info("Logging results");
@@ -2691,6 +2696,90 @@ class ProNonCombatMoveAi {
 
   private Stream<Unit> combinedStream(Collection<Unit> units1, Collection<Unit> units2) {
     return Stream.concat(units1.stream(), units2.stream());
+  }
+
+  /**
+   * Generates embark moves for Phase 2.5 (amphib-no-transports NCM).
+   *
+   * <p>For each player-owned land unit that has not yet moved and is not already embarked, finds
+   * the highest-value reachable sea zone (BFS up to the unit's movement allowance) and emits an
+   * embark move. Contested sea zones (any enemy sea unit present) are skipped. Gated on {@code
+   * AmphContext.isEnabled()}.
+   */
+  private List<MoveDescription> calculateAmphEmbarkMoves() {
+    final AmphContext ctx = proData.getAmphContext();
+    if (!ctx.isEnabled()) {
+      return List.of();
+    }
+
+    // Build enemy territory value map for staging evaluation
+    final Map<Territory, Double> enemyValueMap = new HashMap<>();
+    for (final Territory t : data.getMap().getTerritories()) {
+      if (!t.isWater() && Matches.isTerritoryEnemyAndNotUnownedWater(player).test(t)) {
+        final int prod = TerritoryAttachment.getProduction(t);
+        if (prod > 0) {
+          enemyValueMap.put(t, (double) prod);
+        }
+      }
+    }
+
+    final List<MoveDescription> moves = new ArrayList<>();
+
+    for (final Territory landT : data.getMap().getTerritories()) {
+      if (landT.isWater()) continue;
+
+      final List<Unit> eligibleUnits =
+          landT.getMatches(
+              u ->
+                  u.isOwnedBy(player)
+                      && Matches.unitIsLand().test(u)
+                      && !ctx.isEmbarked(u)
+                      && !u.hasMoved());
+      if (eligibleUnits.isEmpty()) continue;
+
+      // Find best staging destination within each unit's movement range
+      // Group by movement so units with the same allowance share a BFS result
+      final Map<Integer, Map<Territory, Route>> routeCache = new HashMap<>();
+      for (final Unit u : eligibleUnits) {
+        final int maxHops = u.getMovementLeft().intValue();
+        if (maxHops <= 0) continue;
+
+        final Map<Territory, Route> reachable =
+            routeCache.computeIfAbsent(
+                maxHops, hops -> ProAmphUtils.findEmbarkReachableRoutes(landT, player, hops));
+        if (reachable.isEmpty()) continue;
+
+        Territory bestDest = null;
+        Route bestRoute = null;
+        double bestScore = 0;
+        for (final Map.Entry<Territory, Route> e : reachable.entrySet()) {
+          final double score =
+              ProAmphUtils.findAmphReachableLandValue(
+                  e.getKey(), player, enemyValueMap, List.of(), List.of());
+          if (score > bestScore) {
+            bestScore = score;
+            bestDest = e.getKey();
+            bestRoute = e.getValue();
+          }
+        }
+
+        if (bestRoute != null && bestScore > 0) {
+          moves.add(new MoveDescription(List.of(u), bestRoute));
+          ProLogger.debug(
+              "Amphib embark: "
+                  + u.toStringNoOwner()
+                  + " "
+                  + landT.getName()
+                  + " -> "
+                  + bestDest.getName()
+                  + " (score="
+                  + bestScore
+                  + ")");
+        }
+      }
+    }
+
+    return moves;
   }
 
   private void logAttackMoves(final List<ProTerritory> prioritizedTerritories) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProAmphUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProAmphUtils.java
@@ -1,19 +1,27 @@
 package games.strategy.triplea.ai.pro.util;
 
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.util.BreadthFirstSearch;
 import games.strategy.triplea.attachments.TerritoryAttachment;
+import games.strategy.triplea.delegate.Matches;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import lombok.experimental.UtilityClass;
 
 /**
- * Sea-bridging helpers for amphib-enabled value scoring (Phase 2.3).
+ * Sea-bridging helpers for amphib-enabled value scoring (Phase 2.3) and embark route planning
+ * (Phase 2.5).
  *
- * <p>Both methods are gated by the caller ({@link ProTerritoryValueUtils}) on {@code
+ * <p>Value-scoring methods are gated by the caller ({@link ProTerritoryValueUtils}) on {@code
  * AmphContext.isEnabled()} — callers must not invoke these methods when the amphib toggle is off.
  */
 @UtilityClass
@@ -145,5 +153,60 @@ public final class ProAmphUtils {
             });
 
     return totalValue[0];
+  }
+
+  /**
+   * Returns all sea zones reachable from {@code landT} within {@code maxHops} moves, mapped to the
+   * route from {@code landT} to each destination.
+   *
+   * <p>The first hop is the embark step (land → adjacent sea zone); subsequent hops are sea-zone
+   * transits. Contested sea zones (any enemy sea unit present) are excluded. Canal-aware.
+   *
+   * @param landT starting land territory
+   * @param player the moving player
+   * @param maxHops maximum total hops (embark + transit); must be ≥ 1
+   * @return map of reachable sea-zone territory → route from {@code landT}; insertion-ordered by
+   *     BFS discovery (nearest first)
+   */
+  public static Map<Territory, Route> findEmbarkReachableRoutes(
+      final Territory landT, final GamePlayer player, final int maxHops) {
+
+    final Map<Territory, Route> routes = new LinkedHashMap<>();
+    final Map<Territory, Integer> hopsTo = new HashMap<>();
+    // Queue entries: (sea zone reached so far, full path list from landT)
+    final Queue<Map.Entry<Territory, List<Territory>>> queue = new ArrayDeque<>();
+
+    // Seed: adjacent sea zones — each costs 1 hop (the embark step)
+    for (final Territory sz : player.getData().getMap().getNeighbors(landT)) {
+      if (!sz.isWater()) continue;
+      if (sz.anyUnitsMatch(Matches.enemyUnit(player).and(Matches.unitIsSea()))) continue;
+      final List<Territory> path = new ArrayList<>(List.of(landT, sz));
+      routes.put(sz, new Route(path));
+      hopsTo.put(sz, 1);
+      queue.add(Map.entry(sz, path));
+    }
+
+    while (!queue.isEmpty()) {
+      final Map.Entry<Territory, List<Territory>> entry = queue.poll();
+      final Territory current = entry.getKey();
+      final List<Territory> currentPath = entry.getValue();
+      final int hops = hopsTo.get(current);
+      if (hops >= maxHops) continue;
+
+      for (final Territory next : player.getData().getMap().getNeighbors(current)) {
+        if (!next.isWater()) continue;
+        if (routes.containsKey(next)) continue;
+        if (next.anyUnitsMatch(Matches.enemyUnit(player).and(Matches.unitIsSea()))) continue;
+        if (!ProMatches.noCanalsBetweenTerritories(player).test(current, next)) continue;
+
+        final List<Territory> newPath = new ArrayList<>(currentPath);
+        newPath.add(next);
+        routes.put(next, new Route(newPath));
+        hopsTo.put(next, hops + 1);
+        queue.add(Map.entry(next, newPath));
+      }
+    }
+
+    return routes;
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAmphTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAmphTest.java
@@ -1,0 +1,264 @@
+package games.strategy.triplea.ai.pro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.MoveDescription;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.player.PlayerBridge;
+import games.strategy.triplea.ai.pro.data.AmphContext;
+import games.strategy.triplea.ai.pro.logging.ProLogCapture;
+import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.delegate.remote.IMoveDelegate;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Tests for Phase 2.5 NCM embark move generation.
+ *
+ * <p>Verifies that {@code ProNonCombatMoveAi.calculateAmphEmbarkMoves} correctly embarks eligible
+ * land units toward high-value staging sea zones during the non-combat move phase.
+ *
+ * <p>Test map: G40 Pacific. Americans vs Japanese at war.
+ *
+ * <ul>
+ *   <li>Korea (adjacent to 6 Sea Zone, which is adjacent to Japan) — infantry with no prior move
+ *       must embark toward 6 SZ.
+ *   <li>Same setup but unit marked as already moved — must NOT produce an embark move.
+ *   <li>Korea with a Japanese destroyer in 6 Sea Zone — contested SZ must be skipped; no embark.
+ *   <li>Manchuria (adjacent to 19 SZ, which connects to 6 SZ) with mech_infantry (movement=2) —
+ *       must reach 6 Sea Zone (better staging) rather than stopping in 19 Sea Zone.
+ *   <li>Toggle off ({@link AmphContext#DISABLED}) — no embark moves produced.
+ * </ul>
+ */
+public class ProNonCombatMoveAmphTest {
+
+  private static final String KOREA = "Korea";
+  private static final String SOVIET_FAR_EAST = "Soviet Far East";
+  private static final String SEA_ZONE_5 = "5 Sea Zone";
+  private static final String SEA_ZONE_6 = "6 Sea Zone";
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer japanese;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    japanese = data.getPlayerList().getPlayerId("Japanese");
+    declareWar(americans, japanese);
+
+    // Clear all units for a clean slate; individual tests re-add what they need.
+    for (final Territory t : data.getMap().getTerritories()) {
+      data.performChange(ChangeFactory.removeUnits(t, t.getUnits()));
+    }
+  }
+
+  // --- unmoved unit embarks to adjacent staging zone ---
+
+  @Test
+  void infantryEmbarksToAdjacentStagingZone() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+
+    final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
+    final List<MoveDescription> dispatched = runNonCombatMove(americans, ctx);
+
+    final boolean embarkToSz6 =
+        dispatched.stream()
+            .anyMatch(m -> m.getRoute().getEnd().equals(sz6) && m.getUnits().contains(infantry));
+
+    assertThat(embarkToSz6)
+        .as(
+            "Infantry in Korea (adjacent to 6 Sea Zone → Japan) must embark to 6 SZ in NCM. "
+                + "Dispatched: "
+                + dispatched)
+        .isTrue();
+  }
+
+  // --- already-moved unit does NOT embark ---
+
+  @Test
+  void alreadyMovedUnitDoesNotEmbark() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+    // Consume all movement so hasMoved() == true
+    data.performChange(ChangeFactory.markNoMovementChange(List.of(infantry)));
+
+    final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
+    final List<MoveDescription> dispatched = runNonCombatMove(americans, ctx);
+
+    final boolean embarkToSz6 =
+        dispatched.stream()
+            .anyMatch(m -> m.getRoute().getEnd().equals(sz6) && m.getUnits().contains(infantry));
+
+    assertThat(embarkToSz6)
+        .as("Unit with alreadyMoved > 0 must not produce an embark move. Dispatched: " + dispatched)
+        .isFalse();
+  }
+
+  // --- contested sea zone is skipped ---
+
+  @Test
+  void noEmbarkIntoContestedSeaZone() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+
+    // Place an enemy destroyer in 6 SZ — makes it contested
+    final Unit destroyer = GameDataTestUtil.destroyer(data).create(1, japanese).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(destroyer)));
+
+    final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
+    final List<MoveDescription> dispatched = runNonCombatMove(americans, ctx);
+
+    final boolean embarkToSz6 =
+        dispatched.stream()
+            .anyMatch(m -> m.getRoute().getEnd().equals(sz6) && m.getUnits().contains(infantry));
+
+    assertThat(embarkToSz6)
+        .as(
+            "Contested sea zone (enemy destroyer present) must be skipped; no embark. "
+                + "Dispatched: "
+                + dispatched)
+        .isFalse();
+  }
+
+  // --- mech infantry transits to higher-value staging zone ---
+
+  @Test
+  void mechInfantryTransitsToHigherValueStagingZone() {
+    // Soviet Far East → 5 Sea Zone (embark, hop 1) → 6 Sea Zone (transit, hop 2, adj to Japan).
+    // 6 SZ scores higher than 5 SZ because:
+    //   - 5 SZ: only Russian land adjacent (Soviet Far East, Amur, Siberia — NOT enemy) → score
+    //           comes only from Japan/Korea at seaDistance=1 ≈ 2.75
+    //   - 6 SZ: Japan (prod=8) and Korea (prod=3) at seaDistance=0 → score 5.5
+    // mech_infantry has movement=2, so the 2-hop route SovietFarEast→5SZ→6SZ is reachable.
+    final Territory sovietFarEast = data.getMap().getTerritoryOrThrow(SOVIET_FAR_EAST);
+    final Territory sz5 = data.getMap().getTerritoryOrThrow(SEA_ZONE_5);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    // Transfer Soviet Far East to Americans so the AI's unit-move-map includes it and the unit
+    // is in a player-accessible territory.
+    data.performChange(ChangeFactory.changeOwner(sovietFarEast, americans));
+
+    final Unit mechInf = GameDataTestUtil.mechInfantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sovietFarEast, List.of(mechInf)));
+
+    final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
+    final List<MoveDescription> dispatched = runNonCombatMove(americans, ctx);
+
+    final boolean reachedSz6 =
+        dispatched.stream()
+            .anyMatch(m -> m.getRoute().getEnd().equals(sz6) && m.getUnits().contains(mechInf));
+
+    final boolean stoppedAtSz5 =
+        dispatched.stream()
+            .anyMatch(m -> m.getRoute().getEnd().equals(sz5) && m.getUnits().contains(mechInf));
+
+    assertThat(reachedSz6)
+        .as(
+            "mech_infantry in Soviet Far East (movement=2) must transit SovietFarEast→5 SZ→6 SZ "
+                + "(6 SZ adjacent to Japan scores 5.5 vs 5 SZ non-enemy adjacency scores ~2.75). "
+                + "Dispatched: "
+                + dispatched)
+        .isTrue();
+    assertThat(stoppedAtSz5)
+        .as("mech_infantry must not stop at 5 SZ when 6 SZ is reachable and scores higher")
+        .isFalse();
+  }
+
+  // --- toggle off: no embark moves ---
+
+  @Test
+  void toggleOffDoesNotProduceEmbarkMoves() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+
+    final List<MoveDescription> dispatched = runNonCombatMove(americans, AmphContext.DISABLED);
+
+    final boolean embarkToSz6 =
+        dispatched.stream()
+            .anyMatch(m -> m.getRoute().getEnd().equals(sz6) && m.getUnits().contains(infantry));
+
+    assertThat(embarkToSz6)
+        .as(
+            "With AmphContext.DISABLED the embark pathway must not produce moves. "
+                + "Dispatched: "
+                + dispatched)
+        .isFalse();
+  }
+
+  // ---- helpers ----
+
+  private void declareWar(final GamePlayer p1, final GamePlayer p2) {
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            p1,
+            p2,
+            data.getRelationshipTracker().getRelationshipType(p1, p2),
+            data.getRelationshipTypeList().getRelationshipType("War")));
+  }
+
+  private List<MoveDescription> runNonCombatMove(final GamePlayer player, final AmphContext ctx) {
+    // Advance the game sequence to the Americans NCM step so GameStepPropertiesHelper can resolve
+    // isCombatMove correctly (it reads the step name/properties).
+    advanceToStep("americansNonCombatMove");
+
+    final ProAi proAi = new ProAi("Test " + player.getName(), player.getName() + " AI");
+    final PlayerBridge bridge = mock(PlayerBridge.class);
+    proAi.initialize(bridge, player);
+    when(bridge.getGameData()).thenReturn(data);
+    proAi.reinitializeProDataForSidecar();
+    proAi.getProData().setAmphContext(ctx);
+
+    final List<MoveDescription> dispatched = new ArrayList<>();
+    final IMoveDelegate moveDelegate = mock(IMoveDelegate.class);
+    when(moveDelegate.performMove(any()))
+        .then(
+            inv -> {
+              dispatched.add(inv.getArgument(0));
+              return Optional.empty();
+            });
+
+    try (ProLogCapture ignored = new ProLogCapture()) {
+      proAi.invokeNonCombatMoveForSidecar(moveDelegate, data, player);
+    }
+    return dispatched;
+  }
+
+  private void advanceToStep(final String stepName) {
+    try (GameData.Unlocker ignored = data.acquireWriteLock()) {
+      final int length = data.getSequence().size();
+      for (int i = 0; i < length; i++) {
+        if (data.getSequence().getStep().getName().contains(stepName)) break;
+        data.getSequence().next();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **`ProAmphUtils.findEmbarkReachableRoutes`**: canal-aware BFS returning all sea zones reachable from a land territory within N hops, with full `Route` objects for dispatch. Used by `calculateAmphEmbarkMoves` for multi-hop routing.
- **`ProNonCombatMoveAi.calculateAmphEmbarkMoves`**: in NCM, moves unmoved land units (`hasMoved()==false`, not yet embarked) to the highest-value staging sea zone within their movement range. Scores destinations via `ProAmphUtils.findAmphReachableLandValue`.
- Guards: `!hasMoved()` (unmoved only), `!isEmbarked` (not already at sea), no enemy sea units in destination zone (contested), `AmphContext.isEnabled()` toggle gate.
- Closes #2708

## Test plan

- [x] `infantryEmbarksToAdjacentStagingZone` — Korea infantry (adj to 6 SZ) embarks to 6 SZ
- [x] `alreadyMovedUnitDoesNotEmbark` — `markNoMovementChange` unit is not re-embarked
- [x] `noEmbarkIntoContestedSeaZone` — enemy destroyer in 6 SZ blocks Korea infantry from embarking
- [x] `mechInfantryTransitsToHigherValueStagingZone` — mech inf (movement=2) in Soviet Far East transits Soviet Far East → 5 SZ → 6 SZ (scores 5.5) rather than stopping at 5 SZ (scores ~2.75)
- [x] `toggleOffDoesNotProduceEmbarkMoves` — `AmphContext.DISABLED` produces no embark moves
- [x] Full game-core test suite green