### PR TITLE
fix(amphib-ai): bypass MoveValidator for free-embark NCM moves + regression test (#2715)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingMoveDelegate.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/RecordingMoveDelegate.java
@@ -18,6 +18,12 @@ import java.util.Optional;
  * validation are captured; invalid moves return the error {@link Optional} so that ProAi can
  * observe the rejection and avoid re-submitting the same move.
  *
+ * <p><b>Amphib free-embark exception:</b> when {@link
+ * games.strategy.triplea.ai.pro.data.AmphContext#isEnabled()} is {@code true}, Phase 2.5
+ * free-embark moves (land unit → sea zone with no physical transport) bypass {@code
+ * super.performMove()} entirely. Java's MoveValidator has no concept of free embark and would
+ * reject them; the TS engine enforces its own rules instead.
+ *
  * <p>Callers must set up the bridge before use:
  *
  * <ol>
@@ -73,10 +79,23 @@ public final class RecordingMoveDelegate extends MoveDelegate {
   @Override
   public Optional<String> performMove(final MoveDescription move) {
     if (!dryRun) {
-      final Optional<String> error = super.performMove(move);
-      if (error.isPresent()) {
-        // Move failed MoveValidator — do NOT record, propagate error to ProAi.
-        return error;
+      // When amphib-no-transports mode is active, Phase 2.5 free-embark moves
+      // (land unit → sea zone, no physical transport) would be rejected by Java's
+      // MoveValidator with "Not enough transports".  The TS engine enforces its own
+      // free-embark rules, so we capture these moves directly without running the
+      // Java-side validation.  This is safe because Phase 2.5 embark moves are the
+      // last NCM action; skipping the Java game-state mutation does not affect any
+      // subsequent AI calculation in the same turn.
+      final boolean isAmphFreeEmbark =
+          proAi.getProData().getAmphContext().isEnabled()
+              && move.getRoute().isLoad()
+              && move.getUnitsToSeaTransports().isEmpty();
+      if (!isAmphFreeEmbark) {
+        final Optional<String> error = super.performMove(move);
+        if (error.isPresent()) {
+          // Move failed MoveValidator — do NOT record, propagate error to ProAi.
+          return error;
+        }
       }
     }
     final Territory end = move.getRoute().getEnd();

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/RecordingMoveDelegateTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/exec/RecordingMoveDelegateTest.java
@@ -1,9 +1,27 @@
 package org.triplea.ai.sidecar.exec;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.MoveDescription;
+import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.ai.pro.data.AmphContext;
+import games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge;
+import games.strategy.triplea.delegate.GameDataTestUtil;
 import games.strategy.triplea.delegate.MoveDelegate;
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -18,9 +36,14 @@ import org.sonatype.goodies.prefs.memory.MemoryPreferences;
  * noncombat-move step — those conditions are met by {@code CombatMoveExecutorIntegrationTest} and
  * {@code NoncombatMoveExecutorIntegrationTest}, which provide end-to-end capture coverage.
  *
- * <p>This test class only verifies the structural invariant: {@link RecordingMoveDelegate} must
- * extend {@link MoveDelegate} (not just implement the interface) so that {@link
- * RecordingMoveDelegate#performMove} can call {@code super.performMove()} and get real validation.
+ * <p>This test class verifies:
+ *
+ * <ul>
+ *   <li>The structural invariant: {@link RecordingMoveDelegate} must extend {@link MoveDelegate}.
+ *   <li>Regression map-room#2715: free-embark moves must be captured directly without being passed
+ *       through Java's {@code MoveValidator} (which has no free-embark concept and rejects with
+ *       "Not enough transports").
+ * </ul>
  */
 class RecordingMoveDelegateTest {
 
@@ -34,6 +57,94 @@ class RecordingMoveDelegateTest {
     // RecordingMoveDelegate must extend the real MoveDelegate so super.performMove()
     // validates via MoveValidator rather than silently accepting every move.
     assertInstanceOf(MoveDelegate.class, new RecordingMoveDelegate(null));
+  }
+
+  /**
+   * Regression for map-room#2715: a free-embark move (AmphContext.enabled, isLoad() route, empty
+   * unitsToSeaTransports) must be <em>captured</em> by {@link RecordingMoveDelegate#performMove},
+   * not rejected with "Not enough transports".
+   *
+   * <p>Before the fix, {@code performMove()} called {@code super.performMove()} unconditionally.
+   * Java's {@code MoveValidator} has no concept of the free-embark rule: it always rejects a
+   * land-to-sea route that has no physical transport mapped in {@code unitsToSeaTransports},
+   * returning {@code Optional.of("Not enough transports")}. The AI then silently discarded the
+   * move, leaving it fully inert in no-transports mode.
+   *
+   * <p>The fix adds an early-return guard: when the three free-embark conditions are all true
+   * ({@code AmphContext.isEnabled()}, {@code route.isLoad()}, {@code
+   * unitsToSeaTransports.isEmpty()}) the delegate bypasses {@code super.performMove()} and records
+   * the move directly.
+   *
+   * <p><b>Failure mode without the fix:</b> {@code result.isPresent()} with message "Not enough
+   * transports" and {@code recorder.captured().isEmpty()}.
+   *
+   * <p>This test does <b>not</b> mock {@code performMove} — mocking it defeats the purpose of
+   * verifying the bypass exists in the real implementation path.
+   */
+  @Test
+  void freeEmbarkIsCapturedNotRejectedByMoveValidator() {
+    final GameData data = TestMapGameData.GLOBAL1940.getGameData();
+    final GamePlayer americans = data.getPlayerList().getPlayerId("Americans");
+
+    // Clear all units for a clean slate, then place one infantry in Korea.
+    // Korea is adjacent to 6 Sea Zone (water) — the load route we'll use.
+    // No transport anywhere: Java MoveValidator would return "Not enough transports".
+    for (final Territory t : data.getMap().getTerritories()) {
+      data.performChange(ChangeFactory.removeUnits(t, t.getUnits()));
+    }
+    final Territory korea = data.getMap().getTerritoryOrThrow("Korea");
+    final Territory sz6 = data.getMap().getTerritoryOrThrow("6 Sea Zone");
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+
+    // Advance the game sequence to the Americans NCM step so MoveDelegate delegates are
+    // correctly scoped (same pattern used in ProNonCombatMoveAmphTest).
+    try (GameData.Unlocker ignored = data.acquireWriteLock()) {
+      final int length = data.getSequence().size();
+      for (int i = 0; i < length; i++) {
+        if (data.getSequence().getStep().getName().contains("americansNonCombatMove")) {
+          break;
+        }
+        data.getSequence().next();
+      }
+    }
+
+    // Wire up ProAi + RecordingMoveDelegate — same sequence as NoncombatMoveExecutor.
+    final ProAi proAi = new ProAi("Test Americans", "Americans AI");
+    ExecutorSupport.initializeProAi(proAi, data, americans);
+    final RecordingMoveDelegate recorder = new RecordingMoveDelegate(proAi);
+    recorder.initialize("move", "Move");
+    recorder.setDelegateBridgeAndPlayer(new ProDummyDelegateBridge(proAi, americans, data));
+    proAi.reinitializeProDataForSidecar();
+    // Set AmphContext AFTER reinitialize: reinitializeProDataForSidecar() resets proData,
+    // so any context set before that call would be overwritten.
+    proAi.getProData().setAmphContext(new AmphContext(true, Set.of(), Set.of()));
+
+    // Build the free-embark MoveDescription:
+    //   - Route: Korea (land) → 6 Sea Zone (water)  →  isLoad() == true
+    //   - unitsToSeaTransports: empty  →  no physical transport involved
+    final Route loadRoute = new Route(korea, sz6);
+    assertTrue(loadRoute.isLoad(), "Precondition: Korea → 6 Sea Zone must satisfy isLoad()");
+    final MoveDescription move = new MoveDescription(List.of(infantry), loadRoute, Map.of());
+    assertTrue(
+        move.getUnitsToSeaTransports().isEmpty(),
+        "Precondition: unitsToSeaTransports must be empty for a free-embark move");
+
+    // --- Exercise ---
+    final Optional<String> result = recorder.performMove(move);
+
+    // --- Assert ---
+    assertTrue(
+        result.isEmpty(),
+        "Free-embark (AmphContext.enabled + isLoad + no sea transport) must be accepted "
+            + "(Optional.empty()), not rejected. Error returned: "
+            + result.orElse("(none)"));
+    assertEquals(
+        1, recorder.captured().size(), "Free-embark move must appear exactly once in captured()");
+    assertEquals(
+        move,
+        recorder.captured().get(0).move(),
+        "Captured move must match the submitted MoveDescription");
   }
 
   // NOTE: The former "capturesMovesInOrder", "partitionsNonBombingMoves",

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -244,11 +244,16 @@ class ProNonCombatMoveAi {
     ProMoveUtils.doMove(
         proData, ProMoveUtils.calculateMoveRoutes(proData, player, moveMap, isCombatMove), moveDel);
 
-    // Calculate amphib move routes and perform moves
-    ProMoveUtils.doMove(
-        proData,
-        ProMoveUtils.calculateAmphibRoutes(proData, player, moveMap, isCombatMove),
-        moveDel);
+    // Skip old transport-based amphib routes when amphib-no-transports mode is active.
+    // In that mode no transport units exist so the route calculator is a no-op anyway, but
+    // skipping it avoids the overhead of iterating an empty map and clarifies intent.
+    // Phase 2.5 (calculateAmphEmbarkMoves) handles NCM amphib movement instead.
+    if (!proData.getAmphContext().isEnabled()) {
+      ProMoveUtils.doMove(
+          proData,
+          ProMoveUtils.calculateAmphibRoutes(proData, player, moveMap, isCombatMove),
+          moveDel);
+    }
   }
 
   private void findUnitsThatCantMove(


### PR DESCRIPTION
Closes map-room/map-room#2715
Closes map-room/map-room#2713

## What

### 1. `RecordingMoveDelegate.performMove()` — bypass MoveValidator for free-embark moves (map-room#2715)

**Root cause:** Phase 2.5 generates embark moves of the form `land unit → sea zone` with no physical transport (`unitsToSeaTransports` empty). Java's `MoveValidator.validateTransport()` requires a transport for any `isLoad()` route and rejects these with _"Not enough transports"_. The pre-fix code called `super.performMove()` unconditionally, so every Phase 2.5 NCM embark move was silently dropped — leaving the AI **fully inert** in no-transports mode.

**Fix:** Early-return guard in `performMove()` bypasses `super.performMove()` and records the move directly when all three free-embark conditions hold:
- `AmphContext.isEnabled()` (amphib mode active)
- `route.isLoad()` (land → water route)
- `unitsToSeaTransports.isEmpty()` (no physical transport provided)

### 2. `ProNonCombatMoveAi.doMove()` — gate `calculateAmphibRoutes` (map-room#2713)

When the amphib toggle is on, `calculateAmphibRoutes` is already a no-op (no transport units → empty `amphibAttackMap`). The guard now makes that intent explicit and saves the overhead of iterating an empty map.

## Tests

### New (regression for #2715 — real performMove, no mocks)
- `RecordingMoveDelegateTest.freeEmbarkIsCapturedNotRejectedByMoveValidator` — drives a real `RecordingMoveDelegate.performMove()` with `AmphContext.enabled=true`, a Korea→6SZ `isLoad()` route, empty `unitsToSeaTransports`. Would **FAIL** against pre-fix code (MoveValidator returns "Not enough transports"); **PASS** with bypass.

### Existing
- `ProNonCombatMoveAmphTest` — all 5 NCM embark scenarios pass
- `ProCombatMoveAmphTest` — all 4 CM assault scenarios pass
- `:game-app:game-core:test` + `:game-app:ai-sidecar:test` — full suite passes
- Spotless applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
