### PR TITLE
feat(amphib-ai): unified embarked-movement model — ProAmphUtils primitive + NCM/CM caller rewrite (#2716 #2717 #2712)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -2101,6 +2101,17 @@ public class ProCombatMoveAi {
    *
    * @return map of coastal land territory → list of staged units that can assault it
    */
+  /**
+   * Identifies amphib assault options for the CM pass (design §6.3).
+   *
+   * <p>Candidate units: embarked, {@code !embarkedThisTurn}, and with {@code attack > 0}. AA guns
+   * and other attack-0 units are excluded — they cannot contribute to the land battle and should
+   * not be assaulted onto a hostile coast (design §5.2-2 / #2712). They remain fully eligible for
+   * NCM embark/disembark.
+   *
+   * <p>Destinations: adjacent (1-hop) hostile coasts only, matching the engine rule ({@code
+   * getEmbarkCombatDestinations}).
+   */
   private Map<Territory, List<Unit>> findAmphAssaultOptions() {
     final AmphContext ctx = proData.getAmphContext();
     final Map<Territory, List<Unit>> options = new HashMap<>();
@@ -2109,18 +2120,21 @@ public class ProCombatMoveAi {
       if (!sz.isWater()) {
         continue;
       }
-      // Land units in this sea zone that are staged (embarked, not embarked this turn)
+      // Staged units: embarked from a prior turn, attack > 0 (excludes AA guns per §5.2-2).
+      // AA guns and other attack-0 units are excluded from CM assault candidates — they cannot
+      // contribute to the land battle and should not be stranded on a hostile coast.
       final List<Unit> staged =
           sz.getMatches(
               u ->
                   u.isOwnedBy(player)
                       && Matches.unitIsLand().test(u)
                       && ctx.isEmbarked(u)
-                      && !ctx.isEmbarkedThisTurn(u));
+                      && !ctx.isEmbarkedThisTurn(u)
+                      && Matches.unitCanAttack(player).test(u));
       if (staged.isEmpty()) {
         continue;
       }
-      // Collect adjacent hostile coasts (1 hop only)
+      // Collect adjacent hostile coasts (1 hop only, mirrors engine getEmbarkCombatDestinations).
       for (final Territory adj : data.getMap().getNeighbors(sz)) {
         if (!adj.isWater()
             && ProMatches.territoryIsEnemyOrCantBeHeld(player, List.of()).test(adj)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -2704,12 +2704,33 @@ class ProNonCombatMoveAi {
   }
 
   /**
-   * Generates embark moves for Phase 2.5 (amphib-no-transports NCM).
+   * Generates amphib moves for Phase 2.5 (amphib-no-transports NCM) using the unified
+   * embarked-movement model (design §6.2).
    *
-   * <p>For each player-owned land unit that has not yet moved and is not already embarked, finds
-   * the highest-value reachable sea zone (BFS up to the unit's movement allowance) and emits an
-   * embark move. Contested sea zones (any enemy sea unit present) are skipped. Gated on {@code
-   * AmphContext.isEnabled()}.
+   * <p>Resolves:
+   *
+   * <ul>
+   *   <li><b>#2716</b> — uses {@code ProAmphUtils.NAVAL_MOVE} (2) instead of the unit's land
+   *       movement as the sea-hop budget.
+   *   <li><b>#2717</b> — iterates over sea zones as well as land territories so already-embarked
+   *       units (prior-turn embark) are not silently excluded.
+   *   <li><b>§5.2-1 survival gate</b> — sea-zone destinations with {@code survivalProbability <
+   *       DISEMBARK_SURVIVAL_THRESHOLD} are rejected; only safe staging zones and friendly-coast
+   *       disembark targets are scored and dispatched.
+   * </ul>
+   *
+   * <p>Candidate units: player-owned land units that have not moved, either on coastal land
+   * (non-embarked) or already in a sea zone (embarked from a prior turn, not fresh). Gated on
+   * {@link AmphContext#isEnabled()}.
+   *
+   * <p>Scoring:
+   *
+   * <ul>
+   *   <li><b>Sea-zone destination</b>: gated by {@code survivalProbability ≥ 0.70}; scored by
+   *       {@link ProAmphUtils#findAmphReachableLandValue} (assault-staging value).
+   *   <li><b>Friendly-coast disembark destination</b>: always safe; scored by production value
+   *       (reinforcement value of the landing zone).
+   * </ul>
    */
   private List<MoveDescription> calculateAmphEmbarkMoves() {
     final AmphContext ctx = proData.getAmphContext();
@@ -2717,7 +2738,7 @@ class ProNonCombatMoveAi {
       return List.of();
     }
 
-    // Build enemy territory value map for staging evaluation
+    // Enemy territory value map used by findAmphReachableLandValue for staging scoring.
     final Map<Territory, Double> enemyValueMap = new HashMap<>();
     for (final Territory t : data.getMap().getTerritories()) {
       if (!t.isWater() && Matches.isTerritoryEnemyAndNotUnownedWater(player).test(t)) {
@@ -2730,40 +2751,59 @@ class ProNonCombatMoveAi {
 
     final List<MoveDescription> moves = new ArrayList<>();
 
-    for (final Territory landT : data.getMap().getTerritories()) {
-      if (landT.isWater()) continue;
+    // Iterate over ALL territories (land + sea) to catch both:
+    //   - non-embarked units on coastal land (branch A of getAmphReachableTerritories)
+    //   - already-embarked units in sea zones from a prior turn (branch B)  — fixes #2717
+    for (final Territory from : data.getMap().getTerritories()) {
+      final boolean fromIsSz = from.isWater();
 
+      // Units eligible for this pass:
+      //   - land territory: non-embarked (about to embark)
+      //   - sea zone: embarked (already staged, !isEmbarked would have filtered them out pre-fix)
       final List<Unit> eligibleUnits =
-          landT.getMatches(
+          from.getMatches(
               u ->
                   u.isOwnedBy(player)
                       && Matches.unitIsLand().test(u)
-                      && !ctx.isEmbarked(u)
-                      && !u.hasMoved());
+                      && !u.hasMoved()
+                      && (fromIsSz == ctx.isEmbarked(u)));
       if (eligibleUnits.isEmpty()) continue;
 
-      // Find best staging destination within each unit's movement range
-      // Group by movement so units with the same allowance share a BFS result
-      final Map<Integer, Map<Territory, Route>> routeCache = new HashMap<>();
       for (final Unit u : eligibleUnits) {
-        final int maxHops = u.getMovementLeft().intValue();
-        if (maxHops <= 0) continue;
-
+        // Unified reachability primitive (design §6.1): applies NAVAL_MOVE budget,
+        // embarkedThisTurn guard, canal check, and contested-SZ exclusion internally.
         final Map<Territory, Route> reachable =
-            routeCache.computeIfAbsent(
-                maxHops, hops -> ProAmphUtils.findEmbarkReachableRoutes(landT, player, hops));
+            ProAmphUtils.getAmphReachableTerritories(u, from, false, ctx, player);
         if (reachable.isEmpty()) continue;
 
         Territory bestDest = null;
         Route bestRoute = null;
         double bestScore = 0;
+
         for (final Map.Entry<Territory, Route> e : reachable.entrySet()) {
-          final double score =
-              ProAmphUtils.findAmphReachableLandValue(
-                  e.getKey(), player, enemyValueMap, List.of(), List.of());
+          final Territory dest = e.getKey();
+          final double score;
+
+          if (dest.isWater()) {
+            // Sea-zone destination: apply survival-probability gate (§5.2-1 / §6.6).
+            // Units whose expected survival < 70% in that zone are not sent there.
+            final double p = ProAmphUtils.survivalProbability(List.of(u), dest, player);
+            if (p < ProAmphUtils.DISEMBARK_SURVIVAL_THRESHOLD) {
+              continue; // unsafe — skip
+            }
+            score =
+                ProAmphUtils.findAmphReachableLandValue(
+                    dest, player, enemyValueMap, List.of(), List.of());
+          } else {
+            // Friendly-coast disembark destination: always safe, score by production value
+            // (reinforcement / defensive placement). AA / attack-0 units and all others
+            // are eligible for NCM disembark per §5.2-2.
+            score = TerritoryAttachment.getProduction(dest);
+          }
+
           if (score > bestScore) {
             bestScore = score;
-            bestDest = e.getKey();
+            bestDest = dest;
             bestRoute = e.getValue();
           }
         }
@@ -2774,7 +2814,7 @@ class ProNonCombatMoveAi {
               "Amphib embark: "
                   + u.toStringNoOwner()
                   + " "
-                  + landT.getName()
+                  + from.getName()
                   + " -> "
                   + bestDest.getName()
                   + " (score="

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProAmphUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProAmphUtils.java
@@ -3,7 +3,9 @@ package games.strategy.triplea.ai.pro.util;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.util.BreadthFirstSearch;
+import games.strategy.triplea.ai.pro.data.AmphContext;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import java.util.ArrayDeque;
@@ -29,6 +31,80 @@ public final class ProAmphUtils {
 
   /** Maximum sea-hop depth searched when scoring amphib reachability. */
   static final int MAX_SEA_HOPS = 4;
+
+  /**
+   * Naval movement allowance for embarked land units under the no-transports amphib rule.
+   *
+   * <p>Mirrors {@code NAVAL_MOVE = 2} in {@code tech-effects.ts:6}. An embarked land unit gets
+   * exactly 2 sea-hop transits per turn (+ 1 if starting adjacent to a friendly naval base). This
+   * budget is independent of the unit's land-movement value.
+   */
+  public static final int NAVAL_MOVE = 2;
+
+  /**
+   * Survival-probability threshold below which a staging sea zone is considered too dangerous for
+   * transit or continued staging.
+   *
+   * <p>A sea zone with {@code survivalProbability(stack, sz) < DISEMBARK_SURVIVAL_THRESHOLD} will
+   * either trigger a retreat to a friendly coast (if one is adjacent and available) or be rejected
+   * as a destination during planning. Single named constant so callers can tune it without hunting
+   * for magic numbers.
+   *
+   * <p>Design §5.2-1: "P ≥ 0.70 → progress/stay; P < 0.70 → retreat."
+   */
+  public static final double DISEMBARK_SURVIVAL_THRESHOLD = 0.70;
+
+  /**
+   * Estimates the probability that {@code embarkedStack} survives a single-turn enemy attack on the
+   * staging sea zone {@code sz}.
+   *
+   * <p>The implementation converts the existing {@link ProBattleUtils#estimateStrengthDifference}
+   * metric to a probability in {@code [0, 1]}:
+   *
+   * <pre>  P = clamp(1.0 − sd / 100.0, 0.0, 1.0)</pre>
+   *
+   * where {@code sd = estimateStrengthDifference(sz, attackers, defenders)}.
+   *
+   * <ul>
+   *   <li>{@code sd = 0} (no attack threat) → P = 1.0.
+   *   <li>{@code sd = 50} (balanced) → P = 0.50.
+   *   <li>{@code sd ≥ 100} (overwhelming attack) → P = 0.0.
+   *   <li>{@code sd = 30} → P = 0.70 (right at the threshold).
+   * </ul>
+   *
+   * <p><b>Attacker scope:</b> all enemy units in {@code sz} itself and all enemy units in adjacent
+   * territories (sea zones for naval threats, land territories for air threats). This is a
+   * single-turn, static-disposition estimate — it does not model multi-turn enemy manoeuvring.
+   *
+   * <p><b>Defender scope:</b> all units in {@code embarkedStack} plus any friendly sea units
+   * already present in {@code sz} (escorts).
+   *
+   * @param embarkedStack the land units staged at or destined for {@code sz}
+   * @param sz the staging sea zone to evaluate
+   * @param player the moving player
+   * @return survival probability in {@code [0.0, 1.0]}; 1.0 when no enemy threat is reachable
+   */
+  public static double survivalProbability(
+      final java.util.Collection<Unit> embarkedStack, final Territory sz, final GamePlayer player) {
+
+    // Defenders: the embarked stack + any friendly sea units already present as escorts
+    final List<Unit> defenders = new ArrayList<>(embarkedStack);
+    defenders.addAll(sz.getMatches(Matches.isUnitAllied(player).and(Matches.unitIsSea())));
+
+    // Attackers: enemy units in sz itself + adjacent territories (naval + air threats)
+    final List<Unit> attackers = new ArrayList<>();
+    attackers.addAll(sz.getMatches(ProMatches.unitIsEnemyNotNeutral(player)));
+    for (final Territory adj : player.getData().getMap().getNeighbors(sz)) {
+      attackers.addAll(adj.getMatches(ProMatches.unitIsEnemyNotNeutral(player)));
+    }
+
+    if (attackers.isEmpty()) {
+      return 1.0; // No enemy threat
+    }
+
+    final double sd = ProBattleUtils.estimateStrengthDifference(sz, attackers, defenders);
+    return Math.max(0.0, Math.min(1.0, 1.0 - sd / 100.0));
+  }
 
   /**
    * Returns the maximum connected land-mass size when sea zones act as one-hop bridges between land
@@ -153,6 +229,241 @@ public final class ProAmphUtils {
             });
 
     return totalValue[0];
+  }
+
+  /**
+   * Returns the full set of destinations reachable by a land unit under the amphib-no-transports
+   * movement model, as a direct Java mirror of the TS engine's {@code
+   * getValidDestinationsForSingle} (movement-validator.ts).
+   *
+   * <p>The primitive is <em>reachability-only</em> — it does not score destinations and does not
+   * apply the survival-probability threshold. Callers (NCM pass, CM pass) apply survival gating and
+   * scoring on the returned set.
+   *
+   * <h2>Branches (match TS engine §3.2)</h2>
+   *
+   * <ul>
+   *   <li><b>(A) Non-embarked NCM:</b> adjacent sea zones (free embark, 0 budget) plus all sea
+   *       zones reachable within {@link #NAVAL_MOVE} sea-hop transits from any adjacent SZ (mirror
+   *       of {@code addEmbarkTransitTargets}). No land disembark — fresh embark and disembark in
+   *       the same turn is not permitted.
+   *   <li><b>(B) Embarked NCM:</b> sea zones reachable within {@code NAVAL_MOVE} hops from the
+   *       current staging SZ (transit) plus adjacent friendly coasts if {@code !embarkedThisTurn}
+   *       (mirror of {@code addDirectDisembarkTargets}).
+   *   <li><b>(C) Embarked CM:</b> adjacent hostile coasts only, provided {@code !embarkedThisTurn}
+   *       and the unit has an attack value ≥ 1. AA / attack-0 units return empty (mirror of {@code
+   *       getEmbarkCombatDestinations}).
+   *   <li><b>(D) Non-embarked CM:</b> empty — no amphib in CM for non-embarked units.
+   * </ul>
+   *
+   * <p>Guards: returns empty when (a) {@code amphContext.enabled == false}, (b) the unit has
+   * already moved this turn ({@code unit.hasMoved()} — mirrors TS {@code movedThisTurn > 0} guard),
+   * or (c) applicable per-branch conditions above.
+   *
+   * <p>All sea-BFS hops apply the canal guard ({@link ProMatches#noCanalsBetweenTerritories}) and
+   * skip contested sea zones (any enemy sea unit present).
+   *
+   * @param unit the land unit to plan for
+   * @param from the unit's current territory
+   * @param isCombatMove {@code true} if this is the combat-move phase
+   * @param amphContext current AmphContext (must be enabled)
+   * @param player the moving player
+   * @return map of destination territory → proposable {from, to} route; empty if no amphib
+   *     destinations are reachable
+   */
+  public static Map<Territory, Route> getAmphReachableTerritories(
+      final Unit unit,
+      final Territory from,
+      final boolean isCombatMove,
+      final AmphContext amphContext,
+      final GamePlayer player) {
+
+    // Guard: toggle must be on
+    if (!amphContext.isEnabled()) {
+      return Map.of();
+    }
+
+    final boolean embarked = amphContext.isEmbarked(unit);
+    final boolean embarkedThisTurn = amphContext.isEmbarkedThisTurn(unit);
+
+    // (D) non-embarked CM: no amphib destinations
+    if (isCombatMove && !embarked) {
+      return Map.of();
+    }
+
+    // (C) embarked CM: adjacent hostile coasts, !embarkedThisTurn, attack>0 only
+    if (isCombatMove) {
+      if (embarkedThisTurn) {
+        return Map.of();
+      }
+      // AA / attack-0 units cannot assault
+      if (unit.getUnitAttachment().getAttack(player) == 0) {
+        return Map.of();
+      }
+      final Map<Territory, Route> result = new LinkedHashMap<>();
+      for (final Territory adj : player.getData().getMap().getNeighbors(from)) {
+        if (!adj.isWater()
+            && ProMatches.territoryIsEnemyOrCantBeHeld(player, List.of()).test(adj)) {
+          result.put(adj, new Route(from, adj));
+        }
+      }
+      return result;
+    }
+
+    // NCM from here — hasMoved guard (mirrors TS :1473)
+    if (unit.hasMoved()) {
+      return Map.of();
+    }
+
+    // (A) non-embarked NCM: sea-zone embark destinations
+    if (!embarked) {
+      return buildNonEmbarkedNcmDestinations(from, player);
+    }
+
+    // (B) embarked NCM: transit + optional friendly-coast disembark
+    return buildEmbarkedNcmDestinations(from, embarkedThisTurn, player);
+  }
+
+  /**
+   * Case (A): non-embarked land unit, NCM. Returns reachable sea zones.
+   *
+   * <p>The embark hop (land → adjacent SZ) is free (0 budget). Each adjacent SZ seeds a sea BFS
+   * with the {@link #NAVAL_MOVE} budget. Contested SZs (enemy sea units) and canal-blocked hops are
+   * excluded.
+   */
+  private static Map<Territory, Route> buildNonEmbarkedNcmDestinations(
+      final Territory landFrom, final GamePlayer player) {
+
+    final Map<Territory, Route> result = new LinkedHashMap<>();
+    // Hops consumed so far in the sea BFS; keyed by SZ
+    final Map<Territory, Integer> seaHopsUsed = new HashMap<>();
+    final Queue<Map.Entry<Territory, List<Territory>>> queue = new ArrayDeque<>();
+
+    // Seed: adjacent sea zones — embark is free (0 sea hops consumed)
+    for (final Territory adjSz : player.getData().getMap().getNeighbors(landFrom)) {
+      if (!adjSz.isWater()) {
+        continue;
+      }
+      if (adjSz.anyUnitsMatch(Matches.enemyUnit(player).and(Matches.unitIsSea()))) {
+        continue;
+      }
+      final List<Territory> path = new ArrayList<>(List.of(landFrom, adjSz));
+      result.put(adjSz, new Route(path));
+      seaHopsUsed.put(adjSz, 0); // 0 sea-transit hops used (embark is free)
+      queue.add(Map.entry(adjSz, path));
+    }
+
+    // Sea-transit BFS up to NAVAL_MOVE hops from each adjacent SZ
+    while (!queue.isEmpty()) {
+      final Map.Entry<Territory, List<Territory>> entry = queue.poll();
+      final Territory current = entry.getKey();
+      final List<Territory> currentPath = entry.getValue();
+      final int hops = seaHopsUsed.get(current);
+      if (hops >= NAVAL_MOVE) {
+        continue;
+      }
+      for (final Territory next : player.getData().getMap().getNeighbors(current)) {
+        if (!next.isWater()) {
+          continue;
+        }
+        if (result.containsKey(next)) {
+          continue;
+        }
+        if (next.anyUnitsMatch(Matches.enemyUnit(player).and(Matches.unitIsSea()))) {
+          continue;
+        }
+        if (!ProMatches.noCanalsBetweenTerritories(player).test(current, next)) {
+          continue;
+        }
+        final List<Territory> newPath = new ArrayList<>(currentPath);
+        newPath.add(next);
+        result.put(next, new Route(newPath));
+        seaHopsUsed.put(next, hops + 1);
+        queue.add(Map.entry(next, newPath));
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Case (B): already-embarked land unit, NCM. Returns sea-zone transit destinations and, if {@code
+   * !embarkedThisTurn}, adjacent friendly coasts for disembark.
+   *
+   * <p>Sea transit uses the {@link #NAVAL_MOVE} budget from the staging SZ. Friendly-coast
+   * disembark is exactly 1-hop (adjacent), gated by {@code !embarkedThisTurn} (mirrors TS {@code
+   * canEmbarkedUnitDisembark :286}).
+   */
+  private static Map<Territory, Route> buildEmbarkedNcmDestinations(
+      final Territory stagingSz, final boolean embarkedThisTurn, final GamePlayer player) {
+
+    final Map<Territory, Route> result = new LinkedHashMap<>();
+    // visitedSz tracks sea zones we've already processed — includes stagingSz so the BFS
+    // does not loop back and try to add the starting zone as a destination.
+    final Set<Territory> visitedSz = new HashSet<>();
+    visitedSz.add(stagingSz);
+    final Map<Territory, Integer> seaHopsUsed = new HashMap<>();
+    final Queue<Map.Entry<Territory, List<Territory>>> queue = new ArrayDeque<>();
+
+    // Friendly-coast disembark (1-hop, !embarkedThisTurn guard)
+    if (!embarkedThisTurn) {
+      for (final Territory adj : player.getData().getMap().getNeighbors(stagingSz)) {
+        if (!adj.isWater() && Matches.isTerritoryFriendly(player).test(adj)) {
+          result.put(adj, new Route(stagingSz, adj));
+        }
+      }
+    }
+
+    // Sea-transit BFS from staging SZ, up to NAVAL_MOVE hops
+    // Seed: adjacent sea zones (1 hop each)
+    for (final Territory adjSz : player.getData().getMap().getNeighbors(stagingSz)) {
+      if (!adjSz.isWater()) {
+        continue;
+      }
+      if (visitedSz.contains(adjSz)) {
+        continue;
+      }
+      if (adjSz.anyUnitsMatch(Matches.enemyUnit(player).and(Matches.unitIsSea()))) {
+        continue;
+      }
+      if (!ProMatches.noCanalsBetweenTerritories(player).test(stagingSz, adjSz)) {
+        continue;
+      }
+      result.put(adjSz, new Route(stagingSz, adjSz));
+      visitedSz.add(adjSz);
+      seaHopsUsed.put(adjSz, 1);
+      queue.add(Map.entry(adjSz, new ArrayList<>(List.of(stagingSz, adjSz))));
+    }
+
+    while (!queue.isEmpty()) {
+      final Map.Entry<Territory, List<Territory>> entry = queue.poll();
+      final Territory current = entry.getKey();
+      final List<Territory> currentPath = entry.getValue();
+      final int hops = seaHopsUsed.getOrDefault(current, 1);
+      if (hops >= NAVAL_MOVE) {
+        continue;
+      }
+      for (final Territory next : player.getData().getMap().getNeighbors(current)) {
+        if (!next.isWater()) {
+          continue;
+        }
+        if (visitedSz.contains(next)) {
+          continue;
+        }
+        if (next.anyUnitsMatch(Matches.enemyUnit(player).and(Matches.unitIsSea()))) {
+          continue;
+        }
+        if (!ProMatches.noCanalsBetweenTerritories(player).test(current, next)) {
+          continue;
+        }
+        final List<Territory> newPath = new ArrayList<>(currentPath);
+        newPath.add(next);
+        result.put(next, new Route(newPath));
+        visitedSz.add(next);
+        seaHopsUsed.put(next, hops + 1);
+        queue.add(Map.entry(next, newPath));
+      }
+    }
+    return result;
   }
 
   /**

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProCombatMoveUnifiedAmphTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProCombatMoveUnifiedAmphTest.java
@@ -39,7 +39,6 @@ import org.sonatype.goodies.prefs.memory.MemoryPreferences;
 public class ProCombatMoveUnifiedAmphTest {
 
   private static final String SEA_ZONE_6 = "6 Sea Zone";
-  private static final String JAPAN = "Japan";
 
   private GameData data;
   private GamePlayer americans;
@@ -79,10 +78,9 @@ public class ProCombatMoveUnifiedAmphTest {
   @Test
   void aaGunExcludedFromCombatAssaultCandidates_issue2712d() {
     final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
-    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
 
     // AA gun in 6 SZ — embarked from a prior turn, NOT embarkedThisTurn.
-    // Japan is adjacent to 6 SZ and is hostile (Japanese-owned) → valid 1-hop assault target.
+    // Japan and Korea are adjacent to 6 SZ and hostile (Japanese-owned) — valid assault targets.
     final Unit aaGun = GameDataTestUtil.aaGun(data).create(1, americans).get(0);
     data.performChange(ChangeFactory.addUnits(sz6, List.of(aaGun)));
 
@@ -119,9 +117,8 @@ public class ProCombatMoveUnifiedAmphTest {
   @Test
   void infantryAssaultStillWorksAfterAaExclusion() {
     final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
-    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
 
-    // Infantry staged in 6 SZ (embarked, not fresh) alongside the AA gun scenario.
+    // Infantry staged in 6 SZ (embarked, not fresh). Japan/Korea adjacent → hostile coasts.
     final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
     data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProCombatMoveUnifiedAmphTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProCombatMoveUnifiedAmphTest.java
@@ -1,0 +1,180 @@
+package games.strategy.triplea.ai.pro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.MoveDescription;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.player.PlayerBridge;
+import games.strategy.triplea.ai.pro.data.AmphContext;
+import games.strategy.triplea.ai.pro.logging.ProLogCapture;
+import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.delegate.remote.IMoveDelegate;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Integration tests for the unified CM assault model (design §6.3) in {@link
+ * ProCombatMoveAi#findAmphAssaultOptions}.
+ *
+ * <p>Validates the AA / attack-0 exclusion from CM assault candidates (design §5.2-2 / §7.5(d)): AA
+ * guns are fully eligible for NCM embark and disembark, but must be excluded from CM assault
+ * candidates because they cannot contribute to the land battle (attack=0).
+ *
+ * <p>Test map: G40. Americans vs Japanese at war. All units cleared in {@link #setUp}.
+ */
+public class ProCombatMoveUnifiedAmphTest {
+
+  private static final String SEA_ZONE_6 = "6 Sea Zone";
+  private static final String JAPAN = "Japan";
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer japanese;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    japanese = data.getPlayerList().getPlayerId("Japanese");
+    declareWar(americans, japanese);
+
+    for (final Territory t : data.getMap().getTerritories()) {
+      data.performChange(ChangeFactory.removeUnits(t, t.getUnits()));
+    }
+  }
+
+  // ─── §7.5(d) — AA gun excluded from CM assault candidates ────────────────────
+
+  /**
+   * Regression for design §5.2-2 / §7.5(d): an AA gun (attack=0) that is already embarked in 6 Sea
+   * Zone (adjacent to Japan) must NOT be dispatched in a CM assault, even when {@code
+   * isEmbarked=true} and {@code isEmbarkedThisTurn=false}.
+   *
+   * <p>Before the fix, {@code findAmphAssaultOptions} included ALL land units that satisfy {@code
+   * isEmbarked && !isEmbarkedThisTurn}, which includes AA guns. An AA gun dispatched into a combat
+   * assault is pointless (attack=0 contributes nothing) and strands the unit on an enemy coast.
+   *
+   * <p>After the fix, the CM pass excludes units with {@code attack == 0} (AA guns and equivalents)
+   * from assault candidates. AA guns remain fully eligible for NCM embark/disembark (including onto
+   * just-captured coasts per §5.2-2).
+   *
+   * <p><b>Failure mode before the fix:</b> AA gun dispatched to Japan as a CM assault move.
+   * <b>After the fix:</b> no assault move dispatched for the AA gun; it remains in 6 SZ until NCM.
+   */
+  @Test
+  void aaGunExcludedFromCombatAssaultCandidates_issue2712d() {
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+
+    // AA gun in 6 SZ — embarked from a prior turn, NOT embarkedThisTurn.
+    // Japan is adjacent to 6 SZ and is hostile (Japanese-owned) → valid 1-hop assault target.
+    final Unit aaGun = GameDataTestUtil.aaGun(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(aaGun)));
+
+    // AmphContext: AA gun is embarked but NOT fresh — eligible per the old !embarkedThisTurn check.
+    final AmphContext ctx =
+        new AmphContext(true, Set.of(aaGun.getId()), Set.of(/* not embarkedThisTurn */ ));
+
+    final List<MoveDescription> dispatched = runCombatMove(americans, ctx);
+
+    // AA gun must not be dispatched to ANY hostile coast — Japan OR Korea (both adjacent to 6 SZ).
+    final boolean aaAssaultToAnyHostileCoast =
+        dispatched.stream()
+            .anyMatch(m -> m.getUnits().contains(aaGun) && !m.getRoute().getEnd().isWater());
+
+    assertThat(aaAssaultToAnyHostileCoast)
+        .as(
+            "AA gun (attack=0) in 6 Sea Zone must NOT be dispatched as a CM assault to any "
+                + "hostile coast (Japan or Korea). "
+                + "Before the fix: any embarked land unit was included in assault candidates. "
+                + "After the fix: attack-0 units are excluded from CM assault candidates per §5.2-2. "
+                + "Dispatched: "
+                + dispatched)
+        .isFalse();
+  }
+
+  // ─── regression guard: infantry assault still works after AA exclusion ────────
+
+  /**
+   * Regression guard: after excluding AA from CM assault candidates, a regular infantry (attack>0)
+   * staged in 6 SZ must still be dispatched as a CM assault to Japan.
+   *
+   * <p>This test ensures the AA exclusion does not accidentally filter attack-capable units.
+   */
+  @Test
+  void infantryAssaultStillWorksAfterAaExclusion() {
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+
+    // Infantry staged in 6 SZ (embarked, not fresh) alongside the AA gun scenario.
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+
+    final AmphContext ctx =
+        new AmphContext(true, Set.of(infantry.getId()), Set.of(/* not embarkedThisTurn */ ));
+
+    final List<MoveDescription> dispatched = runCombatMove(americans, ctx);
+
+    // Infantry should assault to Japan or any adjacent hostile coast.
+    final boolean infantryAssaultsAnyCoast =
+        dispatched.stream()
+            .anyMatch(m -> m.getUnits().contains(infantry) && !m.getRoute().getEnd().isWater());
+
+    assertThat(infantryAssaultsAnyCoast)
+        .as(
+            "Infantry (attack>0) in 6 Sea Zone must still be dispatched as a CM assault to a "
+                + "hostile coast (Japan or Korea) after the AA exclusion is applied. "
+                + "Dispatched: "
+                + dispatched)
+        .isTrue();
+  }
+
+  // ─── helpers ─────────────────────────────────────────────────────────────────
+
+  private void declareWar(final GamePlayer p1, final GamePlayer p2) {
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            p1,
+            p2,
+            data.getRelationshipTracker().getRelationshipType(p1, p2),
+            data.getRelationshipTypeList().getRelationshipType("War")));
+  }
+
+  private List<MoveDescription> runCombatMove(final GamePlayer player, final AmphContext ctx) {
+    final ProAi proAi = new ProAi("Test " + player.getName(), player.getName() + " AI");
+    final PlayerBridge bridge = mock(PlayerBridge.class);
+    proAi.initialize(bridge, player);
+    when(bridge.getGameData()).thenReturn(data);
+    proAi.reinitializeProDataForSidecar();
+    proAi.getProData().setAmphContext(ctx);
+
+    final List<MoveDescription> dispatched = new ArrayList<>();
+    final IMoveDelegate moveDelegate = mock(IMoveDelegate.class);
+    when(moveDelegate.performMove(any()))
+        .then(
+            inv -> {
+              dispatched.add(inv.getArgument(0));
+              return Optional.empty();
+            });
+
+    try (ProLogCapture ignored = new ProLogCapture()) {
+      proAi.invokeCombatMoveForSidecar(moveDelegate, data, player);
+    }
+    return dispatched;
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAmphTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAmphTest.java
@@ -69,12 +69,15 @@ public class ProNonCombatMoveAmphTest {
     }
   }
 
-  // --- unmoved unit embarks to adjacent staging zone ---
+  // --- unmoved unit embarks toward best staging zone ---
 
   @Test
-  void infantryEmbarksToAdjacentStagingZone() {
+  void infantryEmbarksTowardBestStagingZone() {
+    // With the NAVAL_MOVE=2 budget fix (#2716), infantry is no longer limited to the adjacent 6 SZ.
+    // It can now transit up to 2 sea hops from the free-embark point, so the AI may pick a further
+    // sea zone (e.g. 19 SZ) that scores higher than 6 SZ.  The assertion is therefore relaxed to
+    // "infantry embarks to SOME sea zone" — the specific destination is scoring-dependent.
     final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
-    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
 
     final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
     data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
@@ -82,13 +85,13 @@ public class ProNonCombatMoveAmphTest {
     final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
     final List<MoveDescription> dispatched = runNonCombatMove(americans, ctx);
 
-    final boolean embarkToSz6 =
+    final boolean embarkToAnySz =
         dispatched.stream()
-            .anyMatch(m -> m.getRoute().getEnd().equals(sz6) && m.getUnits().contains(infantry));
+            .anyMatch(m -> m.getRoute().getEnd().isWater() && m.getUnits().contains(infantry));
 
-    assertThat(embarkToSz6)
+    assertThat(embarkToAnySz)
         .as(
-            "Infantry in Korea (adjacent to 6 Sea Zone → Japan) must embark to 6 SZ in NCM. "
+            "Infantry in Korea must embark to some sea zone in NCM (highest-value staging). "
                 + "Dispatched: "
                 + dispatched)
         .isTrue();
@@ -147,21 +150,18 @@ public class ProNonCombatMoveAmphTest {
         .isFalse();
   }
 
-  // --- mech infantry transits to higher-value staging zone ---
+  // --- mech infantry transits past closest SZ to higher-value zone ---
 
   @Test
-  void mechInfantryTransitsToHigherValueStagingZone() {
-    // Soviet Far East → 5 Sea Zone (embark, hop 1) → 6 Sea Zone (transit, hop 2, adj to Japan).
-    // 6 SZ scores higher than 5 SZ because:
-    //   - 5 SZ: only Russian land adjacent (Soviet Far East, Amur, Siberia — NOT enemy) → score
-    //           comes only from Japan/Korea at seaDistance=1 ≈ 2.75
-    //   - 6 SZ: Japan (prod=8) and Korea (prod=3) at seaDistance=0 → score 5.5
-    // mech_infantry has movement=2, so the 2-hop route SovietFarEast→5SZ→6SZ is reachable.
+  void mechInfantryTransitsPastClosestSzToHigherValueZone() {
+    // Soviet Far East is adjacent to 5 Sea Zone. With NAVAL_MOVE=2:
+    //   - 5 SZ: free embark hop, then 2 sea-transit hops available
+    //   - The AI should NOT stop at 5 SZ when a higher-value zone is reachable
+    //   - 6 SZ (adj to Japan) or 19 SZ score higher than 5 SZ (only Russian land adjacent)
+    // mech_infantry has land-movement=2 but NAVAL_MOVE=2 governs sea transit.
     final Territory sovietFarEast = data.getMap().getTerritoryOrThrow(SOVIET_FAR_EAST);
     final Territory sz5 = data.getMap().getTerritoryOrThrow(SEA_ZONE_5);
-    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
-    // Transfer Soviet Far East to Americans so the AI's unit-move-map includes it and the unit
-    // is in a player-accessible territory.
+    // Transfer Soviet Far East to Americans so the AI's unit-move-map includes it.
     data.performChange(ChangeFactory.changeOwner(sovietFarEast, americans));
 
     final Unit mechInf = GameDataTestUtil.mechInfantry(data).create(1, americans).get(0);
@@ -170,23 +170,29 @@ public class ProNonCombatMoveAmphTest {
     final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
     final List<MoveDescription> dispatched = runNonCombatMove(americans, ctx);
 
-    final boolean reachedSz6 =
+    // The unit must embark somewhere (any sea zone).
+    final boolean embarkedAnywhere =
         dispatched.stream()
-            .anyMatch(m -> m.getRoute().getEnd().equals(sz6) && m.getUnits().contains(mechInf));
+            .anyMatch(m -> m.getRoute().getEnd().isWater() && m.getUnits().contains(mechInf));
 
+    // The unit must NOT stop at 5 SZ — 5 SZ has no enemy land adjacent (only Russian), so any
+    // further zone with enemy adjacency scores higher and should be preferred.
     final boolean stoppedAtSz5 =
         dispatched.stream()
             .anyMatch(m -> m.getRoute().getEnd().equals(sz5) && m.getUnits().contains(mechInf));
 
-    assertThat(reachedSz6)
+    assertThat(embarkedAnywhere)
         .as(
-            "mech_infantry in Soviet Far East (movement=2) must transit SovietFarEast→5 SZ→6 SZ "
-                + "(6 SZ adjacent to Japan scores 5.5 vs 5 SZ non-enemy adjacency scores ~2.75). "
+            "mech_infantry in Soviet Far East must transit to some sea zone (highest-value staging). "
                 + "Dispatched: "
                 + dispatched)
         .isTrue();
     assertThat(stoppedAtSz5)
-        .as("mech_infantry must not stop at 5 SZ when 6 SZ is reachable and scores higher")
+        .as(
+            "mech_infantry must not stop at 5 SZ when a higher-value zone is reachable "
+                + "(5 SZ has no enemy land adjacent — only Russian territories). "
+                + "Dispatched: "
+                + dispatched)
         .isFalse();
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProNonCombatMoveUnifiedAmphTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProNonCombatMoveUnifiedAmphTest.java
@@ -1,0 +1,360 @@
+package games.strategy.triplea.ai.pro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.MoveDescription;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.player.PlayerBridge;
+import games.strategy.triplea.ai.pro.data.AmphContext;
+import games.strategy.triplea.ai.pro.logging.ProLogCapture;
+import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.delegate.remote.IMoveDelegate;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Integration tests for the unified embarked-movement model (design §6.2) in {@link
+ * ProNonCombatMoveAi#calculateAmphEmbarkMoves}.
+ *
+ * <p>Resolves #2717 (already-embarked units stranded by {@code !isEmbarked} filter) and validates
+ * the survival-probability gate (§6.6 / §5.2-1). Tests are ordered from lowest-level behavioural
+ * regression to highest-level end-to-end scenarios.
+ *
+ * <p>Test map: G40. Americans vs Japanese at war. All units cleared in {@link #setUp}; each test
+ * places exactly the units it needs.
+ */
+public class ProNonCombatMoveUnifiedAmphTest {
+
+  private static final String KOREA = "Korea";
+  private static final String SEA_ZONE_5 = "5 Sea Zone";
+  private static final String SEA_ZONE_6 = "6 Sea Zone";
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer japanese;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    japanese = data.getPlayerList().getPlayerId("Japanese");
+    declareWar(americans, japanese);
+
+    for (final Territory t : data.getMap().getTerritories()) {
+      data.performChange(ChangeFactory.removeUnits(t, t.getUnits()));
+    }
+  }
+
+  // ─── §7.3 (#2717a) — already-embarked unit is not filtered out ──────────────
+
+  /**
+   * Regression for #2717a: an infantry unit that is already embarked in a sea zone (from a prior
+   * turn) must be included in NCM embark-move candidates.
+   *
+   * <p>Before the fix, {@code calculateAmphEmbarkMoves} iterated only over non-water territories
+   * and filtered {@code !ctx.isEmbarked(u)} — so an embarked unit sitting in 6 Sea Zone was
+   * completely invisible to the NCM pass; it received no move.
+   *
+   * <p>After the fix the code also iterates over sea zones, finds the embarked infantry, and
+   * dispatches it to an adjacent friendly coast (Korea, transferred to Americans so there is a
+   * disembark target with production value).
+   *
+   * <p><b>Why Korea must be American:</b> branch (B) of {@code getAmphReachableTerritories} only
+   * adds adjacent <em>friendly</em> coasts as disembark targets. An enemy Korea would not be a
+   * valid disembark destination, so the only remaining destinations are further sea zones — and
+   * with no enemy land adjacent to those zones, {@code findAmphReachableLandValue} would return 0
+   * for all of them, leaving the AI with no positive-scoring move. Transferring Korea to Americans
+   * gives the unit a productive landing zone (Korea production=3).
+   */
+  @Test
+  void alreadyEmbarkedInfantryGetsNcmMove_issue2717a() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+
+    // Transfer Korea to Americans — friendly disembark target with production value.
+    data.performChange(ChangeFactory.changeOwner(korea, americans));
+
+    // Place enemy infantry in Japan so 6 SZ has staging value
+    // (Japan is adjacent to 6 SZ — gives findAmphReachableLandValue > 0 for sea zones adj to it).
+    final Territory japan = data.getMap().getTerritoryOrThrow("Japan");
+    final List<Unit> japaneseInfantry = GameDataTestUtil.infantry(data).create(1, japanese);
+    data.performChange(ChangeFactory.addUnits(japan, japaneseInfantry));
+
+    // Infantry is ALREADY IN 6 Sea Zone and EMBARKED (not fresh — prior-turn embark).
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+
+    // AmphContext: infantry is embarked but NOT embarkedThisTurn.
+    final AmphContext ctx =
+        new AmphContext(true, Set.of(infantry.getId()), Set.of(/* not fresh */ ));
+
+    final List<MoveDescription> dispatched = runNonCombatMove(americans, ctx);
+
+    final boolean infantryMoved =
+        dispatched.stream().anyMatch(m -> m.getUnits().contains(infantry));
+
+    assertThat(infantryMoved)
+        .as(
+            "An already-embarked infantry in 6 Sea Zone must receive an NCM move "
+                + "(disembark to Korea or transit to an adjacent SZ). "
+                + "Before the fix the !isEmbarked filter silently excluded it. "
+                + "Dispatched: "
+                + dispatched)
+        .isTrue();
+  }
+
+  // ─── §7.10 — freshly-embarked unit must NOT disembark same turn ─────────────
+
+  /**
+   * A unit that embarked THIS turn ({@code isEmbarkedThisTurn=true}) must not receive a disembark
+   * (or further NCM) move in the same NCM pass. Engine rule: {@code embarkedThisTurn} blocks
+   * disembark (§5.2-1 design ref, engine source {@code canEmbarkedUnitDisembark:284}).
+   *
+   * <p>This test is primarily a regression guard: the current code never even finds a freshly-
+   * embarked unit (it sits in a sea zone and the old loop skips water territories). After the loop
+   * is extended to cover sea zones, the {@code isEmbarkedThisTurn} guard inside {@link
+   * games.strategy.triplea.ai.pro.util.ProAmphUtils#getAmphReachableTerritories} must prevent a
+   * disembark move.
+   */
+  @Test
+  void freshlyEmbarkedInfantryDoesNotDisembark() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+
+    // Friendly Korea — would be a valid disembark target if the guard were absent.
+    data.performChange(ChangeFactory.changeOwner(korea, americans));
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+
+    // BOTH embarked AND embarkedThisTurn → same-turn guard must fire.
+    final AmphContext ctx =
+        new AmphContext(true, Set.of(infantry.getId()), Set.of(infantry.getId()) /* fresh */);
+
+    final List<MoveDescription> dispatched = runNonCombatMove(americans, ctx);
+
+    final boolean disembarkedToKorea =
+        dispatched.stream()
+            .anyMatch(m -> m.getUnits().contains(infantry) && m.getRoute().getEnd().equals(korea));
+
+    assertThat(disembarkedToKorea)
+        .as(
+            "A freshly-embarked infantry (embarkedThisTurn=true) must NOT disembark to Korea "
+                + "in the same NCM pass. Dispatched: "
+                + dispatched)
+        .isFalse();
+  }
+
+  // ─── §7.7 — survival gate blocks embark to threatened zone ──────────────────
+
+  /**
+   * Regression for §5.2-1 (design): when enemy strength makes {@code P(stagingZone) < 0.70}, the
+   * NCM pass must NOT embark the unit into that zone.
+   *
+   * <p>Before the fix there is no survival-probability gate: the AI always embarks toward the
+   * highest-valued staging zone regardless of enemy presence. Adding 5 Japanese battleships to 5
+   * Sea Zone (adjacent to 6 Sea Zone) makes the expected-survival probability of 6 SZ well below
+   * the 0.70 threshold, so the fix must suppress the embark.
+   *
+   * <p>The test is RED before the fix (unit embarks into the threatened 6 SZ) and GREEN after (the
+   * gate rejects 6 SZ as too risky; with no other safe sea zone adjacent to Korea, no embark is
+   * generated).
+   */
+  @Test
+  void survivalGateBlocksEmbarkToThreatenedZone() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory sz5 = data.getMap().getTerritoryOrThrow(SEA_ZONE_5);
+
+    // Infantry in Korea (non-water, non-embarked) — standard embark candidate.
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+
+    // Overwhelming enemy fleet in 5 SZ (adjacent to 6 SZ) — 5 battleships.
+    // survivalProbability([infantry], 6 SZ, Americans) with 5 adjacent enemy battleships
+    // and no friendly escort must come out well below DISEMBARK_SURVIVAL_THRESHOLD (0.70).
+    final List<Unit> enemyFleet = GameDataTestUtil.battleship(data).create(5, japanese);
+    data.performChange(ChangeFactory.addUnits(sz5, enemyFleet));
+
+    final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
+    final List<MoveDescription> dispatched = runNonCombatMove(americans, ctx);
+
+    final boolean embarkToSz6 =
+        dispatched.stream()
+            .anyMatch(m -> m.getUnits().contains(infantry) && m.getRoute().getEnd().equals(sz6));
+
+    assertThat(embarkToSz6)
+        .as(
+            "5 Japanese battleships in 5 SZ make P(6 SZ) < 0.70 — "
+                + "the survival gate must block the embark. "
+                + "Before the fix (no gate): unit embarks unconditionally. "
+                + "Dispatched: "
+                + dispatched)
+        .isFalse();
+  }
+
+  // ─── §7.7 (positive) — survival gate allows embark when escort is sufficient ─
+
+  /**
+   * Regression guard (§5.2-1 positive): when friendly escort in the staging zone makes {@code
+   * P(stagingZone) ≥ 0.70}, the NCM pass MUST embark the infantry.
+   *
+   * <p>This test is GREEN before the fix (no gate ⇒ always embark) and must remain GREEN after
+   * (gate passes because of the escort). It guards against the gate over-firing and blocking safe
+   * embark routes.
+   */
+  @Test
+  void survivalGateAllowsEmbarkWithSufficientEscort() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory sz5 = data.getMap().getTerritoryOrThrow(SEA_ZONE_5);
+
+    // Infantry in Korea — standard embark candidate.
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+
+    // 5 American battleships in 6 SZ — strong escort.
+    final List<Unit> escort = GameDataTestUtil.battleship(data).create(5, americans);
+    data.performChange(ChangeFactory.addUnits(sz6, escort));
+
+    // Weak enemy: 1 Japanese destroyer in 5 SZ — minor threat, easily overmatched by escort.
+    final List<Unit> weakEnemy = GameDataTestUtil.destroyer(data).create(1, japanese);
+    data.performChange(ChangeFactory.addUnits(sz5, weakEnemy));
+
+    // Japan is enemy territory (gives 6 SZ a positive staging score).
+    // Japan is already owned by Japanese and adjacent to 6 SZ — no extra setup needed.
+
+    final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
+    final List<MoveDescription> dispatched = runNonCombatMove(americans, ctx);
+
+    // The infantry must be dispatched to SOME sea zone (gate allowed).
+    // We do not constrain the specific destination: the AI picks the highest-value staging zone,
+    // which may be 6 SZ or a further zone (e.g. 19 SZ) depending on adjacency scoring.
+    final boolean embarkToAnySz =
+        dispatched.stream()
+            .anyMatch(m -> m.getUnits().contains(infantry) && m.getRoute().getEnd().isWater());
+
+    assertThat(embarkToAnySz)
+        .as(
+            "5 American battleships in 6 SZ vs 1 Japanese destroyer in 5 SZ → "
+                + "P must be ≥ 0.70. Survival gate must NOT block this embark to any sea zone. "
+                + "Dispatched: "
+                + dispatched)
+        .isTrue();
+  }
+
+  // ─── §7.8 — retreat trigger: already-embarked unit is dispatched when SZ is threatened ────────
+
+  /**
+   * Regression for §5.2-1 / §7.8 (design): an already-embarked infantry in a staging zone must
+   * receive an NCM move when the staging zone is under threat.
+   *
+   * <p>Before the fix, the unit is invisible to NCM (in a sea zone, skipped by the {@code
+   * !isWater()} loop) — dispatched is empty. After the fix the unit is found and scored: Korea
+   * (American-owned, adjacent to 6 SZ, production=3) is a valid disembark target, and several
+   * adjacent sea zones may also be reachable. The specific destination (Korea vs a sea zone)
+   * depends on per-SZ scoring and is not constrained here — the key regression is that the unit is
+   * found and gets SOME move, as opposed to the pre-fix silent exclusion.
+   *
+   * <p>The survival-gate mechanics (sea-zone destinations gated by {@code survivalProbability ≥
+   * DISEMBARK_SURVIVAL_THRESHOLD}) are validated at the level of the non-embarked path by {@link
+   * #survivalGateBlocksEmbarkToThreatenedZone} and {@link
+   * #survivalGateAllowsEmbarkWithSufficientEscort}.
+   */
+  @Test
+  void retreatTrigger_alreadyEmbarkedUnitIsDispatchedWhenSzUnderThreat() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory sz5 = data.getMap().getTerritoryOrThrow(SEA_ZONE_5);
+
+    // Transfer Korea to Americans — gives the unit a friendly disembark target.
+    data.performChange(ChangeFactory.changeOwner(korea, americans));
+
+    // Infantry already in 6 SZ (embarked from a prior turn).
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+
+    // Threatening enemy fleet in 5 SZ (adjacent to 6 SZ).
+    final List<Unit> enemyFleet = GameDataTestUtil.battleship(data).create(5, japanese);
+    data.performChange(ChangeFactory.addUnits(sz5, enemyFleet));
+
+    // AmphContext: infantry embarked (not fresh — prior turn).
+    final AmphContext ctx =
+        new AmphContext(true, Set.of(infantry.getId()), Set.of(/* not embarkedThisTurn */ ));
+
+    final List<MoveDescription> dispatched = runNonCombatMove(americans, ctx);
+
+    final boolean infantryDispatched =
+        dispatched.stream().anyMatch(m -> m.getUnits().contains(infantry));
+
+    assertThat(infantryDispatched)
+        .as(
+            "Already-embarked infantry in 6 SZ (prior-turn embark) must receive an NCM move "
+                + "— retreat to Korea or transit to an adjacent SZ. "
+                + "Before the fix the !isWater() loop skipped the unit entirely. "
+                + "Dispatched: "
+                + dispatched)
+        .isTrue();
+  }
+
+  // ─── helpers ─────────────────────────────────────────────────────────────────
+
+  private void declareWar(final GamePlayer p1, final GamePlayer p2) {
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            p1,
+            p2,
+            data.getRelationshipTracker().getRelationshipType(p1, p2),
+            data.getRelationshipTypeList().getRelationshipType("War")));
+  }
+
+  private List<MoveDescription> runNonCombatMove(final GamePlayer p, final AmphContext ctx) {
+    advanceToStep("americansNonCombatMove");
+
+    final ProAi proAi = new ProAi("Test " + p.getName(), p.getName() + " AI");
+    final PlayerBridge bridge = mock(PlayerBridge.class);
+    proAi.initialize(bridge, p);
+    when(bridge.getGameData()).thenReturn(data);
+    proAi.reinitializeProDataForSidecar();
+    proAi.getProData().setAmphContext(ctx);
+
+    final List<MoveDescription> dispatched = new ArrayList<>();
+    final IMoveDelegate moveDelegate = mock(IMoveDelegate.class);
+    when(moveDelegate.performMove(any()))
+        .then(
+            inv -> {
+              dispatched.add(inv.getArgument(0));
+              return Optional.empty();
+            });
+
+    try (ProLogCapture ignored = new ProLogCapture()) {
+      proAi.invokeNonCombatMoveForSidecar(moveDelegate, data, p);
+    }
+    return dispatched;
+  }
+
+  private void advanceToStep(final String stepName) {
+    try (GameData.Unlocker ignored = data.acquireWriteLock()) {
+      final int length = data.getSequence().size();
+      for (int i = 0; i < length; i++) {
+        if (data.getSequence().getStep().getName().contains(stepName)) break;
+        data.getSequence().next();
+      }
+    }
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphUtilsGetAmphReachableTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphUtilsGetAmphReachableTest.java
@@ -1,0 +1,432 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.triplea.ai.pro.data.AmphContext;
+import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Tests for {@link ProAmphUtils#getAmphReachableTerritories} — the unified reachability primitive.
+ *
+ * <p>All tests use G40 Pacific geography. American vs Japanese war declared.
+ *
+ * <p>Map reference (Pacific region):
+ *
+ * <ul>
+ *   <li>Korea (land, adj to 6 Sea Zone) → 6 Sea Zone (adj to Japan, 5 SZ, 7 SZ, 16 SZ, 17 SZ, 18
+ *       SZ, 19 SZ)
+ *   <li>5 Sea Zone (adj to Soviet Far East, Amur, Siberia, 7 SZ, 4 SZ, 6 SZ)
+ *   <li>Japan (land, adj to 6 SZ — initial owner: Japanese)
+ * </ul>
+ *
+ * <p>Resolves: map-room#2716 (NAVAL_MOVE budget), map-room#2717a (already-embarked NCM move),
+ * map-room#2712 (AA policy), guards (§7.10), CM 1-hop (§7.11).
+ */
+public class ProAmphUtilsGetAmphReachableTest {
+
+  private static final String KOREA = "Korea";
+  private static final String SEA_ZONE_6 = "6 Sea Zone";
+  private static final String SEA_ZONE_5 = "5 Sea Zone";
+  private static final String SEA_ZONE_7 = "7 Sea Zone";
+  private static final String JAPAN = "Japan";
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer japanese;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    japanese = data.getPlayerList().getPlayerId("Japanese");
+    declareWar(americans, japanese);
+    // Clear all units for a stable, predictable map state.
+    for (final Territory t : data.getMap().getTerritories()) {
+      data.performChange(ChangeFactory.removeUnits(t, t.getUnits()));
+    }
+  }
+
+  // ─── toggle-off (§7.13) ───────────────────────────────────────────────────
+
+  @Test
+  void disabledContextReturnsEmpty() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(
+            infantry, korea, false, AmphContext.DISABLED, americans);
+
+    assertThat(result).as("AmphContext.DISABLED must return empty for any unit/position").isEmpty();
+  }
+
+  // ─── non-embarked, combat move (§6.1 D) ──────────────────────────────────
+
+  @Test
+  void nonEmbarkedCombatMoveReturnsEmpty() {
+    // (D) non-embarked land unit in CM has no amphib destinations.
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+    final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(infantry, korea, true, ctx, americans);
+
+    assertThat(result)
+        .as("Non-embarked land unit in CM has no amphib destinations (case D)")
+        .isEmpty();
+  }
+
+  // ─── hasMoved guard (§7.10) ───────────────────────────────────────────────
+
+  @Test
+  void hasMovedGuardReturnsEmptyForNonEmbarked() {
+    // A land unit that has already moved this turn has no further NCM destinations.
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+    // Mark unit as having moved (alreadyMoved > 0)
+    data.performChange(ChangeFactory.markNoMovementChange(List.of(infantry)));
+    final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(infantry, korea, false, ctx, americans);
+
+    assertThat(result)
+        .as("Unit with hasMoved()=true must yield empty NCM reachable set (mirrors :1473)")
+        .isEmpty();
+  }
+
+  // ─── #2716: NAVAL_MOVE budget — non-embarked unit reaches beyond adjacent SZ ───
+
+  /**
+   * Regression for map-room#2716: a non-embarked infantry (land move = 1) must be able to transit
+   * to sea zones beyond the first adjacent SZ using the NAVAL_MOVE = 2 budget.
+   *
+   * <p>Before the fix: {@code maxHops = u.getMovementLeft() = 1} → only 6 Sea Zone (adjacent).
+   * After the fix: sea BFS runs with budget = {@code NAVAL_MOVE = 2} from each adjacent SZ, so 5
+   * Sea Zone (1 sea hop from 6 SZ) is also reachable.
+   */
+  @Test
+  void infantryInKoreaReachesAdjacentAndTransitSeaZones_issue2716() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory sz5 = data.getMap().getTerritoryOrThrow(SEA_ZONE_5);
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+    final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(infantry, korea, false, ctx, americans);
+
+    assertThat(result)
+        .as("6 Sea Zone (adjacent, free embark) must be in reachable set")
+        .containsKey(sz6);
+    assertThat(result)
+        .as(
+            "5 Sea Zone (1 sea hop from 6 SZ, within NAVAL_MOVE=2) must be in reachable set. "
+                + "#2716: pre-fix code used land movement (1) as maxHops → only 6 SZ reachable.")
+        .containsKey(sz5);
+  }
+
+  @Test
+  void nonEmbarkedUnitSeaDestinationsAreAllWaterTerritories() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+    final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(infantry, korea, false, ctx, americans);
+
+    // Case A: non-embarked NCM destinations are all sea zones (no disembark)
+    assertThat(result.keySet())
+        .as("Non-embarked NCM: all destinations must be sea zones (no disembark in same turn)")
+        .allMatch(Territory::isWater);
+  }
+
+  // ─── #2717a: already-embarked gets NCM move ───────────────────────────────
+
+  /**
+   * Regression for map-room#2717a: an already-embarked unit (prior turn) must receive a non-empty
+   * NCM reachable set. The pre-fix {@code !isEmbarked} filter in {@code calculateAmphEmbarkMoves}
+   * caused all staged units to be silently skipped.
+   */
+  @Test
+  void alreadyEmbarkedInfantryGetsNcmTransitDestinations_issue2717a() {
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+    // Unit is embarked from a prior turn, NOT embarked this turn.
+    final AmphContext ctx = new AmphContext(true, Set.of(infantry.getId()), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(infantry, sz6, false, ctx, americans);
+
+    assertThat(result)
+        .as("Already-embarked unit must get a non-empty NCM reachable set")
+        .isNotEmpty();
+    assertThat(result)
+        .as("5 Sea Zone (adjacent to 6 SZ, clear transit) must be reachable for embarked NCM")
+        .containsKey(data.getMap().getTerritoryOrThrow(SEA_ZONE_5));
+  }
+
+  @Test
+  void alreadyEmbarkedTransitDestinationsAreAllSeaZones() {
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+    final AmphContext ctx = new AmphContext(true, Set.of(infantry.getId()), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(infantry, sz6, false, ctx, americans);
+
+    // With Japan hostile and Korea also hostile (default G40), all adjacent land is enemy.
+    // So no friendly-coast disembark target here — all destinations are sea zones.
+    // (Korea is Japanese-owned in default setup; Japan is Japanese.)
+    final long friendlyLandCount =
+        result.keySet().stream()
+            .filter(t -> !t.isWater())
+            .filter(t -> Matches.isTerritoryFriendly(americans).test(t))
+            .count();
+    final long seaCount = result.keySet().stream().filter(Territory::isWater).count();
+    assertThat(seaCount)
+        .as("At least the adjacent SZs should be reachable transit targets")
+        .isPositive();
+    // Friendly land disembark check - zero in default setup (all adjacent land is Japanese)
+    assertThat(friendlyLandCount)
+        .as("No friendly land adjacent to 6 SZ in default G40 setup → 0 friendly disembark targets")
+        .isEqualTo(0);
+  }
+
+  // ─── embarked NCM — disembark to friendly coast ───────────────────────────
+
+  @Test
+  void embarkedUnitDisembarksToFriendlyAdjacentCoast() {
+    // Transfer Korea to Americans so it becomes a friendly disembark target adjacent to 6 SZ.
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    data.performChange(ChangeFactory.changeOwner(korea, americans));
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+    // Embarked from prior turn, NOT embarked this turn.
+    final AmphContext ctx = new AmphContext(true, Set.of(infantry.getId()), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(infantry, sz6, false, ctx, americans);
+
+    assertThat(result)
+        .as(
+            "Korea (now American-owned, adjacent to 6 SZ) must be a friendly disembark target "
+                + "for an embarked infantry doing NCM")
+        .containsKey(korea);
+    final Route disembarkRoute = result.get(korea);
+    assertThat(disembarkRoute.getStart())
+        .as("Disembark route must start at the staging sea zone (6 SZ)")
+        .isEqualTo(sz6);
+    assertThat(disembarkRoute.getEnd())
+        .as("Disembark route must end at the friendly coast (Korea)")
+        .isEqualTo(korea);
+  }
+
+  // ─── embarkedThisTurn guard — no disembark (§7.10) ───────────────────────
+
+  @Test
+  void freshlyEmbarkedUnitHasNoNcmDisembarkTargets() {
+    // Transfer Korea to Americans so it would be a disembark target — but embarkedThisTurn
+    // must block it.
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    data.performChange(ChangeFactory.changeOwner(korea, americans));
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+    // Embarked this turn → blocks disembark
+    final AmphContext ctx =
+        new AmphContext(true, Set.of(infantry.getId()), Set.of(infantry.getId()));
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(infantry, sz6, false, ctx, americans);
+
+    assertThat(result)
+        .as("Freshly-embarked unit (embarkedThisTurn) must NOT disembark in the same NCM turn")
+        .doesNotContainKey(korea);
+    // But sea-zone transit IS allowed (embarkedThisTurn only blocks disembark, not transit)
+    assertThat(result.keySet())
+        .as("Freshly-embarked unit may still transit to other sea zones in NCM")
+        .anyMatch(Territory::isWater);
+  }
+
+  // ─── CM assault — 1-hop hostile coasts only (§7.11) ──────────────────────
+
+  @Test
+  void embarkedInfantryCombatMovReachesAdjacentHostileCoastOnly() {
+    // In 6 Sea Zone: Japan (hostile) is adjacent. Korea is also adjacent but needs ownership check.
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Territory japan = data.getMap().getTerritoryOrThrow(JAPAN);
+    // Japan stays Japanese-owned (hostile).
+    data.performChange(ChangeFactory.changeOwner(japan, japanese));
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+    // Embarked from prior turn, NOT this turn.
+    final AmphContext ctx = new AmphContext(true, Set.of(infantry.getId()), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(infantry, sz6, true, ctx, americans);
+
+    assertThat(result)
+        .as("Japan (hostile, 1 hop from 6 SZ) must be a CM assault target")
+        .containsKey(japan);
+    assertThat(result.keySet())
+        .as("CM assault destinations must all be land territories (no sea-zone destinations)")
+        .noneMatch(Territory::isWater);
+    for (final Territory dest : result.keySet()) {
+      assertThat(data.getMap().getNeighbors(sz6))
+          .as("CM assault destination %s must be exactly 1 hop from staging SZ", dest.getName())
+          .contains(dest);
+    }
+  }
+
+  @Test
+  void embarkedThisTurnBlocksCombatAssault() {
+    // embarkedThisTurn → no CM assault (same-turn guard).
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(infantry)));
+    // Embarked this turn
+    final AmphContext ctx =
+        new AmphContext(true, Set.of(infantry.getId()), Set.of(infantry.getId()));
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(infantry, sz6, true, ctx, americans);
+
+    assertThat(result)
+        .as(
+            "embarkedThisTurn must block CM assault (mirrors TS engine :1296): "
+                + "same-turn embark+assault not allowed")
+        .isEmpty();
+  }
+
+  // ─── #2712: AA / attack-0 excluded from CM assault (§7.5d) ───────────────
+
+  /**
+   * Regression for map-room#2712: an AA gun (attack=0) must return empty CM destinations.
+   *
+   * <p>AA guns can embark and NCM-disembark freely, but must never appear in CM assault candidates
+   * — they cannot contribute to a land battle and would occupy a staging SZ uselessly.
+   */
+  @Test
+  void aaGunEmbarkedCombatMoveReturnsEmpty_issue2712d() {
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Unit aaGun = GameDataTestUtil.aaGun(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(aaGun)));
+    // Embarked from prior turn
+    final AmphContext ctx = new AmphContext(true, Set.of(aaGun.getId()), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(aaGun, sz6, true, ctx, americans);
+
+    assertThat(result)
+        .as(
+            "AA gun (attack=0) must return empty CM destinations — "
+                + "AA cannot contribute to assault and must not appear in CM candidates (#2712)")
+        .isEmpty();
+  }
+
+  @Test
+  void aaGunEmbarkedNcmHasTransitDestinations() {
+    // AA should still be allowed to transit in NCM (only CM assault is excluded).
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Unit aaGun = GameDataTestUtil.aaGun(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(aaGun)));
+    // Embarked from prior turn
+    final AmphContext ctx = new AmphContext(true, Set.of(aaGun.getId()), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(aaGun, sz6, false, ctx, americans);
+
+    assertThat(result)
+        .as("AA gun should still have NCM transit destinations (excluded only from CM assault)")
+        .isNotEmpty();
+  }
+
+  // ─── route structure ─────────────────────────────────────────────────────
+
+  @Test
+  void routeStartIsFromAndEndIsDestination() {
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+    final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(infantry, korea, false, ctx, americans);
+
+    assertThat(result).containsKey(sz6);
+    final Route route = result.get(sz6);
+    assertThat(route.getStart()).as("Route start must equal 'from' (Korea)").isEqualTo(korea);
+    assertThat(route.getEnd()).as("Route end must equal the destination (6 SZ)").isEqualTo(sz6);
+  }
+
+  // ─── contested SZ excluded ────────────────────────────────────────────────
+
+  @Test
+  void contestedSeaZoneIsExcludedFromReachable() {
+    // Place an enemy destroyer in 6 SZ — makes it contested.
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(korea, List.of(infantry)));
+    final Unit destroyer = GameDataTestUtil.destroyer(data).create(1, japanese).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(destroyer)));
+    final AmphContext ctx = new AmphContext(true, Set.of(), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(infantry, korea, false, ctx, americans);
+
+    assertThat(result)
+        .as("Contested sea zone (enemy warship present) must be excluded from reachable set")
+        .doesNotContainKey(sz6);
+  }
+
+  // ─── NAVAL_MOVE constant ─────────────────────────────────────────────────
+
+  @Test
+  void navalMoveConstantIsTwo() {
+    assertThat(ProAmphUtils.NAVAL_MOVE)
+        .as("NAVAL_MOVE must equal 2 (matches TS engine tech-effects.ts:6)")
+        .isEqualTo(2);
+  }
+
+  // ─── helpers ─────────────────────────────────────────────────────────────
+
+  private void declareWar(final GamePlayer p1, final GamePlayer p2) {
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            p1,
+            p2,
+            data.getRelationshipTracker().getRelationshipType(p1, p2),
+            data.getRelationshipTypeList().getRelationshipType("War")));
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphUtilsGetAmphReachableTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphUtilsGetAmphReachableTest.java
@@ -42,7 +42,6 @@ public class ProAmphUtilsGetAmphReachableTest {
   private static final String KOREA = "Korea";
   private static final String SEA_ZONE_6 = "6 Sea Zone";
   private static final String SEA_ZONE_5 = "5 Sea Zone";
-  private static final String SEA_ZONE_7 = "7 Sea Zone";
   private static final String JAPAN = "Japan";
 
   private GameData data;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphUtilsGetAmphReachableTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphUtilsGetAmphReachableTest.java
@@ -369,6 +369,52 @@ public class ProAmphUtilsGetAmphReachableTest {
         .isNotEmpty();
   }
 
+  /**
+   * §7 test #6 (design §5.2-2, "verify, don't assume"): an embarked AA gun may disembark onto a
+   * coast captured this turn by another unit's CM assault.
+   *
+   * <p>Setup simulates post-CM state: Korea is initially Japanese-owned, then captured via {@link
+   * ChangeFactory#changeOwner} (mirroring what the engine does when a CM assault succeeds). The NCM
+   * disembark-eligibility check in {@link ProAmphUtils#getAmphReachableTerritories} uses {@link
+   * games.strategy.triplea.delegate.Matches#isTerritoryFriendly}, which reads the territory's
+   * current owner. This test confirms that post-CM ownership change surfaces correctly to the NCM
+   * primitive — no stale cached state hides the just-captured coast.
+   *
+   * <p>The TS engine's CM→NCM phase ordering makes this natural in production; this test provides
+   * evidence rather than assumption (design instruction: "confirm with a dedicated test, don't
+   * assume").
+   */
+  @Test
+  void aaGunDisembarksOntoJustCapturedCoast_issue2712b() {
+    // Korea starts as Japanese-owned (default G40; setUp does not change it).
+    // Simulate another unit's CM assault capturing Korea this turn.
+    final Territory korea = data.getMap().getTerritoryOrThrow(KOREA);
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    data.performChange(ChangeFactory.changeOwner(korea, americans));
+
+    // Place an AA gun in 6 Sea Zone, embarked from a prior turn (eligible for NCM disembark).
+    final Unit aaGun = GameDataTestUtil.aaGun(data).create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(sz6, List.of(aaGun)));
+    // embarked=true, embarkedThisTurn=false → eligible for NCM disembark
+    final AmphContext ctx = new AmphContext(true, Set.of(aaGun.getId()), Set.of());
+
+    final Map<Territory, Route> result =
+        ProAmphUtils.getAmphReachableTerritories(aaGun, sz6, false, ctx, americans);
+
+    assertThat(result)
+        .as(
+            "Korea (just captured via CM) must appear as a friendly disembark target in the same "
+                + "turn's NCM — post-CM ownership change must surface to the NCM primitive (§5.2-2)")
+        .containsKey(korea);
+    final Route disembarkRoute = result.get(korea);
+    assertThat(disembarkRoute.getStart())
+        .as("Disembark route must start at the staging SZ (6 Sea Zone)")
+        .isEqualTo(sz6);
+    assertThat(disembarkRoute.getEnd())
+        .as("Disembark route must end at the just-captured coast (Korea)")
+        .isEqualTo(korea);
+  }
+
   // ─── route structure ─────────────────────────────────────────────────────
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphUtilsSurvivalTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphUtilsSurvivalTest.java
@@ -1,0 +1,185 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Tests for {@link ProAmphUtils#survivalProbability} and {@link
+ * ProAmphUtils#DISEMBARK_SURVIVAL_THRESHOLD}.
+ *
+ * <p>Verifies the survival-gate semantics described in design §6.6 and §5.2-1.
+ */
+public class ProAmphUtilsSurvivalTest {
+
+  private static final String SEA_ZONE_6 = "6 Sea Zone";
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer japanese;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    japanese = data.getPlayerList().getPlayerId("Japanese");
+    declareWar(americans, japanese);
+    for (final Territory t : data.getMap().getTerritories()) {
+      data.performChange(ChangeFactory.removeUnits(t, t.getUnits()));
+    }
+  }
+
+  // ─── constant ────────��───────────────────────────────────────────────────
+
+  @Test
+  void disembarkSurvivalThresholdIsSeventyPercent() {
+    assertThat(ProAmphUtils.DISEMBARK_SURVIVAL_THRESHOLD)
+        .as("DISEMBARK_SURVIVAL_THRESHOLD must equal 0.70 (design §6.6)")
+        .isEqualTo(0.70);
+  }
+
+  // ─── no enemy threat → P = 1.0 ────────────────────────���──────────────────
+
+  @Test
+  void noEnemyUnitsNearbyYieldsProbabilityOne() {
+    // Staging SZ with one American infantry and zero enemy units anywhere.
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+
+    final double p = ProAmphUtils.survivalProbability(List.of(infantry), sz6, americans);
+
+    assertThat(p).as("No enemy threat → P must be 1.0 (definitely safe)").isEqualTo(1.0);
+  }
+
+  // ─── overwhelming attack → P < threshold ───────────────────────��─────────
+
+  @Test
+  void overwhelmingEnemyFleetYieldsProbabilityBelowThreshold() {
+    // Place a large Japanese fleet adjacent to 6 SZ (e.g., in Korea → not water; use another SZ).
+    // 5 battleships adjacent to 6 SZ with only 1 infantry defending → attacker wins overwhelmingly.
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    // Put enemy battleships IN 6 SZ (or an adjacent SZ adjacent to 6 SZ)
+    // Using 5 SZ as the adjacent hostile location.
+    final Territory sz5 = data.getMap().getTerritoryOrThrow("5 Sea Zone");
+    final List<Unit> enemyFleet = GameDataTestUtil.battleship(data).create(5, japanese);
+    data.performChange(ChangeFactory.addUnits(sz5, enemyFleet));
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+
+    final double p = ProAmphUtils.survivalProbability(List.of(infantry), sz6, americans);
+
+    assertThat(p)
+        .as(
+            "5 Japanese battleships adjacent to 6 SZ vs 1 American infantry → "
+                + "P must be below the survival threshold (%s)",
+            ProAmphUtils.DISEMBARK_SURVIVAL_THRESHOLD)
+        .isLessThan(ProAmphUtils.DISEMBARK_SURVIVAL_THRESHOLD);
+  }
+
+  // ─── strong friendly escort → P ≥ threshold ──────────────────────��───────
+
+  @Test
+  void strongFriendlyEscortYieldsProbabilityAboveThreshold() {
+    // Large American fleet in 6 SZ as escorts, vs weak enemy threat.
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+    final List<Unit> americanFleet = GameDataTestUtil.battleship(data).create(5, americans);
+    data.performChange(ChangeFactory.addUnits(sz6, americanFleet));
+
+    // Weak enemy threat
+    final Territory sz5 = data.getMap().getTerritoryOrThrow("5 Sea Zone");
+    final List<Unit> enemyOne = GameDataTestUtil.destroyer(data).create(1, japanese);
+    data.performChange(ChangeFactory.addUnits(sz5, enemyOne));
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    // Stack includes both the infantry and the friendly escorts
+    final List<Unit> stack = new java.util.ArrayList<>();
+    stack.add(infantry);
+    stack.addAll(americanFleet);
+
+    final double p = ProAmphUtils.survivalProbability(stack, sz6, americans);
+
+    assertThat(p)
+        .as(
+            "5 American battleships + infantry vs 1 enemy destroyer → "
+                + "P must be ≥ the survival threshold (%s)",
+            ProAmphUtils.DISEMBARK_SURVIVAL_THRESHOLD)
+        .isGreaterThanOrEqualTo(ProAmphUtils.DISEMBARK_SURVIVAL_THRESHOLD);
+  }
+
+  // ─── threshold flips ─────────────────────────────────────────────────────
+
+  @Test
+  void addingEnemyAttackersDropsProbabilityBelowThreshold() {
+    // Start with escorts that make P ≥ threshold; add enough enemy attackers to flip P < threshold.
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+
+    // 2 American destroyers = moderate defense
+    final List<Unit> friendlyEscort = GameDataTestUtil.destroyer(data).create(2, americans);
+    data.performChange(ChangeFactory.addUnits(sz6, friendlyEscort));
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    final List<Unit> stack = new java.util.ArrayList<>();
+    stack.add(infantry);
+    stack.addAll(friendlyEscort);
+
+    final Territory sz5 = data.getMap().getTerritoryOrThrow("5 Sea Zone");
+
+    // Without enemy: P must be ≥ threshold
+    final double pSafe = ProAmphUtils.survivalProbability(stack, sz6, americans);
+    assertThat(pSafe)
+        .as("With 2 friendly destroyers and no enemy, P must be ≥ threshold")
+        .isGreaterThanOrEqualTo(ProAmphUtils.DISEMBARK_SURVIVAL_THRESHOLD);
+
+    // Add overwhelming enemy fleet to adjacent SZ
+    final List<Unit> enemyHuge = GameDataTestUtil.battleship(data).create(8, japanese);
+    data.performChange(ChangeFactory.addUnits(sz5, enemyHuge));
+
+    final double pUnsafe = ProAmphUtils.survivalProbability(stack, sz6, americans);
+    assertThat(pUnsafe)
+        .as(
+            "Adding 8 enemy battleships to adjacent SZ must drop P below threshold "
+                + "(threshold flips)")
+        .isLessThan(ProAmphUtils.DISEMBARK_SURVIVAL_THRESHOLD);
+  }
+
+  // ─── probability is bounded [0, 1] ────────────────────────��──────────────
+
+  @Test
+  void probabilityIsAlwaysBetweenZeroAndOne() {
+    final Territory sz6 = data.getMap().getTerritoryOrThrow(SEA_ZONE_6);
+
+    // Extreme case: massive enemy attack
+    final Territory sz5 = data.getMap().getTerritoryOrThrow("5 Sea Zone");
+    final List<Unit> massiveFleet = GameDataTestUtil.battleship(data).create(20, japanese);
+    data.performChange(ChangeFactory.addUnits(sz5, massiveFleet));
+
+    final Unit infantry = GameDataTestUtil.infantry(data).create(1, americans).get(0);
+    final double p = ProAmphUtils.survivalProbability(List.of(infantry), sz6, americans);
+
+    assertThat(p).as("P must be ≥ 0.0").isGreaterThanOrEqualTo(0.0);
+    assertThat(p).as("P must be ≤ 1.0").isLessThanOrEqualTo(1.0);
+  }
+
+  // ─── helpers ─────────────────���────────────────────────��──────────────────
+
+  private void declareWar(final GamePlayer p1, final GamePlayer p2) {
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            p1,
+            p2,
+            data.getRelationshipTracker().getRelationshipType(p1, p2),
+            data.getRelationshipTypeList().getRelationshipType("War")));
+  }
+}


### PR DESCRIPTION
## Summary

Implements the **unified embarked-movement model** for the ProAI amphib system, replacing two narrow special-cases with a single phase-aware reachability primitive that mirrors the TS engine's `getValidDestinationsForSingle`.

**Integration branch:** `feat/amphib-no-transports`

### Root cause (three defects, one missing capability)

| Defect | Root cause |
|--------|-----------|
| **#2716** multi-hop staging | `maxHops = u.getMovementLeft()` (land=1) capped transit at 1 hop instead of NAVAL_MOVE=2 |
| **#2717** already-embarked stranded | `!isEmbarked` filter + `!isWater()` loop excluded units already in sea zones |
| **#2712** AA assaulting offensively | No attack-value guard in CM assault candidates — AA guns were included |

## Changes

### `ProAmphUtils.java` — new primitives

- **`NAVAL_MOVE = 2`** constant (mirrors `tech-effects.ts:6`)
- **`DISEMBARK_SURVIVAL_THRESHOLD = 0.70`** constant
- **`getAmphReachableTerritories(unit, from, isCombatMove, ctx, player)`** — Java mirror of `getValidDestinationsForSingle` with 4 branches (A/B/C/D), canal guard, embarkedThisTurn guard
- **`survivalProbability(stack, sz, player)`** — `P = clamp(1 - sd/100, 0, 1)` via `ProBattleUtils.estimateStrengthDifference`

### `ProNonCombatMoveAi.calculateAmphEmbarkMoves` — rewrite

- Iterates over **all** territories (land + sea) → **fixes #2717** already-embarked units no longer invisible
- Uses `getAmphReachableTerritories` instead of `findEmbarkReachableRoutes` → **fixes #2716** NAVAL_MOVE=2
- Sea-zone destinations **gated by** `survivalProbability ≥ 0.70` (§5.2-1 survival gate)
- Land (disembark) destinations scored by production value (reinforcement/retreat)

### `ProCombatMoveAi.findAmphAssaultOptions` — fix

- Added `Matches.unitCanAttack(player)` to staged-unit filter
- **Fixes #2712**: AA guns and attack-0 units excluded from CM assault candidates

## Tests

| Class | Tests | Purpose |
|-------|-------|---------|
| `ProAmphUtilsGetAmphReachableTest` | 16 | Primitive reachability — all 4 branches, guards, canal, contested-SZ |
| `ProAmphUtilsSurvivalTest` | 6 | `survivalProbability` + `DISEMBARK_SURVIVAL_THRESHOLD = 0.70` |
| `ProNonCombatMoveUnifiedAmphTest` | 5 | NCM integration: #2717a, survival gate blocks/allows, retreat, freshly-embarked guard |
| `ProCombatMoveUnifiedAmphTest` | 2 | CM integration: AA excluded from assault, infantry still assaults |

All 4 test classes follow **TDD discipline** (RED → GREEN verified). No mocks on paths under test (per #2715 lesson).

## Build

```
./gradlew :game-app:game-core:test    # ✅ all tests pass
./gradlew :game-app:ai-sidecar:test   # ✅ all tests pass
./gradlew spotlessCheck                # ✅ formatting clean
```

---

Closes map-room/map-room#2716
Closes map-room/map-room#2717
Closes map-room/map-room#2712

🤖 Generated with [Claude Code](https://claude.com/claude-code)
