### PR TITLE
fix(ai): scope island production floor to enemy candidates only (map-room#2747)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -403,7 +403,15 @@ public final class ProTerritoryValueUtils {
     // the proximity math regardless of their production, because all distance calculations
     // use land-only routing. Apply a production-based floor so islands aren't silently zeroed
     // in the hold-value map and discarded before amphibious planning considers them.
-    if (landMassSize == 1) {
+    //
+    // Scoped to *attack candidates* only (enemy-owned or can't-be-held) — friendly islands
+    // already have their own defense scoring path and shouldn't appear in the amphib
+    // destination set via this floor. Pre-scoping the floor was inflating West Indies (UK,
+    // production=1) to 0.5, which then dominated US East Coast amphib unload destinations
+    // when no enemy target was within range. #2747
+    final boolean isAttackCandidate =
+        ProMatches.territoryIsEnemyOrCantBeHeld(player, territoriesThatCantBeHeld).test(t);
+    if (landMassSize == 1 && isAttackCandidate) {
       value = Math.max(value, TerritoryAttachment.getProduction(t) * 0.5);
     }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProFriendlyIslandFloorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProFriendlyIslandFloorTest.java
@@ -1,0 +1,104 @@
+package games.strategy.triplea.ai.pro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.triplea.ai.pro.util.ProTerritoryValueUtils;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for #2747: the island production floor introduced in #2736 was over-scoped to all
+ * island territories regardless of ownership. Friendly islands like West Indies (UK-owned,
+ * production=1) were getting a floor of 0.5, which made them the highest-value amphib unload
+ * destination for US East Coast transports when no real enemy target was within range.
+ *
+ * <p>Fix: gate the floor on {@code territoryIsEnemyOrCantBeHeld(player, territoriesThatCantBeHeld)}
+ * so friendly islands fall back to whatever the proximity math produces (usually 0 unless adjacent
+ * to enemies). Enemy islands retain the floor from #2736.
+ */
+public class ProFriendlyIslandFloorTest {
+
+  private GameData data;
+  private GamePlayer americans;
+  private ProData proData;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    proData = proDataFor(data);
+  }
+
+  /**
+   * Friendly islands score 0.0 — the floor should not lift them above the proximity-math result.
+   * West Indies is the regression case: UK-owned, production=1, far from any Axis adjacency,
+   * accumulated 0.5 via the unconditional floor pre-fix.
+   */
+  @Test
+  void westIndiesScoresZeroInTerritoryValueMap() {
+    final Territory westIndies = data.getMap().getTerritoryOrThrow("West Indies");
+    final Set<Territory> toCheck = new HashSet<>();
+    toCheck.add(westIndies);
+
+    final Map<Territory, Double> values =
+        ProTerritoryValueUtils.findTerritoryValues(
+            proData, americans, List.of(), List.of(), toCheck);
+
+    assertThat(values.get(westIndies))
+        .as(
+            "West Indies (UK-allied, production=1) must score 0.0 from Americans' perspective."
+                + " The island floor introduced in #2736 should only apply to enemy attack"
+                + " candidates, not friendly territory.")
+        .isEqualTo(0.0);
+  }
+
+  /**
+   * Enemy islands still receive the floor — verifies the #2736 fix is preserved. We pick a known
+   * Japanese-owned island that should always be present in G40.
+   */
+  @Test
+  void enemyIslandsStillReceiveTheFloor() {
+    // Declare war on Japan so Japanese territories satisfy isEnemyOrCantBeHeld and the floor
+    // gate fires. Iwo Jima is Japanese-owned, production=1, an island in G40 — the canonical
+    // #2736 regression case.
+    final GamePlayer japanese = data.getPlayerList().getPlayerId("Japanese");
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            americans,
+            japanese,
+            data.getRelationshipTracker().getRelationshipType(americans, japanese),
+            data.getRelationshipTypeList().getRelationshipType("War")));
+
+    final Territory iwoJima = data.getMap().getTerritoryOrThrow("Iwo Jima");
+    final Set<Territory> toCheck = new HashSet<>();
+    toCheck.add(iwoJima);
+
+    final Map<Territory, Double> values =
+        ProTerritoryValueUtils.findTerritoryValues(
+            proData, americans, List.of(), List.of(), toCheck);
+
+    assertThat(values.get(iwoJima))
+        .as(
+            "Iwo Jima (Japanese, production=1) must retain the island floor from #2736 —"
+                + " scoping the floor to enemy candidates must not regress that fix.")
+        .isGreaterThanOrEqualTo(0.5);
+  }
+
+  private static ProData proDataFor(final GameData gameData) throws Exception {
+    final ProData proData = new ProData();
+    final Field f = ProData.class.getDeclaredField("data");
+    f.setAccessible(true);
+    f.set(proData, gameData);
+    return proData;
+  }
+}


### PR DESCRIPTION
Paired with map-room/map-room#2747. Third in a chain: #2736 (Pacific amphib zeros) → #2745 (neutral staging) → this.

## Summary

The island production floor added in #2736 was applied unconditionally to every \`landMassSize==1\` territory. Friendly islands like West Indies (UK-owned, production=1) got the floor and ended up at \`territoryValue=0.5\` — exactly enough to become the highest-value amphib unload destination for US East Coast transports when no real enemy target was in range. Symptom: US infantry/armour kept routing to West Indies turn after turn.

One-line gate: only apply the floor to territories satisfying \`territoryIsEnemyOrCantBeHeld(player, territoriesThatCantBeHeld)\`. Friendly islands fall back to whatever the proximity math produces; enemy islands keep the #2736 floor.

## Test plan

- [x] New \`ProFriendlyIslandFloorTest\`:
  - West Indies (UK-friendly) → 0.0
  - Iwo Jima (Japanese, war-declared) → ≥0.5
- [x] \`ProPacificAmphibIslandValueTest\` (#2736) still passes
- [x] \`ProNeutralStagingValueTest\` (#2745) still passes
- [x] \`ProBaseValueTest\` still passes
- [x] \`ProAmphibPenaltyPlayerAwareTest\` (#2624) still passes
- [x] Full \`./gradlew :game-app:game-core:test --tests \"games.strategy.triplea.ai.pro.*\"\` passes
- [x] \`./gradlew spotlessApply\` clean
- [ ] 🧑 Manual: post-deploy ai-vs-ai should show US East Coast units no longer routed to West Indies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)