### PR TITLE
feat(proai): Phase 0 — ProValueHeatmapDumper for SVF instrumentation

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumper.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumper.java
@@ -1,0 +1,212 @@
+package games.strategy.triplea.ai.pro.logging;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.ai.pro.ProData;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
+
+/**
+ * Phase-0 instrumentation for the Strategic Value Field epic (map-room#2755).
+ *
+ * <p>When enabled, dumps the {@code Map<Territory, Double>} produced by {@link
+ * games.strategy.triplea.ai.pro.util.ProTerritoryValueUtils#findTerritoryValues} (and its sea-only
+ * sibling) to a JSON file under {@code $HOME/.maproom/ai-debug/}. The dump is a debugging aid — the
+ * Map Room client overlay reads it and renders a heatmap. Disabled by default; enable by setting
+ * env var {@code AI_DUMP_VALUES=1} or system property {@code ai.dump.values=1} (the property is for
+ * tests so they can flip the gate without spawning a child JVM).
+ *
+ * <p>JSON shape:
+ *
+ * <pre>{@code
+ * { "round": 3,
+ *   "player": "Americans",
+ *   "entrypoint": "combined" | "sea-only",
+ *   "timestampMs": 1716732123456,
+ *   "seq": 42,
+ *   "territories": [
+ *     { "name": "Eastern United States", "isWater": false, "value": 12.5 },
+ *     ...
+ *   ]
+ * }
+ * }</pre>
+ *
+ * <p>This class is intentionally self-contained: no Jackson, no DI, no sidecar deps. Future phases
+ * will extend the schema (S(n) cache, blended vs baseline split) — keep the JSON loose so the
+ * client overlay can ignore unknown fields.
+ */
+public final class ProValueHeatmapDumper {
+
+  /** Output subdirectory under {@code $HOME}. */
+  static final String OUTPUT_SUBDIR = ".maproom/ai-debug";
+
+  private static final AtomicLong SEQ = new AtomicLong(0);
+
+  private ProValueHeatmapDumper() {}
+
+  /** Returns {@code true} when dumping is enabled via env var or system property. */
+  public static boolean isEnabled() {
+    return "1".equals(System.getenv("AI_DUMP_VALUES"))
+        || "1".equals(System.getProperty("ai.dump.values"));
+  }
+
+  /**
+   * Writes the value map to disk if enabled; no-op otherwise. Never throws — instrumentation must
+   * not break a running game. Failures are logged via {@link ProLogger#warn} and swallowed.
+   *
+   * @param entrypoint short label identifying the {@code ProTerritoryValueUtils} entrypoint that
+   *     produced this map ({@code "combined"} for {@code findTerritoryValues}, {@code "sea-only"}
+   *     for {@code findSeaTerritoryValues}).
+   */
+  public static void dumpIfEnabled(
+      final ProData proData,
+      final GamePlayer player,
+      final String entrypoint,
+      final Map<Territory, Double> territoryValueMap) {
+    dumpIfEnabledFromGameData(proData.getData(), player, entrypoint, territoryValueMap);
+  }
+
+  /**
+   * Overload for callers that don't have a {@link ProData} on hand — notably {@link
+   * games.strategy.triplea.ai.pro.util.ProTerritoryValueUtils#findSeaTerritoryValues}, whose
+   * signature takes only {@link GamePlayer}.
+   */
+  public static void dumpIfEnabledFromGameData(
+      final GameData data,
+      final GamePlayer player,
+      final String entrypoint,
+      final Map<Territory, Double> territoryValueMap) {
+    if (!isEnabled()) {
+      return;
+    }
+    try {
+      final Path outDir = resolveOutputDir();
+      Files.createDirectories(outDir);
+      final int round = data.getSequence().getRound();
+      final long timestampMs = Instant.now().toEpochMilli();
+      final long seq = SEQ.incrementAndGet();
+      final String filename =
+          String.format(
+              "%d-%s-%s-%d-%05d.json",
+              round, sanitize(player.getName()), entrypoint, timestampMs, seq);
+      final Path outFile = outDir.resolve(filename);
+      try (Writer w = Files.newBufferedWriter(outFile, StandardCharsets.UTF_8)) {
+        writeJson(w, round, player.getName(), entrypoint, timestampMs, seq, territoryValueMap);
+      }
+    } catch (final IOException | RuntimeException e) {
+      ProLogger.warn("ProValueHeatmapDumper failed: " + e.getMessage());
+    }
+  }
+
+  /** Resolves the output dir. Override via system property {@code ai.dump.values.dir} for tests. */
+  static Path resolveOutputDir() {
+    final String override = System.getProperty("ai.dump.values.dir");
+    if (override != null && !override.isEmpty()) {
+      return Paths.get(override);
+    }
+    final String home = System.getProperty("user.home");
+    if (home == null || home.isEmpty()) {
+      throw new UncheckedIOException(new IOException("user.home not set"));
+    }
+    return Paths.get(home, OUTPUT_SUBDIR);
+  }
+
+  /** Reset the monotonic sequence counter — for tests. */
+  static void resetSeqForTests() {
+    SEQ.set(0);
+  }
+
+  /** Strips characters that would break a filename. */
+  private static String sanitize(final String s) {
+    return s.replaceAll("[^A-Za-z0-9_-]", "_");
+  }
+
+  /**
+   * Writes the JSON document. Hand-rolled to avoid pulling Jackson into game-core for a debug tool.
+   * Sorts territories by name so diffs across dumps are readable.
+   */
+  private static void writeJson(
+      final Writer w,
+      final int round,
+      final String playerName,
+      final String entrypoint,
+      final long timestampMs,
+      final long seq,
+      final Map<Territory, Double> territoryValueMap)
+      throws IOException {
+    final List<Map.Entry<Territory, Double>> entries =
+        new ArrayList<>(territoryValueMap.entrySet());
+    entries.sort((a, b) -> a.getKey().getName().compareTo(b.getKey().getName()));
+    w.write("{\"round\":");
+    w.write(Integer.toString(round));
+    w.write(",\"player\":");
+    writeJsonString(w, playerName);
+    w.write(",\"entrypoint\":");
+    writeJsonString(w, entrypoint);
+    w.write(",\"timestampMs\":");
+    w.write(Long.toString(timestampMs));
+    w.write(",\"seq\":");
+    w.write(Long.toString(seq));
+    w.write(",\"territories\":[");
+    boolean first = true;
+    for (final Map.Entry<Territory, Double> e : entries) {
+      if (!first) {
+        w.write(",");
+      }
+      first = false;
+      w.write("{\"name\":");
+      writeJsonString(w, e.getKey().getName());
+      w.write(",\"isWater\":");
+      w.write(Boolean.toString(e.getKey().isWater()));
+      w.write(",\"value\":");
+      w.write(formatDouble(e.getValue()));
+      w.write("}");
+    }
+    w.write("]}");
+  }
+
+  private static void writeJsonString(final Writer w, final @Nullable String s) throws IOException {
+    if (s == null) {
+      w.write("null");
+      return;
+    }
+    w.write("\"");
+    for (int i = 0; i < s.length(); i++) {
+      final char c = s.charAt(i);
+      switch (c) {
+        case '"' -> w.write("\\\"");
+        case '\\' -> w.write("\\\\");
+        case '\n' -> w.write("\\n");
+        case '\r' -> w.write("\\r");
+        case '\t' -> w.write("\\t");
+        default -> {
+          if (c < 0x20) {
+            w.write(String.format("\\u%04x", (int) c));
+          } else {
+            w.write(c);
+          }
+        }
+      }
+    }
+    w.write("\"");
+  }
+
+  private static String formatDouble(final @Nullable Double d) {
+    if (d == null || d.isNaN() || d.isInfinite()) {
+      return "0";
+    }
+    return Double.toString(d);
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumper.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumper.java
@@ -23,10 +23,16 @@ import javax.annotation.Nullable;
  *
  * <p>When enabled, dumps the {@code Map<Territory, Double>} produced by {@link
  * games.strategy.triplea.ai.pro.util.ProTerritoryValueUtils#findTerritoryValues} (and its sea-only
- * sibling) to a JSON file under {@code $HOME/.maproom/ai-debug/}. The dump is a debugging aid — the
- * Map Room client overlay reads it and renders a heatmap. Disabled by default; enable by setting
- * env var {@code AI_DUMP_VALUES=1} or system property {@code ai.dump.values=1} (the property is for
- * tests so they can flip the gate without spawning a child JVM).
+ * sibling) to a JSON file. The dump is a debugging aid — the Map Room client overlay reads it and
+ * renders a heatmap.
+ *
+ * <p>Disabled by default; enable by setting env var {@code AI_DUMP_VALUES=1} or system property
+ * {@code ai.dump.values=1} (the property is for tests so they can flip the gate without spawning a
+ * child JVM).
+ *
+ * <p>Output directory precedence: env {@code AI_DUMP_PATH} (canonical for docker-compose
+ * bind-mounts) → system property {@code ai.dump.path} (test sibling) → {@code
+ * $HOME/.maproom/ai-debug} (fallback for local non-docker runs).
  *
  * <p>JSON shape:
  *
@@ -46,10 +52,16 @@ import javax.annotation.Nullable;
  * <p>This class is intentionally self-contained: no Jackson, no DI, no sidecar deps. Future phases
  * will extend the schema (S(n) cache, blended vs baseline split) — keep the JSON loose so the
  * client overlay can ignore unknown fields.
+ *
+ * <p>Phase-0.1 follow-up: filenames do not include the boardgame.io matchId. The sidecar already
+ * tracks it via {@code AiTraceLogger.currentMatchId()} thread-local, but that helper lives in the
+ * {@code ai-sidecar} module which {@code game-core} can't depend on. Reaching it cleanly needs a
+ * sibling thread-local in {@code game-core} (e.g., {@code AbstractProAi.currentMatchId()}) that the
+ * sidecar writes alongside its own — deferred per the Phase-0 scope discipline.
  */
 public final class ProValueHeatmapDumper {
 
-  /** Output subdirectory under {@code $HOME}. */
+  /** Fallback subdirectory under {@code $HOME} when no explicit output path is set. */
   static final String OUTPUT_SUBDIR = ".maproom/ai-debug";
 
   private static final AtomicLong SEQ = new AtomicLong(0);
@@ -110,11 +122,24 @@ public final class ProValueHeatmapDumper {
     }
   }
 
-  /** Resolves the output dir. Override via system property {@code ai.dump.values.dir} for tests. */
+  /**
+   * Resolves the output dir. Precedence:
+   *
+   * <ol>
+   *   <li>env {@code AI_DUMP_PATH} (canonical override — used for docker-compose bind-mounts)
+   *   <li>system property {@code ai.dump.path} (test-friendly sibling, mirrors the {@code
+   *       ai.dump.values} gate)
+   *   <li>{@code $HOME/.maproom/ai-debug} (default for local non-docker runs)
+   * </ol>
+   */
   static Path resolveOutputDir() {
-    final String override = System.getProperty("ai.dump.values.dir");
-    if (override != null && !override.isEmpty()) {
-      return Paths.get(override);
+    final String envPath = System.getenv("AI_DUMP_PATH");
+    if (envPath != null && !envPath.isEmpty()) {
+      return Paths.get(envPath);
+    }
+    final String propPath = System.getProperty("ai.dump.path");
+    if (propPath != null && !propPath.isEmpty()) {
+      return Paths.get(propPath);
     }
     final String home = System.getProperty("user.home");
     if (home == null || home.isEmpty()) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.util.BreadthFirstSearch;
 import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.logging.ProValueHeatmapDumper;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import java.util.ArrayList;
@@ -145,6 +146,7 @@ public final class ProTerritoryValueUtils {
       }
     }
 
+    ProValueHeatmapDumper.dumpIfEnabled(proData, player, "combined", territoryValueMap);
     return territoryValueMap;
   }
 
@@ -194,6 +196,9 @@ public final class ProTerritoryValueUtils {
       }
     }
 
+    // findSeaTerritoryValues doesn't receive ProData; use the GameData-shaped dumper overload.
+    ProValueHeatmapDumper.dumpIfEnabledFromGameData(
+        player.getData(), player, "sea-only", territoryValueMap);
     return territoryValueMap;
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumperTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumperTest.java
@@ -27,14 +27,14 @@ class ProValueHeatmapDumperTest {
 
   @BeforeEach
   void setUp() {
-    System.setProperty("ai.dump.values.dir", tempDir.toString());
+    System.setProperty("ai.dump.path", tempDir.toString());
     ProValueHeatmapDumper.resetSeqForTests();
   }
 
   @AfterEach
   void tearDown() {
     System.clearProperty("ai.dump.values");
-    System.clearProperty("ai.dump.values.dir");
+    System.clearProperty("ai.dump.path");
   }
 
   @Test
@@ -125,6 +125,48 @@ class ProValueHeatmapDumperTest {
     assertThat(files).hasSize(1);
     final String name = files.get(0).getFileName().toString();
     assertThat(name).contains("British_Pacific").doesNotContain("/");
+  }
+
+  @Test
+  void systemPropertyPathIsHonored() {
+    // Default precedence: ai.dump.path sysprop > $HOME/.maproom/ai-debug.
+    // setUp() already set ai.dump.path to tempDir; verify the dumper resolved it.
+    System.setProperty("ai.dump.values", "1");
+    final GameData data = stubGameData(1);
+    final GamePlayer player = stubPlayer("Americans");
+    final Map<Territory, Double> values = Map.of(stubTerritory("Foo", false), 1.0);
+
+    ProValueHeatmapDumper.dumpIfEnabledFromGameData(data, player, "combined", values);
+
+    assertThat(listDumpedFiles()).hasSize(1);
+  }
+
+  @Test
+  void fallsBackToHomeDirWhenNoOverrideSet(@TempDir final Path fakeHome) {
+    // Clear the sysprop set by setUp() to exercise the user.home fallback path.
+    System.clearProperty("ai.dump.path");
+    System.setProperty("user.home", fakeHome.toString());
+    System.setProperty("ai.dump.values", "1");
+    try {
+      final GameData data = stubGameData(1);
+      final GamePlayer player = stubPlayer("Americans");
+      final Map<Territory, Double> values = Map.of(stubTerritory("Foo", false), 1.0);
+
+      ProValueHeatmapDumper.dumpIfEnabledFromGameData(data, player, "combined", values);
+
+      final Path expectedDir = fakeHome.resolve(ProValueHeatmapDumper.OUTPUT_SUBDIR);
+      assertThat(expectedDir).exists();
+      try (Stream<Path> s = Files.list(expectedDir)) {
+        assertThat(s.toList()).hasSize(1);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    } finally {
+      // Restore HOME so other tests in the JVM aren't affected. user.home is normally
+      // immutable for the process lifetime; setting it for one test is OK but we want
+      // to be polite about cleanup.
+      System.clearProperty("user.home");
+    }
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumperTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumperTest.java
@@ -1,0 +1,191 @@
+package games.strategy.triplea.ai.pro.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.GameSequence;
+import games.strategy.engine.data.Territory;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProValueHeatmapDumperTest {
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  void setUp() {
+    System.setProperty("ai.dump.values.dir", tempDir.toString());
+    ProValueHeatmapDumper.resetSeqForTests();
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.clearProperty("ai.dump.values");
+    System.clearProperty("ai.dump.values.dir");
+  }
+
+  @Test
+  void disabledByDefault_writesNothing() {
+    final GameData data = stubGameData(1);
+    final GamePlayer player = stubPlayer("Americans");
+    final Map<Territory, Double> values = Map.of(stubTerritory("Foo", false), 1.0);
+
+    ProValueHeatmapDumper.dumpIfEnabledFromGameData(data, player, "combined", values);
+
+    assertThat(listDumpedFiles()).isEmpty();
+  }
+
+  @Test
+  void enabledViaSystemProperty_writesJsonFile() throws IOException {
+    System.setProperty("ai.dump.values", "1");
+    final GameData data = stubGameData(7);
+    final GamePlayer player = stubPlayer("Americans");
+    final Map<Territory, Double> values =
+        orderedMap(
+            stubTerritory("Eastern United States", false), 12.5,
+            stubTerritory("Sea Zone 10", true), 0.0);
+
+    ProValueHeatmapDumper.dumpIfEnabledFromGameData(data, player, "combined", values);
+
+    final List<Path> files = listDumpedFiles();
+    assertThat(files).hasSize(1);
+    final String content = Files.readString(files.get(0), StandardCharsets.UTF_8);
+    assertThat(content)
+        .contains("\"round\":7")
+        .contains("\"player\":\"Americans\"")
+        .contains("\"entrypoint\":\"combined\"")
+        .contains("\"name\":\"Eastern United States\"")
+        .contains("\"isWater\":false")
+        .contains("\"value\":12.5")
+        .contains("\"name\":\"Sea Zone 10\"")
+        .contains("\"isWater\":true");
+  }
+
+  @Test
+  void territoriesAreSortedByName() throws IOException {
+    System.setProperty("ai.dump.values", "1");
+    final GameData data = stubGameData(1);
+    final GamePlayer player = stubPlayer("Americans");
+    final Map<Territory, Double> values =
+        orderedMap(
+            stubTerritory("Zulu", false), 1.0,
+            stubTerritory("Alpha", false), 2.0,
+            stubTerritory("Mike", false), 3.0);
+
+    ProValueHeatmapDumper.dumpIfEnabledFromGameData(data, player, "combined", values);
+
+    final String content = Files.readString(listDumpedFiles().get(0), StandardCharsets.UTF_8);
+    final int alphaIdx = content.indexOf("\"name\":\"Alpha\"");
+    final int mikeIdx = content.indexOf("\"name\":\"Mike\"");
+    final int zuluIdx = content.indexOf("\"name\":\"Zulu\"");
+    assertThat(alphaIdx).isPositive().isLessThan(mikeIdx);
+    assertThat(mikeIdx).isLessThan(zuluIdx);
+  }
+
+  @Test
+  void multipleDumpsAreUniquelyNumbered() {
+    System.setProperty("ai.dump.values", "1");
+    final GameData data = stubGameData(1);
+    final GamePlayer player = stubPlayer("Americans");
+    final Map<Territory, Double> values = Map.of(stubTerritory("Foo", false), 1.0);
+
+    ProValueHeatmapDumper.dumpIfEnabledFromGameData(data, player, "combined", values);
+    ProValueHeatmapDumper.dumpIfEnabledFromGameData(data, player, "sea-only", values);
+
+    final List<Path> files = listDumpedFiles();
+    assertThat(files).hasSize(2);
+    assertThat(files.stream().map(Path::getFileName).map(Path::toString))
+        .anyMatch(n -> n.contains("combined"))
+        .anyMatch(n -> n.contains("sea-only"));
+  }
+
+  @Test
+  void playerNameWithUnsafeCharactersIsSanitizedInFilename() {
+    System.setProperty("ai.dump.values", "1");
+    final GameData data = stubGameData(1);
+    final GamePlayer player = stubPlayer("British/Pacific");
+    final Map<Territory, Double> values = Map.of(stubTerritory("Foo", false), 1.0);
+
+    ProValueHeatmapDumper.dumpIfEnabledFromGameData(data, player, "combined", values);
+
+    final List<Path> files = listDumpedFiles();
+    assertThat(files).hasSize(1);
+    final String name = files.get(0).getFileName().toString();
+    assertThat(name).contains("British_Pacific").doesNotContain("/");
+  }
+
+  @Test
+  void nanAndInfinityValuesAreSerializedAsZero() throws IOException {
+    System.setProperty("ai.dump.values", "1");
+    final GameData data = stubGameData(1);
+    final GamePlayer player = stubPlayer("Americans");
+    final Map<Territory, Double> values =
+        orderedMap(
+            stubTerritory("Nan", false), Double.NaN,
+            stubTerritory("PosInf", false), Double.POSITIVE_INFINITY,
+            stubTerritory("NegInf", false), Double.NEGATIVE_INFINITY);
+
+    ProValueHeatmapDumper.dumpIfEnabledFromGameData(data, player, "combined", values);
+
+    final String content = Files.readString(listDumpedFiles().get(0), StandardCharsets.UTF_8);
+    assertThat(content).doesNotContain("NaN").doesNotContain("Infinity");
+    // Three territories, each with "value":0 — assert all three are present.
+    final long zeroCount =
+        Stream.of(content.split("\"value\":0"))
+            .skip(1) // first split is everything before the first match
+            .count();
+    assertThat(zeroCount).isEqualTo(3);
+  }
+
+  // --- helpers ---
+
+  private List<Path> listDumpedFiles() {
+    try (Stream<Path> s = Files.list(tempDir)) {
+      return s.toList();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static GameData stubGameData(final int round) {
+    final GameData data = mock(GameData.class);
+    final GameSequence sequence = mock(GameSequence.class);
+    when(data.getSequence()).thenReturn(sequence);
+    when(sequence.getRound()).thenReturn(round);
+    return data;
+  }
+
+  private static GamePlayer stubPlayer(final String name) {
+    final GamePlayer player = mock(GamePlayer.class);
+    when(player.getName()).thenReturn(name);
+    return player;
+  }
+
+  private static Territory stubTerritory(final String name, final boolean isWater) {
+    final Territory t = mock(Territory.class);
+    when(t.getName()).thenReturn(name);
+    when(t.isWater()).thenReturn(isWater);
+    return t;
+  }
+
+  private static Map<Territory, Double> orderedMap(final Object... kvPairs) {
+    final Map<Territory, Double> m = new LinkedHashMap<>();
+    for (int i = 0; i < kvPairs.length; i += 2) {
+      m.put((Territory) kvPairs[i], (Double) kvPairs[i + 1]);
+    }
+    return m;
+  }
+}


### PR DESCRIPTION
**Phase 0** of the Strategic Value Field epic (map-room#2755). Adds env-gated JSON dumping of `ProTerritoryValueUtils.findTerritoryValues` output so the Map Room client can render heatmaps for AI debugging.

Paired TS-side PR: **map-room/map-room#2757**

## Changes

- **New:** `game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumper.java`
  - `dumpIfEnabled(ProData, GamePlayer, String entrypoint, Map<Territory, Double>)` — primary entrypoint
  - `dumpIfEnabledFromGameData(GameData, ...)` — overload for `findSeaTerritoryValues` which doesn't receive `ProData`
  - Hand-rolled JSON (no Jackson dep on game-core for a debug tool)
  - Output: `$HOME/.maproom/ai-debug/<round>-<player>-<entrypoint>-<timestampMs>-<seq>.json`
  - Gated by env `AI_DUMP_VALUES=1` OR system property `ai.dump.values=1` (the latter is for tests so they can flip the gate without spawning a child JVM)
- **Modified:** `ProTerritoryValueUtils.java`
  - Call site 1: `findTerritoryValues:148` (combined entrypoint — 11 callers across combat-move / NCM / purchase per audit in map-room#2755 plan)
  - Call site 2: `findSeaTerritoryValues:197` (NCM-only sea path)
- **New:** `ProValueHeatmapDumperTest.java` — 6 tests covering gate, JSON shape, sort order, filename sanitization, NaN/infinity handling

## Why an env gate (not a config option)

The dumper writes hundreds of small JSON files per game when enabled. It needs to be **off by default** with **no allocations on the hot path** when disabled. The `System.getenv` + `System.getProperty` check is the cheapest possible gate that's still flippable from a test.

## Phase 0 scope (per plan §6)

| ✅ | Item |
|---|---|
| ✅ | JSON dumper writes per-call value maps |
| ✅ | Dump is a no-op when env var unset (verified by test #1) |
| ✅ | JSON shape is loose / forward-compatible (extra fields ignored) |
| ✅ | Sea-only path is covered (separate call site) |
| 🧑 Manual | With \`AI_DUMP_VALUES=1\`, play one US turn; confirm files appear |
| paired | Client overlay reading the dump → map-room/map-room#2757 |
| paired | Failure catalog → map-room/map-room#2757 (docs live in map-room) |

## Test plan

- [x] \`./gradlew :game-app:game-core:test --tests 'ProValueHeatmapDumperTest'\` — all 6 tests pass
- [x] \`./gradlew spotlessApply && ./gradlew spotlessCheck\` — clean
- [x] \`./gradlew :game-app:game-core:compileJava\` — clean
- [ ] 🧑 Manual: end-to-end with \`AI_DUMP_VALUES=1\` and the TS overlay reading a real dump

## Notes for reviewer

- Dumper lives in \`game-core\` not \`ai-sidecar\` because \`ProTerritoryValueUtils\` is in \`game-core\` and can't depend up the module graph. The class is genuinely game-core territory — it instruments AI value computation, not sidecar wire.
- I chose \`logging/\` for the package because that's where other Pro* observability lives (\`ProLogger\`, \`ProLogUi\`). Alternative \`debug/\` would have been a new package.
- The JSON format is intentionally minimal for Phase 0. Phase 1 will extend it with \`baseline\` vs \`blended\` value separation once \`S(n)\` exists.