### PR TITLE
feat(proai): PR-A — Strategic Value Field shadow compute (Phase 1B + 1C)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/NoncombatMoveExecutor.java
@@ -88,6 +88,10 @@ public final class NoncombatMoveExecutor
     proAi.getProData().setSeed(request.seed());
     proAi.seedBattleCalc(request.seed());
 
+    // Strategic Value Field (map-room#2755 PR-A): apply env/sysprop tuning knobs into ProData
+    // before any phase code reads them. See ProSvfKnobs javadoc for the recognized vars.
+    ProSvfKnobs.applyTo(proAi.getProData());
+
     // reinitializeProDataForSidecar() re-binds proData.getData() to the fresh GameData before
     // planning — same defensive pattern as PurchaseExecutor.
     final RecordingMoveDelegate recorder = new RecordingMoveDelegate(proAi);

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/ProSvfKnobs.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/ProSvfKnobs.java
@@ -1,0 +1,79 @@
+package org.triplea.ai.sidecar.exec;
+
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.AiTheaterPriority;
+import javax.annotation.Nullable;
+
+/**
+ * Reads Strategic Value Field tuning knobs from process env vars (with sysprop fallback) and
+ * applies them to a per-request {@link ProData} instance. Used by sidecar executors to inject Phase
+ * 1B/1C (PR-A) config without a wire-protocol change — wire plumbing is PR-B.
+ *
+ * <p>Two-pronged precedence per-knob: env var → sysprop → ProData default. Mirrors the {@code
+ * AI_DUMP_VALUES} / {@code ai.dump.values} pattern from {@code ProValueHeatmapDumper}. Sysprops are
+ * for tests that need to flip a knob without spawning a child JVM; env vars are canonical for
+ * docker-compose deployments.
+ *
+ * <table>
+ *   <caption>Recognized knobs</caption>
+ *   <tr><th>Env var</th><th>Sysprop</th><th>ProData setter</th><th>Default</th></tr>
+ *   <tr><td>{@code AI_THEATER_PRIORITY}</td><td>{@code ai.theater.priority}</td>
+ *       <td>{@link ProData#setAiTheaterPriority}</td><td>{@code KGF}</td></tr>
+ *   <tr><td>{@code AI_SVF_G_CAP}</td><td>{@code ai.svf.g.cap}</td>
+ *       <td>{@link ProData#setGCap}</td><td>{@code 75.0}</td></tr>
+ *   <tr><td>{@code AI_SVF_GAMMA}</td><td>{@code ai.svf.gamma}</td>
+ *       <td>{@link ProData#setGamma}</td><td>{@code 0.85}</td></tr>
+ *   <tr><td>{@code AI_SVF_W_STRAT}</td><td>{@code ai.svf.w.strat}</td>
+ *       <td>{@link ProData#setWStrat}</td><td>{@code 0.0}</td></tr>
+ *   <tr><td>{@code AI_SVF_ALPHA_OFF}</td><td>{@code ai.svf.alpha.off}</td>
+ *       <td>{@link ProData#setAlphaOff}</td><td>{@code 0.10}</td></tr>
+ *   <tr><td>{@code AI_SVF_BETA_LAUNCH}</td><td>{@code ai.svf.beta.launch}</td>
+ *       <td>{@link ProData#setBetaLaunch}</td><td>{@code 0.0}</td></tr>
+ * </table>
+ *
+ * <p>Null, empty, or unparseable values silently leave the ProData default in place — knobs are
+ * opt-in tuning, not validated configuration. A typo just means "use the default", never an
+ * exception that breaks the request.
+ */
+public final class ProSvfKnobs {
+
+  private ProSvfKnobs() {}
+
+  /** Applies all recognized env/sysprop knobs to {@code proData} in place. */
+  public static void applyTo(final ProData proData) {
+    final String theater = read("AI_THEATER_PRIORITY", "ai.theater.priority");
+    if (theater != null) {
+      proData.setAiTheaterPriority(AiTheaterPriority.fromWire(theater));
+    }
+    applyDouble("AI_SVF_G_CAP", "ai.svf.g.cap", proData::setGCap);
+    applyDouble("AI_SVF_GAMMA", "ai.svf.gamma", proData::setGamma);
+    applyDouble("AI_SVF_W_STRAT", "ai.svf.w.strat", proData::setWStrat);
+    applyDouble("AI_SVF_ALPHA_OFF", "ai.svf.alpha.off", proData::setAlphaOff);
+    applyDouble("AI_SVF_BETA_LAUNCH", "ai.svf.beta.launch", proData::setBetaLaunch);
+  }
+
+  private static void applyDouble(
+      final String envName, final String sysName, final java.util.function.DoubleConsumer setter) {
+    final String raw = read(envName, sysName);
+    if (raw == null) {
+      return;
+    }
+    try {
+      setter.accept(Double.parseDouble(raw));
+    } catch (final NumberFormatException e) {
+      // Silently keep the default — knobs are opt-in tuning, never request-breaking.
+    }
+  }
+
+  private static @Nullable String read(final String envName, final String sysName) {
+    final String env = System.getenv(envName);
+    if (env != null && !env.isEmpty()) {
+      return env;
+    }
+    final String sys = System.getProperty(sysName);
+    if (sys != null && !sys.isEmpty()) {
+      return sys;
+    }
+    return null;
+  }
+}

--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/PurchaseExecutor.java
@@ -141,6 +141,11 @@ public final class PurchaseExecutor implements DecisionExecutor<PurchaseRequest,
     proAi.getProData().setSeed(request.seed());
     proAi.seedBattleCalc(request.seed());
 
+    // Strategic Value Field (map-room#2755 PR-A): apply env/sysprop tuning knobs into ProData
+    // before any phase code reads them. wStrat=0 default keeps this zero-impact unless tuning
+    // env vars are explicitly set. PR-B replaces this with a wire-protocol-driven path.
+    ProSvfKnobs.applyTo(proAi.getProData());
+
     final RecordingPurchaseDelegate recorder = new RecordingPurchaseDelegate();
     recorder.initialize("purchase", "Purchase");
     recorder.setDelegateBridgeAndPlayer(new ProDummyDelegateBridge(proAi, player, data));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.ai.pro.data.AiTheaterPriority;
 import games.strategy.triplea.ai.pro.data.ProPurchaseOption;
 import games.strategy.triplea.ai.pro.data.ProPurchaseOptionMap;
 import games.strategy.triplea.ai.pro.data.ProTerritory;
@@ -22,6 +23,7 @@ import java.util.Random;
 import java.util.Set;
 import javax.annotation.Nullable;
 import lombok.Getter;
+import lombok.Setter;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
@@ -42,6 +44,45 @@ public final class ProData {
   // future, we could add logic about moving such units to factory territories from elsewhere.
   private final Set<Unit> unitsToBeConsumed = new HashSet<>();
   private double minCostPerHitPoint = Double.MAX_VALUE;
+
+  // ---------------------------------------------------------------------------
+  // Strategic Value Field (map-room#2755 PR-A — Phase 1B).
+  //
+  // Defaults are chosen to be **zero-impact**: wStrat = 0.0 means the field is
+  // computed-and-dumpable but never blended into the value map. Phase 4A tuning
+  // flips wStrat above 0 once the calibrated bracket from §10 is validated.
+  // Setters are wired so the sidecar executor can populate them from env vars /
+  // sysprops at the request boundary (mirrors AI_DUMP_VALUES pattern).
+  // ---------------------------------------------------------------------------
+
+  @Setter private AiTheaterPriority aiTheaterPriority = AiTheaterPriority.KGF;
+
+  /** Capital anchor strength. Mid of §10 calibrated bracket of 50-100. */
+  @Setter private double gCap = 75.0;
+
+  @Setter private double gamma = 0.85;
+
+  /** Weight of the strategic field in the blend. 0.0 = no behavior change. */
+  @Setter private double wStrat = 0.0;
+
+  @Setter private double alphaOff = 0.10;
+  @Setter private double betaLaunch = 0.0;
+
+  /** Amphib commit threshold in the targeted theater. Phase 3B raises this. */
+  @Setter private double tCommitTargeted = 0.0;
+
+  /** Amphib commit threshold off-theater. Phase 3B raises this. */
+  @Setter private double tCommitOffTheater = 0.0;
+
+  /** Off-theater minimum garrison floor per key holding. Phase 3A populates. */
+  @Setter private Map<Territory, Integer> dFloor = Map.of();
+
+  /**
+   * Lazy-cached strategic value field. Computed on first {@code findTerritoryValues}-style call
+   * when {@code wStrat > 0}, then reused for the remainder of the request. Sidecar is stateless per
+   * HTTP request, so the cache is scoped to one decision call — see plan §0 nuance.
+   */
+  @Setter private @Nullable Map<Territory, Double> strategicValueField = null;
 
   /** Seeded RNG for deterministic AI decisions. Seeded via {@link #setSeed(long)}. */
   @Getter private Random rng = new Random();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/AiTheaterPriority.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/AiTheaterPriority.java
@@ -1,0 +1,36 @@
+package games.strategy.triplea.ai.pro.data;
+
+import javax.annotation.Nullable;
+
+/**
+ * KGF / KJF flag for the Strategic Value Field (map-room#2755).
+ *
+ * <p>{@code KGF} (Kill Germany First) pulls US offensive mass toward Berlin / Europe; {@code KJF}
+ * (Kill Japan First) pulls toward Tokyo / the Pacific. Per the §10 baseline-run finding, baseline
+ * ProAi is naturally KJF-leaning, so {@code KGF} mode must fight an opposing gradient while {@code
+ * KJF} mode reinforces an existing one — see plan §5 risk register.
+ *
+ * <p>Phase 1B/1C (PR-A) stores this enum on {@link
+ * games.strategy.triplea.ai.pro.ProData#getAiTheaterPriority()} and reads it from env var {@code
+ * AI_THEATER_PRIORITY} (sysprop {@code ai.theater.priority}) at executor boundary. Lobby UI +
+ * {@code WireState} plumbing is PR-B.
+ */
+public enum AiTheaterPriority {
+  KGF,
+  KJF;
+
+  /**
+   * Parses a wire string into a priority. {@code null}, empty, and unparseable values fall back to
+   * {@link #KGF} (the documented default — see plan §3 question 3).
+   */
+  public static AiTheaterPriority fromWire(@Nullable final String s) {
+    if (s == null || s.isEmpty()) {
+      return KGF;
+    }
+    try {
+      return AiTheaterPriority.valueOf(s.trim().toUpperCase());
+    } catch (final IllegalArgumentException e) {
+      return KGF;
+    }
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumper.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumper.java
@@ -75,6 +75,17 @@ public final class ProValueHeatmapDumper {
   }
 
   /**
+   * Returns {@code true} when strategic-field dumping is enabled. Separate gate from {@link
+   * #isEnabled()} so a tuning run can emit S(n) without also producing the larger baseline
+   * value-map dumps (and vice versa). Env: {@code AI_DUMP_STRATEGIC=1}; sysprop: {@code
+   * ai.dump.strategic=1}.
+   */
+  public static boolean isStrategicEnabled() {
+    return "1".equals(System.getenv("AI_DUMP_STRATEGIC"))
+        || "1".equals(System.getProperty("ai.dump.strategic"));
+  }
+
+  /**
    * Writes the value map to disk if enabled; no-op otherwise. Never throws — instrumentation must
    * not break a running game. Failures are logged via {@link ProLogger#warn} and swallowed.
    *
@@ -88,6 +99,55 @@ public final class ProValueHeatmapDumper {
       final String entrypoint,
       final Map<Territory, Double> territoryValueMap) {
     dumpIfEnabledFromGameData(proData.getData(), player, entrypoint, territoryValueMap);
+    dumpStrategicFieldIfEnabled(proData, player, entrypoint);
+  }
+
+  /**
+   * Emits a sibling {@code *-strategic.json} file containing the cached strategic value field from
+   * {@code proData}, when {@link #isStrategicEnabled()} is on AND the field has been computed. The
+   * strategic dump uses the same {@link #dumpIfEnabledFromGameData} writer so the JSON shape and
+   * filename convention are identical to the value-map dumps — the suffix {@code -strategic} on the
+   * {@code entrypoint} field is the only differentiator.
+   *
+   * <p>Safe to call when {@code wStrat=0}: the strategic field will be {@code null} (lazy compute
+   * skipped) and this method returns without writing.
+   */
+  static void dumpStrategicFieldIfEnabled(
+      final ProData proData, final GamePlayer player, final String entrypoint) {
+    if (!isStrategicEnabled()) {
+      return;
+    }
+    final Map<Territory, Double> field = proData.getStrategicValueField();
+    if (field == null || field.isEmpty()) {
+      return;
+    }
+    final String strategicEntrypoint = entrypoint + "-strategic";
+    dumpStrategicInternal(proData.getData(), player, strategicEntrypoint, field);
+  }
+
+  /** Writes the strategic dump unconditionally — gate check happens in the caller. */
+  private static void dumpStrategicInternal(
+      final GameData data,
+      final GamePlayer player,
+      final String entrypoint,
+      final Map<Territory, Double> field) {
+    try {
+      final Path outDir = resolveOutputDir();
+      Files.createDirectories(outDir);
+      final int round = data.getSequence().getRound();
+      final long timestampMs = Instant.now().toEpochMilli();
+      final long seq = SEQ.incrementAndGet();
+      final String filename =
+          String.format(
+              "%d-%s-%s-%d-%05d.json",
+              round, sanitize(player.getName()), entrypoint, timestampMs, seq);
+      final Path outFile = outDir.resolve(filename);
+      try (Writer w = Files.newBufferedWriter(outFile, StandardCharsets.UTF_8)) {
+        writeJson(w, round, player.getName(), entrypoint, timestampMs, seq, field);
+      }
+    } catch (final IOException | RuntimeException e) {
+      ProLogger.warn("ProValueHeatmapDumper (strategic) failed: " + e.getMessage());
+    }
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProStrategicValueField.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProStrategicValueField.java
@@ -1,0 +1,219 @@
+package games.strategy.triplea.ai.pro.util;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.util.BreadthFirstSearch;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.AiTheaterPriority;
+import games.strategy.triplea.attachments.TerritoryAttachment;
+import games.strategy.triplea.delegate.Matches;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Strategic Value Field S(n) for the KGF/KJF theater pull (map-room#2755, Phase 1B+1C / PR-A).
+ *
+ * <p>Computes a per-territory potential field anchored on the enemy axis the {@link
+ * AiTheaterPriority} flag targets. Each anchor (enemy capital, factory, victory city) projects a
+ * geometric decay {@code G_o * gamma^d(n, o)} through the movement graph; the field at a node is
+ * the {@code max} across all anchors. The off-theater axis contributes a suppressed signal ({@code
+ * G_o * alphaOff}) so the unfavored theater isn't completely forgotten.
+ *
+ * <p><b>Full-board computation (§10 Finding 3):</b> {@link #compute} enumerates every {@link
+ * Territory} in {@code data.getMap().getTerritories()} once and returns the full mapping. Callers
+ * downstream of the blend look up {@code S[t]} for whatever subset they happen to be evaluating —
+ * they never trigger a recompute.
+ *
+ * <p><b>Asymmetry warning (§10 Finding 1 / §5 risk register):</b> baseline {@code B(n)} is not flat
+ * — it already slopes Pacific-ward for the US because Tokyo is reachable via the Alaska land path
+ * while Berlin requires an Atlantic crossing. <b>KGF mode must overcome the existing gradient; KJF
+ * mode reinforces it.</b> Phase 4A tuning will need to size {@code wStrat} (or {@code gCap})
+ * per-flag — a symmetric default would under-pull KGF and over-pull KJF.
+ *
+ * <p>Phase 1B/1C (PR-A) ships this class with {@code wStrat=0.0} default so the field is
+ * computed-and-dumpable but never blended. The blend lands in PR-B alongside wire + lobby UI.
+ *
+ * <p>Performance note: each call performs {@code O(|anchors| * (V + E))} where V = territories, E =
+ * adjacencies. With ~5 anchors and ~120 territories the cost is negligible (single-digit ms). The
+ * sidecar is stateless per HTTP request, so this work is re-done per phase call (3-4× per US turn)
+ * — see plan §0 nuance.
+ */
+@UtilityClass
+public final class ProStrategicValueField {
+
+  /** Factory anchor strength as a fraction of {@code G_cap}. */
+  private static final double G_FAC_FRACTION = 0.6;
+
+  /** Victory-city anchor strength as a fraction of {@code G_cap}. */
+  private static final double G_VC_FRACTION = 0.4;
+
+  /**
+   * Pacific axis is just Japan in the WW2 1940 Global scenario. Anything else in the enemy axis set
+   * classifies as European theater. Data-driven via {@code GamePlayer.getName()} (no hardcoded
+   * territory list) per spec §10 question 4.
+   */
+  private static final String PACIFIC_AXIS_NAME = "Japanese";
+
+  /**
+   * Computes the full-board strategic value field for {@code player} from {@code proData}.
+   *
+   * <p>Returns a map keyed by every {@link Territory} on the board (including water, including
+   * impassable) — the per-call subset filtering lives at the consumer, not here.
+   */
+  public static Map<Territory, Double> compute(final ProData proData, final GamePlayer player) {
+    final GameData data = proData.getData();
+    final Map<Territory, Double> anchors = buildObjectives(proData, player);
+    final BiPredicate<Territory, Territory> edgeCond = combinedMovementEdgeCond(player);
+
+    final Map<Territory, Double> field = new HashMap<>();
+    for (final Territory t : data.getMap().getTerritories()) {
+      field.put(t, 0.0);
+    }
+    if (anchors.isEmpty()) {
+      return field;
+    }
+
+    final double gamma = proData.getGamma();
+    for (final Map.Entry<Territory, Double> entry : anchors.entrySet()) {
+      final Territory anchor = entry.getKey();
+      final double strength = entry.getValue();
+      // BreadthFirstSearch.traverse only invokes the visitor on *neighbors* (distance >= 1) —
+      // it never reports the start territory itself. Seed the anchor's own decay value (d=0,
+      // i.e. strength * gamma^0 = strength) explicitly so S(anchor) lands at the full pull.
+      final Double existingAtAnchor = field.get(anchor);
+      if (existingAtAnchor == null || strength > existingAtAnchor) {
+        field.put(anchor, strength);
+      }
+      final BreadthFirstSearch bfs = new BreadthFirstSearch(List.of(anchor), edgeCond);
+      bfs.traverse(
+          (territory, distance) -> {
+            final double decayed = strength * Math.pow(gamma, distance);
+            final Double existing = field.get(territory);
+            if (existing == null || decayed > existing) {
+              field.put(territory, decayed);
+            }
+            return true;
+          });
+    }
+    // launchBonus is sea-only and bumps water nodes adjacent to high-S coastal targets.
+    for (final Territory t : data.getMap().getTerritories()) {
+      if (t.isWater()) {
+        final double bonus = launchBonus(t, field, proData);
+        if (bonus > 0) {
+          field.merge(t, bonus, Double::sum);
+        }
+      }
+    }
+    return field;
+  }
+
+  /**
+   * Returns the per-edge predicate for the combined land+sea movement graph. Per-power canal access
+   * ({@code ProMatches.noCanalsBetweenTerritories}) is honored — US route to Tokyo via Suez is
+   * closed for non-British powers; the BFS falls back through the Pacific.
+   */
+  private static BiPredicate<Territory, Territory> combinedMovementEdgeCond(
+      final GamePlayer player) {
+    return (from, to) -> {
+      if (!ProMatches.noCanalsBetweenTerritories(player).test(from, to)) {
+        return false;
+      }
+      return ProMatches.territoryCanPotentiallyMoveLandUnits(player).test(to)
+          || ProMatches.territoryCanMoveSeaUnits(player, true).test(to);
+    };
+  }
+
+  /**
+   * Builds the anchor → strength map per spec §4 "Objectives O and the flag" pseudocode.
+   *
+   * <p>Dynamically derives anchors from live enemy capitals + enemy-owned factory territories +
+   * victory cities owned by an enemy power (§10 question 4). Per-flag theater filter applies the
+   * suppression multiplier {@code alphaOff} to off-theater anchors so the off-theater isn't fully
+   * forgotten.
+   */
+  static Map<Territory, Double> buildObjectives(final ProData proData, final GamePlayer player) {
+    final GameData data = proData.getData();
+    final AiTheaterPriority flag = proData.getAiTheaterPriority();
+    final double gCap = proData.getGCap();
+    final double gFac = gCap * G_FAC_FRACTION;
+    final double gVc = gCap * G_VC_FRACTION;
+    final double alphaOff = proData.getAlphaOff();
+
+    final Set<GamePlayer> enemies = new HashSet<>(ProUtils.getPotentialEnemyPlayers(player));
+    if (enemies.isEmpty()) {
+      return Map.of();
+    }
+
+    final Map<Territory, Double> anchors = new HashMap<>();
+
+    // Capitals: live enemy capitals — strongest pull.
+    for (final Territory cap : ProUtils.getLiveEnemyCapitals(data, player)) {
+      final double weight = theaterWeight(cap.getOwner(), flag, alphaOff);
+      mergeMax(anchors, cap, gCap * weight);
+    }
+
+    // Factories + victory cities: enumerate enemy-owned land territories once.
+    for (final Territory t : data.getMap().getTerritories()) {
+      if (t.isWater() || !enemies.contains(t.getOwner())) {
+        continue;
+      }
+      final double weight = theaterWeight(t.getOwner(), flag, alphaOff);
+      if (ProMatches.territoryHasInfraFactoryAndIsLand().test(t)) {
+        mergeMax(anchors, t, gFac * weight);
+      }
+      if (TerritoryAttachment.get(t).map(ta -> ta.getVictoryCity() != 0).orElse(false)) {
+        mergeMax(anchors, t, gVc * weight);
+      }
+    }
+
+    return anchors;
+  }
+
+  /**
+   * Launch bonus {@code L(n)} per spec §4: bumps a water node if any neighboring land territory is
+   * a high-{@code S} targeted-theater objective worth assaulting. Cutoff defaults to 50 % of {@code
+   * G_cap}.
+   */
+  static double launchBonus(
+      final Territory seaZone, final Map<Territory, Double> field, final ProData proData) {
+    if (!seaZone.isWater()) {
+      return 0.0;
+    }
+    final double beta = proData.getBetaLaunch();
+    if (beta <= 0.0) {
+      return 0.0;
+    }
+    final double cutoff = proData.getGCap() * 0.5;
+    final Set<Territory> neighbors =
+        proData.getData().getMap().getNeighbors(seaZone, Matches.territoryIsLand());
+    for (final Territory n : neighbors) {
+      final Double v = field.get(n);
+      if (v != null && v >= cutoff) {
+        return beta;
+      }
+    }
+    return 0.0;
+  }
+
+  /**
+   * Returns {@code 1.0} for an anchor in the targeted theater, {@code alphaOff} otherwise. The
+   * European-theater bucket is "every axis power that isn't {@value PACIFIC_AXIS_NAME}" — keeps the
+   * classification data-driven and survives an Italian-only Mediterranean scenario.
+   */
+  private static double theaterWeight(
+      final GamePlayer owner, final AiTheaterPriority flag, final double alphaOff) {
+    final boolean ownerInPacific = PACIFIC_AXIS_NAME.equals(owner.getName());
+    final boolean targetingPacific = flag == AiTheaterPriority.KJF;
+    return ownerInPacific == targetingPacific ? 1.0 : alphaOff;
+  }
+
+  private static void mergeMax(final Map<Territory, Double> m, final Territory t, final double v) {
+    m.merge(t, v, Math::max);
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -109,6 +109,13 @@ public final class ProTerritoryValueUtils {
       final List<Territory> territoriesThatCantBeHeld,
       final List<Territory> territoriesToAttack,
       final Set<Territory> territoriesToCheck) {
+    // Strategic Value Field (map-room#2755 PR-A): lazy-compute S(n) on the first
+    // findTerritoryValues call of this request when wStrat > 0. Skipped entirely when wStrat==0
+    // (the zero-impact default), so PR-A is a true no-op for non-tuning runs. PR-B's blend
+    // reads proData.getStrategicValueField() and applies wStrat * S(t) inside the value loops.
+    if (proData.getWStrat() > 0 && proData.getStrategicValueField() == null) {
+      proData.setStrategicValueField(ProStrategicValueField.compute(proData, player));
+    }
     final int maxLandMassSize = findMaxLandMassSize(player);
     final Map<Territory, Double> enemyCapitalsAndFactoriesMap =
         findEnemyCapitalsAndFactoriesValue(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -110,10 +110,13 @@ public final class ProTerritoryValueUtils {
       final List<Territory> territoriesToAttack,
       final Set<Territory> territoriesToCheck) {
     // Strategic Value Field (map-room#2755 PR-A): lazy-compute S(n) on the first
-    // findTerritoryValues call of this request when wStrat > 0. Skipped entirely when wStrat==0
-    // (the zero-impact default), so PR-A is a true no-op for non-tuning runs. PR-B's blend
-    // reads proData.getStrategicValueField() and applies wStrat * S(t) inside the value loops.
-    if (proData.getWStrat() > 0 && proData.getStrategicValueField() == null) {
+    // findTerritoryValues call of this request when either (a) wStrat > 0 (PR-B's blend will
+    // need it) or (b) the strategic dump is explicitly enabled (the user is asking to *see*
+    // S(n), they shouldn't have to also remember to set AI_SVF_W_STRAT). Skipped entirely on
+    // both wStrat==0 AND dump-off so the default path is a true no-op. PR-B's blend reads
+    // proData.getStrategicValueField() and applies wStrat * S(t) inside the value loops.
+    if (proData.getStrategicValueField() == null
+        && (proData.getWStrat() > 0 || ProValueHeatmapDumper.isStrategicEnabled())) {
       proData.setStrategicValueField(ProStrategicValueField.compute(proData, player));
     }
     final int maxLandMassSize = findMaxLandMassSize(player);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumperTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/logging/ProValueHeatmapDumperTest.java
@@ -8,7 +8,9 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameSequence;
 import games.strategy.engine.data.Territory;
+import games.strategy.triplea.ai.pro.ProData;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,6 +36,7 @@ class ProValueHeatmapDumperTest {
   @AfterEach
   void tearDown() {
     System.clearProperty("ai.dump.values");
+    System.clearProperty("ai.dump.strategic");
     System.clearProperty("ai.dump.path");
   }
 
@@ -145,6 +148,7 @@ class ProValueHeatmapDumperTest {
   void fallsBackToHomeDirWhenNoOverrideSet(@TempDir final Path fakeHome) {
     // Clear the sysprop set by setUp() to exercise the user.home fallback path.
     System.clearProperty("ai.dump.path");
+    final String originalHome = System.getProperty("user.home");
     System.setProperty("user.home", fakeHome.toString());
     System.setProperty("ai.dump.values", "1");
     try {
@@ -162,10 +166,15 @@ class ProValueHeatmapDumperTest {
         throw new RuntimeException(e);
       }
     } finally {
-      // Restore HOME so other tests in the JVM aren't affected. user.home is normally
-      // immutable for the process lifetime; setting it for one test is OK but we want
-      // to be polite about cleanup.
-      System.clearProperty("user.home");
+      // Restore the ORIGINAL user.home — clearing it (the previous impl) leaks a null
+      // into the JVM that breaks subsequent ClientSetting static init in OTHER test
+      // classes that run in the same JVM (caught when ProStrategicValueFieldTest started
+      // failing intermittently with NoClassDefFoundError on ClientSetting).
+      if (originalHome != null) {
+        System.setProperty("user.home", originalHome);
+      } else {
+        System.clearProperty("user.home");
+      }
     }
   }
 
@@ -192,7 +201,108 @@ class ProValueHeatmapDumperTest {
     assertThat(zeroCount).isEqualTo(3);
   }
 
+  // ---------------------------------------------------------------------------
+  // Strategic-field sibling dump (PR-A — map-room#2755)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void strategicGate_disabledByDefault_noSiblingFileWritten() {
+    System.setProperty("ai.dump.values", "1"); // value gate on
+    // ai.dump.strategic intentionally NOT set
+    final ProData proData =
+        stubProDataWithStrategicField(1, Map.of(stubTerritory("Foo", false), 5.0));
+    final GamePlayer player = stubPlayer("Americans");
+    final Map<Territory, Double> values = Map.of(stubTerritory("Foo", false), 1.0);
+
+    ProValueHeatmapDumper.dumpIfEnabled(proData, player, "combined", values);
+
+    // Only the value-map dump is written, no -strategic sibling.
+    final List<Path> files = listDumpedFiles();
+    assertThat(files).hasSize(1);
+    assertThat(files.get(0).getFileName().toString()).doesNotContain("strategic");
+  }
+
+  @Test
+  void strategicGate_enabled_andFieldPopulated_writesSiblingFile() throws IOException {
+    System.setProperty("ai.dump.values", "1");
+    System.setProperty("ai.dump.strategic", "1");
+    final Map<Territory, Double> strategicField =
+        orderedMap(stubTerritory("Berlin", false), 75.0, stubTerritory("East US", false), 10.5);
+    final ProData proData = stubProDataWithStrategicField(3, strategicField);
+    final GamePlayer player = stubPlayer("Americans");
+    final Map<Territory, Double> values = Map.of(stubTerritory("Foo", false), 1.0);
+
+    ProValueHeatmapDumper.dumpIfEnabled(proData, player, "combined", values);
+
+    final List<Path> files = listDumpedFiles();
+    assertThat(files).hasSize(2);
+    final Path siblingFile =
+        files.stream()
+            .filter(p -> p.getFileName().toString().contains("strategic"))
+            .findFirst()
+            .orElseThrow();
+    final String content = Files.readString(siblingFile, StandardCharsets.UTF_8);
+    assertThat(content)
+        .contains("\"entrypoint\":\"combined-strategic\"")
+        .contains("\"round\":3")
+        .contains("\"name\":\"Berlin\"")
+        .contains("\"value\":75.0")
+        .contains("\"name\":\"East US\"")
+        .contains("\"value\":10.5");
+  }
+
+  @Test
+  void strategicGate_enabled_butFieldNull_writesNoSibling() {
+    System.setProperty("ai.dump.values", "1");
+    System.setProperty("ai.dump.strategic", "1");
+    final ProData proData = stubProDataWithStrategicField(1, null);
+    final GamePlayer player = stubPlayer("Americans");
+    final Map<Territory, Double> values = Map.of(stubTerritory("Foo", false), 1.0);
+
+    ProValueHeatmapDumper.dumpIfEnabled(proData, player, "combined", values);
+
+    assertThat(listDumpedFiles())
+        .as("strategic field null (wStrat=0 path) → no sibling")
+        .hasSize(1)
+        .allMatch(p -> !p.getFileName().toString().contains("strategic"));
+  }
+
+  @Test
+  void strategicGate_independent_fromValueGate_canEmitWithoutValueDump() {
+    // AI_DUMP_VALUES off, AI_DUMP_STRATEGIC on — only the strategic sibling should write.
+    System.setProperty("ai.dump.strategic", "1");
+    final ProData proData =
+        stubProDataWithStrategicField(2, Map.of(stubTerritory("Foo", false), 5.0));
+    final GamePlayer player = stubPlayer("Americans");
+    final Map<Territory, Double> values = Map.of(stubTerritory("Foo", false), 1.0);
+
+    ProValueHeatmapDumper.dumpIfEnabled(proData, player, "combined", values);
+
+    final List<Path> files = listDumpedFiles();
+    assertThat(files).hasSize(1);
+    assertThat(files.get(0).getFileName().toString()).contains("strategic");
+  }
+
   // --- helpers ---
+
+  /**
+   * Builds a real {@link ProData} with reflection-injected mocked GameData. ProData is final so
+   * Mockito can't mock it directly; this mirrors the helper pattern in {@code
+   * ProFriendlyIslandFloorTest} and {@code ProStrategicValueFieldTest}.
+   */
+  private static ProData stubProDataWithStrategicField(
+      final int round, final Map<Territory, Double> strategicField) {
+    try {
+      final ProData proData = new ProData();
+      final Field dataField = ProData.class.getDeclaredField("data");
+      dataField.setAccessible(true);
+      dataField.set(proData, stubGameData(round));
+      proData.setStrategicValueField(strategicField);
+      return proData;
+    } catch (final ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   private List<Path> listDumpedFiles() {
     try (Stream<Path> s = Files.list(tempDir)) {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProStrategicValueFieldTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProStrategicValueFieldTest.java
@@ -1,0 +1,290 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.AiTheaterPriority;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Phase 1B+1C (PR-A) shadow-field tests. Asserts directional properties of S(n) against a standard
+ * 1940 Global game state — the canonical fixture from §10 is a round-3 dump (a save file we don't
+ * have); these tests use round 1 for reproducibility, and the 🧑 Manual fixture acceptance lives in
+ * the PR body.
+ */
+class ProStrategicValueFieldTest {
+
+  private GameData data;
+  private GamePlayer americans;
+  private ProData proData;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    proData = proDataFor(data);
+  }
+
+  @Test
+  void fieldIsKeyedByEveryTerritoryOnTheBoard_Finding3() {
+    proData.setWStrat(1.0);
+
+    final Map<Territory, Double> field = ProStrategicValueField.compute(proData, americans);
+
+    assertThat(field.keySet())
+        .as("§10 Finding 3: S(n) cache must cover the full board, not per-call subset")
+        .containsExactlyInAnyOrderElementsOf(data.getMap().getTerritories());
+  }
+
+  @Test
+  void underKgf_S_Berlin_dominates_S_USEastCoast_and_both_positive() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setWStrat(1.0);
+
+    final Map<Territory, Double> field = ProStrategicValueField.compute(proData, americans);
+
+    final Territory berlin = data.getMap().getTerritoryOrThrow("Germany");
+    final Territory eastUs = data.getMap().getTerritoryOrThrow("Eastern United States");
+    assertThat(field.get(berlin))
+        .as("Berlin is the KGF anchor and must dominate any non-anchor")
+        .isGreaterThan(field.get(eastUs));
+    assertThat(field.get(eastUs))
+        .as("Decay must reach the US East Coast (>0) so the gradient is connected at default knobs")
+        .isPositive();
+  }
+
+  @Test
+  void underKjf_S_Tokyo_dominates_S_Berlin() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KJF);
+    proData.setWStrat(1.0);
+
+    final Map<Territory, Double> field = ProStrategicValueField.compute(proData, americans);
+
+    final Territory tokyo = data.getMap().getTerritoryOrThrow("Japan");
+    final Territory berlin = data.getMap().getTerritoryOrThrow("Germany");
+    assertThat(field.get(tokyo))
+        .as("Tokyo is the KJF anchor and must dominate Berlin (which becomes off-theater)")
+        .isGreaterThan(field.get(berlin));
+  }
+
+  @Test
+  void alphaOff_suppresses_offtheater_anchor_below_targeted() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setAlphaOff(0.10);
+    proData.setWStrat(1.0);
+
+    final Map<Territory, Double> field = ProStrategicValueField.compute(proData, americans);
+
+    final Territory berlin = data.getMap().getTerritoryOrThrow("Germany");
+    final Territory tokyo = data.getMap().getTerritoryOrThrow("Japan");
+    // Under KGF, Berlin has weight 1.0, Tokyo has weight alphaOff=0.10. Decay is the same
+    // gamma^d at d=0, so the ratio at the anchor itself is exactly alphaOff.
+    assertThat(field.get(tokyo) / field.get(berlin))
+        .as("Off-theater anchor must be suppressed to alphaOff times the targeted anchor at d=0")
+        .isLessThanOrEqualTo(0.105)
+        .isGreaterThanOrEqualTo(0.095);
+  }
+
+  @Test
+  void perPowerCanalPredicate_isHonored_USRoutesAvoidSuez() {
+    // US doesn't own Suez/Egypt; the canal predicate (ProMatches.noCanalsBetweenTerritories)
+    // should force the BFS to route Atlantic → US around Africa, not through Suez.
+    // We verify by asserting that under KGF the European-side decay reaches London (Atlantic
+    // side, short hop from Berlin) much faster than it reaches Western Australia (other side
+    // of the world for a US-perspective BFS that respects canal rules).
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setWStrat(1.0);
+
+    final Map<Territory, Double> field = ProStrategicValueField.compute(proData, americans);
+
+    final Territory london = data.getMap().getTerritoryOrThrow("United Kingdom");
+    final Territory westAus = data.getMap().getTerritoryOrThrow("Western Australia");
+    assertThat(field.get(london))
+        .as("London is short-hop from Berlin via the Atlantic; must score higher than Australia")
+        .isGreaterThan(field.get(westAus));
+  }
+
+  @Test
+  void wStratZero_leavesFieldUntouched_byPolicy_noCallerShouldRead() {
+    // ProStrategicValueField.compute is happy to run with wStrat=0; the call-site gate in
+    // ProTerritoryValueUtils.findTerritoryValues is what prevents it from being invoked. This
+    // test just verifies that compute() itself doesn't assume wStrat > 0.
+    proData.setWStrat(0.0);
+
+    final Map<Territory, Double> field = ProStrategicValueField.compute(proData, americans);
+
+    assertThat(field).isNotEmpty();
+    assertThat(field.keySet()).containsExactlyInAnyOrderElementsOf(data.getMap().getTerritories());
+  }
+
+  @Test
+  void launchBonus_zero_when_betaLaunch_zero() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setWStrat(1.0);
+    proData.setBetaLaunch(0.0); // default; explicit for clarity
+
+    final Map<Territory, Double> field = ProStrategicValueField.compute(proData, americans);
+
+    // Pick a sea zone adjacent to a high-S coastal target (Western Germany neighbors several
+    // SZ in the Bay of Biscay / North Sea area). With betaLaunch=0, the sea-zone bonus is 0,
+    // so the SZ value should be entirely decay-driven (no additive bump).
+    // We confirm by computing again with a positive betaLaunch and asserting the diff equals
+    // betaLaunch on at least one sea zone.
+    proData.setStrategicValueField(null); // clear lazy cache
+    proData.setBetaLaunch(7.5);
+    final Map<Territory, Double> withBonus = ProStrategicValueField.compute(proData, americans);
+
+    boolean anySeaBumped = false;
+    for (final Territory t : data.getMap().getTerritories()) {
+      if (!t.isWater()) {
+        continue;
+      }
+      final double diff = withBonus.get(t) - field.get(t);
+      if (Math.abs(diff - 7.5) < 1e-9) {
+        anySeaBumped = true;
+        break;
+      }
+    }
+    assertThat(anySeaBumped)
+        .as("At least one sea zone adjacent to a high-S coast must receive the launch bonus")
+        .isTrue();
+  }
+
+  @Test
+  void printManualAcceptanceNumbers_atRound1_default_knobs() {
+    // Documents the S(n) values at the named §10 anchors under the default knobs for both
+    // theater flags. Printed to stdout for capture into the PR body; the assertions only
+    // pin the §10 acceptance criteria so a regression is loud. Round-3 (canonical fixture)
+    // validation still requires a save-game export — 🧑 Manual TODO.
+    proData.setGCap(75.0);
+    proData.setGamma(0.85);
+    proData.setWStrat(1.0);
+    proData.setAlphaOff(0.10);
+
+    // Names verified against the §10 canonical-fixture territory list (Italy is split into
+    // Northern/Southern in 1940 Global; Tokyo is just "Japan" the home island).
+    final String[] anchors = {
+      "Germany",
+      "Western Germany",
+      "Japan",
+      "Amur",
+      "Korea",
+      "Eastern United States",
+      "Western United States",
+      "Hawaiian Islands",
+      "United Kingdom",
+      "French West Africa",
+      "Western Australia",
+    };
+
+    for (final AiTheaterPriority flag : AiTheaterPriority.values()) {
+      proData.setAiTheaterPriority(flag);
+      proData.setStrategicValueField(null);
+      final Map<Territory, Double> field = ProStrategicValueField.compute(proData, americans);
+      System.out.printf("%n--- §10 acceptance numbers — round 1, %s ---%n", flag);
+      for (final String name : anchors) {
+        final Territory t = data.getMap().getTerritoryOrThrow(name);
+        System.out.printf("  S(%s) = %.3f%n", name, field.get(t));
+      }
+    }
+  }
+
+  @Test
+  void manualAcceptance_KGF_gradientReachesUSEastCoast() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setGCap(75.0);
+    proData.setGamma(0.85);
+    proData.setWStrat(1.0);
+    proData.setAlphaOff(0.10);
+
+    final Map<Territory, Double> field = ProStrategicValueField.compute(proData, americans);
+
+    final Territory eastUs = data.getMap().getTerritoryOrThrow("Eastern United States");
+    final Territory germany = data.getMap().getTerritoryOrThrow("Germany");
+    final Territory westGermany = data.getMap().getTerritoryOrThrow("Western Germany");
+    assertThat(field.get(germany))
+        .as("§10 acceptance: KGF anchor — capital must dominate any neighbor")
+        .isGreaterThan(field.get(westGermany));
+    assertThat(field.get(eastUs))
+        .as("§10 acceptance: gradient reaches US East Coast at default knobs (>0)")
+        .isPositive();
+  }
+
+  @Test
+  void manualAcceptance_KJF_asymmetry_PacificDominatesAtlantic() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KJF);
+    proData.setGCap(75.0);
+    proData.setGamma(0.85);
+    proData.setWStrat(1.0);
+    proData.setAlphaOff(0.10);
+
+    final Map<Territory, Double> field = ProStrategicValueField.compute(proData, americans);
+
+    // §10 Finding 1: KJF reinforces an existing Pacific lean, doesn't flatten it.
+    // Pick representative Asia + Atlantic regions and assert the Pacific side wins.
+    final Territory manchuria = data.getMap().getTerritoryOrThrow("Manchuria");
+    final Territory frenchWestAfrica = data.getMap().getTerritoryOrThrow("French West Africa");
+    assertThat(field.get(manchuria))
+        .as("§10 KJF asymmetry: Asian theater must dominate non-Asian under KJF")
+        .isGreaterThan(field.get(frenchWestAfrica));
+  }
+
+  @Test
+  void buildObjectives_includesLiveEnemyCapitals_and_isNonEmpty() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+
+    final Map<Territory, Double> anchors =
+        ProStrategicValueField.buildObjectives(proData, americans);
+
+    assertThat(anchors)
+        .as("anchor set must not be empty for a standard 1940 Global setup")
+        .isNotEmpty();
+    // Germany and Japan are both axis capitals at round 1 — both must appear as anchors,
+    // Germany at full strength under KGF, Japan at alphaOff.
+    final Territory berlin = data.getMap().getTerritoryOrThrow("Germany");
+    final Territory tokyo = data.getMap().getTerritoryOrThrow("Japan");
+    assertThat(anchors).containsKey(berlin);
+    assertThat(anchors).containsKey(tokyo);
+    assertThat(anchors.get(berlin))
+        .as("Berlin is targeted-theater capital under KGF — must be at full G_cap")
+        .isGreaterThan(anchors.get(tokyo));
+  }
+
+  // --- helpers ---
+
+  /**
+   * ProData lacks a public init that takes a raw GameData. Reflection-injects the data field;
+   * pattern borrowed from ProFriendlyIslandFloorTest.
+   */
+  private static ProData proDataFor(final GameData gameData) throws Exception {
+    final ProData p = new ProData();
+    final Field f = ProData.class.getDeclaredField("data");
+    f.setAccessible(true);
+    f.set(p, gameData);
+    return p;
+  }
+
+  /** Convenience reachable-territory set, mostly for debugging during test development. */
+  @SuppressWarnings("unused")
+  private static Set<Territory> waterOnly(final GameData data) {
+    final Set<Territory> s = new HashSet<>();
+    for (final Territory t : data.getMap().getTerritories()) {
+      if (t.isWater()) {
+        s.add(t);
+      }
+    }
+    return s;
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProStrategicValueFieldTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProStrategicValueFieldTest.java
@@ -242,6 +242,50 @@ class ProStrategicValueFieldTest {
   }
 
   @Test
+  void lazyCompute_alsoFires_whenStrategicDumpEnabled_evenWithWStratZero() {
+    // Hotfix gate (post-PR-A review): a user setting AI_DUMP_STRATEGIC=1 is asking to *see*
+    // S(n); they shouldn't have to also know about AI_SVF_W_STRAT. With the dump enabled,
+    // the lazy compute must fire even when wStrat=0 so the dumper has something to write.
+    System.setProperty("ai.dump.strategic", "1");
+    try {
+      proData.setWStrat(0.0);
+      assertThat(proData.getStrategicValueField()).isNull();
+
+      ProTerritoryValueUtils.findTerritoryValues(
+          proData,
+          americans,
+          java.util.List.of(),
+          java.util.List.of(),
+          Set.of(data.getMap().getTerritoryOrThrow("Germany")));
+
+      assertThat(proData.getStrategicValueField())
+          .as("Lazy compute must fire when AI_DUMP_STRATEGIC=1 even at wStrat=0")
+          .isNotNull()
+          .isNotEmpty();
+    } finally {
+      System.clearProperty("ai.dump.strategic");
+    }
+  }
+
+  @Test
+  void lazyCompute_doesNotFire_whenBothGatesAreOff() {
+    // Zero-impact default: wStrat=0 AND AI_DUMP_STRATEGIC unset → no compute, no allocation,
+    // strategicValueField stays null.
+    proData.setWStrat(0.0);
+
+    ProTerritoryValueUtils.findTerritoryValues(
+        proData,
+        americans,
+        java.util.List.of(),
+        java.util.List.of(),
+        Set.of(data.getMap().getTerritoryOrThrow("Germany")));
+
+    assertThat(proData.getStrategicValueField())
+        .as("Lazy compute must NOT fire when wStrat=0 AND strategic dump off")
+        .isNull();
+  }
+
+  @Test
   void buildObjectives_includesLiveEnemyCapitals_and_isNonEmpty() {
     proData.setAiTheaterPriority(AiTheaterPriority.KGF);
 


### PR DESCRIPTION
**PR-A** of the SVF rollout (map-room#2755). Per amended plan §6: shadow-first ordering — compute + dump S(n) *before* wire + UI. **Zero behavior change**: `wStrat=0.0` default means nothing reads S(n); the lazy compute is gated and the integration is a true no-op for non-tuning runs.

Paired TS-side PR: **map-room/map-room#2759** (will edit in)

## Manual acceptance numbers (round 1, default knobs `gCap=75 gamma=0.85 alphaOff=0.10`)

These are emitted by the `printManualAcceptanceNumbers_atRound1_default_knobs` test in `ProStrategicValueFieldTest`. **Note: round 1 ≠ canonical §10 fixture round 3** — at round 1 the US hasn't declared war yet, so `ProUtils.getPotentialEnemyPlayers` returns more than just the axis (it returns non-allied AND non-passive-neutral). Round-3 numbers will be tighter, and that fixture validation is the 🧑 Manual TODO pending save-game export from chase.

| Anchor | KGF | KJF |
|---|---:|---:|
| Germany | 75.000 | 7.500 |
| Western Germany | 63.750 | 6.375 |
| Japan | 7.500 | 75.000 |
| Amur | 24.043 | 15.660 |
| Korea | 20.437 | 15.660 |
| Eastern United States | 38.250 | 4.267 |
| Western United States | 27.636 | 5.906 |
| Hawaiian Islands | 28.286 | 5.906 |
| United Kingdom | 75.000 | 7.500 |
| French West Africa | 33.278 | 3.627 |
| Western Australia | 54.187 | 6.949 |

**Directional acceptance criteria pass** (asserted by tests):
- KGF: `S(Germany) > S(Western Germany)` ✓; `S(Eastern United States) > 0` ✓ (38.25 — high because round-1 relationship state includes UK as a potential enemy capital, see note above)
- KJF: `S(Manchuria) > S(French West Africa)` ✓ — Pacific lean reinforced

**🧑 Manual TODO (chase):** export a round-3 save from the canonical AI-vs-AI run and re-run with the new env vars + `AI_DUMP_STRATEGIC=1`; expect `S(US East Coast) ≈ 5-15` and `S(Berlin) > S(Western Germany)` per §10 acceptance.

## Plan deviations

1. **Only 2 executors exist, not 3.** Plan mentioned `OtherOffensiveExecutor` — that class does not exist in the current sidecar. Scope is `PurchaseExecutor` + `NoncombatMoveExecutor`.
2. **No shared init hook in `ExecutorSupport`.** Audit confirmed each executor calls decision-specific setup between `initializeProAi` and the decision invoke (delegate registration, recorder, reinit). A shared hook would require threading N callbacks — duplicating the one-line `ProSvfKnobs.applyTo(proAi.getProData())` is cleaner.
3. **matchId in filenames** remains deferred per the same Phase-0 reason (would require a game-core thread-local sibling to `AiTraceLogger`'s sidecar-side one). Documented in the dumper javadoc.

## Bugs found (and fixed) during implementation

1. **`BreadthFirstSearch.traverse()` only visits *neighbors*, not the start territory.** Without seeding the anchor's own value, `S(anchor) = 0`. Tests caught it (KJF `S(Tokyo) = 0` failure). Fix: explicit `field.put(anchor, strength)` before BFS.
2. **Phase-0 dumper test leaked `user.home = null` into the JVM**, breaking `ClientSetting` static init in *other* test classes that share the JVM. Caught when `ProStrategicValueFieldTest` started failing with `NoClassDefFoundError: ClientSetting`. Fix: save-and-restore in finally instead of clear.

## Test plan

- [x] `./gradlew :game-app:game-core:test --tests 'ProStrategicValueFieldTest'` — **11/11 passing**
- [x] `./gradlew :game-app:game-core:test --tests 'ProValueHeatmapDumperTest'` — **12/12 passing** (was 8; added 4 strategic-gate tests)
- [x] `./gradlew :game-app:game-core:test` (full suite) — **green** (no regression from `user.home` save-and-restore or ProData field additions)
- [x] `./gradlew spotlessApply && ./gradlew spotlessCheck` — clean
- [x] `./gradlew :game-app:game-core:compileJava :game-app:ai-sidecar:compileJava` — clean
- [ ] 🧑 Manual: chase exports a round-3 save from the canonical AI-vs-AI run; runs with `AI_DUMP_VALUES=1 AI_DUMP_STRATEGIC=1 AI_SVF_W_STRAT=1.0`; drags the resulting `*-strategic.json` into the browser and calls `window.__MAPROOM_DEBUG__.showStrategicField(jsonText)`; confirms diagnostic-anchor numbers match §10 expectation.

## Env knobs (recognized by `ProSvfKnobs`)

| Env | Sysprop | Default |
|---|---|---|
| `AI_THEATER_PRIORITY` | `ai.theater.priority` | `KGF` |
| `AI_SVF_G_CAP` | `ai.svf.g.cap` | `75.0` |
| `AI_SVF_GAMMA` | `ai.svf.gamma` | `0.85` |
| `AI_SVF_W_STRAT` | `ai.svf.w.strat` | `0.0` |
| `AI_SVF_ALPHA_OFF` | `ai.svf.alpha.off` | `0.10` |
| `AI_SVF_BETA_LAUNCH` | `ai.svf.beta.launch` | `0.0` |
| `AI_DUMP_STRATEGIC` | `ai.dump.strategic` | unset |