### PR TITLE
feat(proai): PR-C — Phase 3A off-theater defense floor (map-room#2755)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -23,6 +23,7 @@ import games.strategy.triplea.ai.pro.data.ProTerritoryManager;
 import games.strategy.triplea.ai.pro.data.ProTransport;
 import games.strategy.triplea.ai.pro.logging.ProLogger;
 import games.strategy.triplea.ai.pro.util.ProBattleUtils;
+import games.strategy.triplea.ai.pro.util.ProDefenseFloor;
 import games.strategy.triplea.ai.pro.util.ProMatches;
 import games.strategy.triplea.ai.pro.util.ProMoveUtils;
 import games.strategy.triplea.ai.pro.util.ProOddsCalculator;
@@ -891,6 +892,15 @@ class ProNonCombatMoveAi {
         }
         if (!estimatesMap.isEmpty() && estimatesMap.lastKey() > 60) {
           final Territory minWinTerritory = estimatesMap.lastEntry().getValue();
+          // Phase 3A defense floor (map-room#2755): if pulling this unit would drop its
+          // source territory below the configured garrison floor (Hawaii under KGF, etc.),
+          // skip the assignment so the off-theater holding isn't strip-mined to feed the
+          // targeted theater. Empty floor map for non-US so this is a no-op for other
+          // players. Spec §4 "Off-theater defense floor".
+          if (ProDefenseFloor.wouldViolateFloor(
+              proData, proData.getUnitTerritory(unit), unit, addedUnits)) {
+            continue;
+          }
           final List<Unit> unitsToAdd = ProTransportUtils.getUnitsToAdd(proData, unit, moveMap);
           moveMap.get(minWinTerritory).addTempUnits(unitsToAdd);
           addedUnits.addAll(unitsToAdd);
@@ -924,6 +934,11 @@ class ProNonCombatMoveAi {
           }
         }
         if (maxWinTerritory != null) {
+          // Phase 3A defense floor — see comment on the earlier loop above.
+          if (ProDefenseFloor.wouldViolateFloor(
+              proData, proData.getUnitTerritory(unit), unit, addedUnits)) {
+            continue;
+          }
           ProTerritory to = moveMap.get(maxWinTerritory);
           to.setBattleResult(null);
           final List<Unit> unitsToAdd = ProTransportUtils.getUnitsToAdd(proData, unit, moveMap);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProDefenseFloor.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProDefenseFloor.java
@@ -1,0 +1,120 @@
+package games.strategy.triplea.ai.pro.util;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.AiTheaterPriority;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Off-theater defense floor for the SVF (map-room#2755 Phase 3A).
+ *
+ * <p>The strategic value field pulls US offensive force toward the targeted theater, but a strong
+ * Berlin gradient under KGF will strip Pacific garrisons (Hawaii, US West Coast, ANZAC core) to
+ * feed Europe — handing those territories to Japan. The defense floor is a second lever: enforce a
+ * minimum garrison {@code D_floor(k)} on key off-theater holdings that the NCM "where to defend"
+ * allocator may not pull below. Spec §4 "Auxiliary behaviors the value map cannot express (separate
+ * hooks)".
+ *
+ * <p>Phase 1 scope: US-only (spec §2). Other players get an empty floor map and their NCM is
+ * unaffected. The floor populates per request from the {@link ProData#getAiTheaterPriority()} flag
+ * — KGF puts the floor on the Pacific holdings, KJF mirrors it onto Atlantic holdings.
+ *
+ * <p>Initial garrison values are placeholders per spec §7 — Phase 4A tuning may refine them against
+ * AI-vs-AI win-rate sweeps. The set of guarded territories is small and intentional: just the
+ * anchor positions whose loss would visibly collapse the unfavored theater.
+ */
+@UtilityClass
+public final class ProDefenseFloor {
+
+  /**
+   * Off-theater garrison floors when {@code aiTheaterPriority == KGF}. Pacific holdings the US must
+   * NOT strip to feed Europe. Hawaii is the headline case — without a floor, US tends to empty it
+   * once Berlin's gradient is meaningful, and Japan invades in 2-3 turns.
+   */
+  private static final Map<String, Integer> KGF_FLOORS =
+      Map.of(
+          "Hawaiian Islands", 2,
+          "Western United States", 2,
+          "Queensland", 1,
+          "New South Wales", 1);
+
+  /**
+   * Off-theater garrison floors when {@code aiTheaterPriority == KJF}. Atlantic holdings the US
+   * must NOT strip to feed the Pacific.
+   */
+  private static final Map<String, Integer> KJF_FLOORS =
+      Map.of(
+          "Eastern United States", 2,
+          "Central United States", 1);
+
+  /**
+   * Builds the {@code Territory → garrison-floor} map for the player. Returns an empty map for any
+   * non-Americans player — Phase 1 spec §2 scopes the SVF to US-only. Caller stores the result on
+   * {@link ProData#setDFloor}.
+   */
+  public static Map<Territory, Integer> compute(final ProData proData, final GamePlayer player) {
+    if (player == null || !"Americans".equals(player.getName())) {
+      return Map.of();
+    }
+    final AiTheaterPriority flag = proData.getAiTheaterPriority();
+    final Map<String, Integer> floorByName =
+        flag == AiTheaterPriority.KJF ? KJF_FLOORS : KGF_FLOORS;
+    final GameData data = proData.getData();
+    final Map<Territory, Integer> floor = new HashMap<>();
+    for (final Map.Entry<String, Integer> entry : floorByName.entrySet()) {
+      final Territory t = data.getMap().getTerritoryOrNull(entry.getKey());
+      if (t != null) {
+        floor.put(t, entry.getValue());
+      }
+    }
+    return floor;
+  }
+
+  /**
+   * Returns {@code true} if pulling {@code unit} out of {@code source} would drop the source's
+   * player-owned garrison below the configured floor. Returns {@code false} when no floor is
+   * configured for the source territory, or when the source isn't owned by the player making the
+   * move (defending units somewhere they don't own get no protection).
+   *
+   * @param alreadyAssigned units the NCM allocator has already committed to move OUT of {@code
+   *     source} this pass — counted as already-pulled when computing remaining garrison
+   */
+  public static boolean wouldViolateFloor(
+      final ProData proData,
+      final @Nullable Territory source,
+      final Unit unit,
+      final Collection<Unit> alreadyAssigned) {
+    if (source == null) {
+      return false;
+    }
+    final int floor = proData.getDFloor().getOrDefault(source, 0);
+    if (floor <= 0) {
+      return false;
+    }
+    final GamePlayer player = proData.getPlayer();
+    if (player == null || !source.isOwnedBy(player)) {
+      return false;
+    }
+    long remainingAtSource = 0;
+    for (final Unit u : source.getUnits()) {
+      if (!u.getOwner().equals(player)) {
+        continue;
+      }
+      if (u.equals(unit)) {
+        continue; // about-to-be-pulled
+      }
+      if (alreadyAssigned.contains(u)) {
+        continue; // already pulled this NCM pass
+      }
+      remainingAtSource++;
+    }
+    return remainingAtSource < floor;
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -119,6 +119,18 @@ public final class ProTerritoryValueUtils {
         && (proData.getWStrat() > 0 || ProValueHeatmapDumper.isStrategicEnabled())) {
       proData.setStrategicValueField(ProStrategicValueField.compute(proData, player));
     }
+    // Phase 3A (map-room#2755): populate the off-theater defense floor at the same lazy hook
+    // so NCM's defense allocator can read it via proData.getDFloor(). Empty for non-US per
+    // spec §2; doesn't affect non-US behavior. Populated regardless of wStrat — the floor
+    // protects Pacific holdings (or Atlantic under KJF) from being stripped by NCM even when
+    // the SVF blend itself is off, so a user who sets AI_THEATER_PRIORITY without wStrat still
+    // gets the asymmetric defense protection.
+    if (proData.getDFloor().isEmpty()) {
+      final Map<Territory, Integer> floor = ProDefenseFloor.compute(proData, player);
+      if (!floor.isEmpty()) {
+        proData.setDFloor(floor);
+      }
+    }
     final int maxLandMassSize = findMaxLandMassSize(player);
     final Map<Territory, Double> enemyCapitalsAndFactoriesMap =
         findEnemyCapitalsAndFactoriesValue(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProDefenseFloorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProDefenseFloorTest.java
@@ -1,0 +1,193 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.AiTheaterPriority;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Phase 3A defense-floor tests (map-room#2755 PR-C). The SVF biases US offensive force toward the
+ * targeted theater; the floor is the safety net that prevents the same gradient from stripping the
+ * unfavored theater bare. These tests pin both the lookup table (who has a floor under which flag)
+ * and the {@code wouldViolateFloor} accounting (counts player-owned units only, debits
+ * already-assigned).
+ */
+class ProDefenseFloorTest {
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer germans;
+  private ProData proData;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    germans = data.getPlayerList().getPlayerId("Germans");
+    proData = proDataFor(data, americans);
+  }
+
+  @Test
+  void compute_returnsEmpty_forNonUsPlayer() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+
+    final Map<Territory, Integer> floor = ProDefenseFloor.compute(proData, germans);
+
+    assertThat(floor)
+        .as("Spec §2 Phase 1: SVF + floor are US-only; other players must not be affected")
+        .isEmpty();
+  }
+
+  @Test
+  void compute_kgf_populatesPacificHoldings() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+
+    final Map<Territory, Integer> floor = ProDefenseFloor.compute(proData, americans);
+
+    assertThat(floor)
+        .as("KGF must protect the Pacific holdings the Berlin gradient would otherwise strip")
+        .containsKey(data.getMap().getTerritoryOrThrow("Hawaiian Islands"))
+        .containsKey(data.getMap().getTerritoryOrThrow("Western United States"))
+        .containsKey(data.getMap().getTerritoryOrThrow("Queensland"))
+        .containsKey(data.getMap().getTerritoryOrThrow("New South Wales"));
+    assertThat(floor.get(data.getMap().getTerritoryOrThrow("Hawaiian Islands")))
+        .as("Hawaii is the headline case — Japan invades within 2-3 turns if stripped")
+        .isPositive();
+  }
+
+  @Test
+  void compute_kjf_populatesAtlanticHoldings_andDropsPacificFloors() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KJF);
+
+    final Map<Territory, Integer> floor = ProDefenseFloor.compute(proData, americans);
+
+    assertThat(floor)
+        .as("KJF mirrors the floor onto the Atlantic side — the unfavored theater")
+        .containsKey(data.getMap().getTerritoryOrThrow("Eastern United States"))
+        .containsKey(data.getMap().getTerritoryOrThrow("Central United States"));
+    assertThat(floor)
+        .as("KJF must NOT keep KGF's Pacific floors — the unfavored theater flips")
+        .doesNotContainKey(data.getMap().getTerritoryOrThrow("Hawaiian Islands"))
+        .doesNotContainKey(data.getMap().getTerritoryOrThrow("Queensland"));
+  }
+
+  @Test
+  void wouldViolateFloor_returnsFalse_forTerritoryWithoutAFloor() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setDFloor(ProDefenseFloor.compute(proData, americans));
+    final Territory eastUs = data.getMap().getTerritoryOrThrow("Eastern United States");
+    final Unit anyUnit = eastUs.getUnits().iterator().next();
+
+    final boolean violates = ProDefenseFloor.wouldViolateFloor(proData, eastUs, anyUnit, List.of());
+
+    assertThat(violates)
+        .as("Eastern US has no KGF floor — moving units out must be unconstrained")
+        .isFalse();
+  }
+
+  @Test
+  void wouldViolateFloor_returnsTrue_whenPullingBelowFloor() {
+    // Hawaii's KGF floor is 2. The starting 1940 Global garrison is small — pull enough units
+    // via alreadyAssigned to leave only 1, then the next pull must violate.
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setDFloor(ProDefenseFloor.compute(proData, americans));
+    final Territory hawaii = data.getMap().getTerritoryOrThrow("Hawaiian Islands");
+    final int floor = proData.getDFloor().get(hawaii);
+    final List<Unit> usUnitsAtHawaii =
+        hawaii.getUnits().stream().filter(u -> u.getOwner().equals(americans)).toList();
+    // Need at least floor+1 US units to drive the boundary case; if starting garrison is too
+    // small the assertion below is the canary that says "tune the floor or the test data".
+    assertThat(usUnitsAtHawaii.size())
+        .as("Hawaii must start with >floor US units or the floor is unreachable")
+        .isGreaterThan(floor);
+
+    final List<Unit> alreadyAssigned = usUnitsAtHawaii.subList(0, usUnitsAtHawaii.size() - floor);
+    final Unit nextPull = usUnitsAtHawaii.get(usUnitsAtHawaii.size() - floor);
+
+    final boolean violates =
+        ProDefenseFloor.wouldViolateFloor(
+            proData, hawaii, nextPull, new HashSet<>(alreadyAssigned));
+
+    assertThat(violates)
+        .as("Pulling one past the floor must violate — NCM should skip this assignment")
+        .isTrue();
+  }
+
+  @Test
+  void wouldViolateFloor_returnsFalse_whenStillAboveFloor() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setDFloor(ProDefenseFloor.compute(proData, americans));
+    final Territory hawaii = data.getMap().getTerritoryOrThrow("Hawaiian Islands");
+    final List<Unit> usUnitsAtHawaii =
+        hawaii.getUnits().stream().filter(u -> u.getOwner().equals(americans)).toList();
+
+    // Pull only one unit — this must leave more than the floor still home.
+    final Unit firstPull = usUnitsAtHawaii.get(0);
+
+    final boolean violates =
+        ProDefenseFloor.wouldViolateFloor(proData, hawaii, firstPull, List.of());
+
+    assertThat(violates)
+        .as("A single pull from a full garrison must not violate the floor")
+        .isFalse();
+  }
+
+  @Test
+  void wouldViolateFloor_returnsFalse_whenSourceNotOwnedByPlayer() {
+    // Even when a player has units staging on someone else's territory, the floor is a
+    // defense-the-homeland concept — it shouldn't fire on someone else's land. Use a German
+    // capital so ownership clearly differs from the unit owner.
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setDFloor(
+        Map.of(data.getMap().getTerritoryOrThrow("Germany"), 5)); // force a fake floor
+    final Territory berlin = data.getMap().getTerritoryOrThrow("Germany");
+    final Unit anyGermanUnit = berlin.getUnits().iterator().next();
+
+    final boolean violates =
+        ProDefenseFloor.wouldViolateFloor(proData, berlin, anyGermanUnit, List.of());
+
+    assertThat(violates).as("Floor only protects garrisons on the AI player's own land").isFalse();
+  }
+
+  @Test
+  void wouldViolateFloor_returnsFalse_forNullSource() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setDFloor(ProDefenseFloor.compute(proData, americans));
+    final Unit anyUnit =
+        data.getMap().getTerritoryOrThrow("Eastern United States").getUnits().iterator().next();
+
+    final boolean violates = ProDefenseFloor.wouldViolateFloor(proData, null, anyUnit, List.of());
+
+    assertThat(violates)
+        .as("A unit that isn't tracked back to a source (null) cannot violate any floor")
+        .isFalse();
+  }
+
+  // --- helpers ---
+
+  private static ProData proDataFor(final GameData gameData, final GamePlayer player)
+      throws Exception {
+    final ProData p = new ProData();
+    final Field dataField = ProData.class.getDeclaredField("data");
+    dataField.setAccessible(true);
+    dataField.set(p, gameData);
+    final Field playerField = ProData.class.getDeclaredField("player");
+    playerField.setAccessible(true);
+    playerField.set(p, player);
+    return p;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 3A of the Strategic Value Field (SVF) Theater Pull series — the off-theater defense floor that prevents the same KGF/KJF gradient that pulls offensive force into the targeted theater from also stripping the unfavored theater bare.

Companion to map-room#2755. Builds on PR-A (#133, SVF compute) on this integration branch. PR-D (Phase 3B amphib commit + mass gate) follows.

## What this changes

**`ProDefenseFloor`** (new) — Per-theater `Territory → minimum-garrison` map:
- **KGF** floor: Hawaiian Islands (2), Western United States (2), Queensland (1), New South Wales (1) — Pacific holdings that Japan can pick off if US empties them
- **KJF** floor: Eastern United States (2), Central United States (1) — Atlantic side under inverted priority
- **Spec §2 US-only gate** — `compute(proData, player)` returns empty for any non-Americans player; other AI players unaffected
- `wouldViolateFloor(proData, source, unit, alreadyAssigned)` — per-pass check counting player-owned units only, debits units already pulled this NCM pass

**`ProTerritoryValueUtils.findTerritoryValues`** — populates `proData.setDFloor(...)` at the same lazy hook the SVF uses, but **unconditionally** (not gated on `wStrat>0`). A user who sets `AI_THEATER_PRIORITY=KGF` without `AI_SVF_W_STRAT>0` still gets the asymmetric defense protection.

**`ProNonCombatMoveAi.moveUnitsToDefendTerritories`** — two new floor gates:
- min-win allocation loop (`win > 60` first pass)
- max-win non-air allocation loop

Each gate computes `proData.getUnitTerritory(unit)` as the source, calls `ProDefenseFloor.wouldViolateFloor(...)` passing the current `addedUnits` as already-assigned, and `continue`s if violated. The unit stays home, the NCM moves on to the next candidate.

Air units intentionally skipped — KGF/KJF floor maps only contain ground garrisons; an air-unit gate would be a no-op against the configured tables and adds noise.

## Why not gate on `wStrat>0`

Tested live by chase pre-compaction: when `wStrat` was still being tuned, the Berlin gradient was already strong enough to pull Hawaii's fighter+infantry into Atlantic ops. The floor is a separate safety lever — running it whenever a theater flag is set decouples "tune the offensive pull" from "don't get invaded by Japan turn 4."

## Tests

`ProDefenseFloorTest` (new, 7 cases):
- `compute_returnsEmpty_forNonUsPlayer` — spec §2 enforcement
- `compute_kgf_populatesPacificHoldings` / `compute_kjf_populatesAtlanticHoldings_andDropsPacificFloors` — table parity
- `wouldViolateFloor_returnsFalse_forTerritoryWithoutAFloor` — empty-floor short-circuit
- `wouldViolateFloor_returnsTrue_whenPullingBelowFloor` — boundary case with the canonical "pull garrison-floor-1 already, next pull violates"
- `wouldViolateFloor_returnsFalse_whenStillAboveFloor` — single pull from full garrison is fine
- `wouldViolateFloor_returnsFalse_whenSourceNotOwnedByPlayer` — floor only protects homeland
- `wouldViolateFloor_returnsFalse_forNullSource` — defensive null guard

## Test plan

- [x] `:game-app:game-core:spotlessCheck` clean
- [x] `:game-app:game-core:test` — full game-core suite green
- [x] `:game-app:game-core:test --tests "games.strategy.triplea.ai.pro.*"` rerun all ProAi tests
- [ ] 🧑 Manual: AI-vs-AI run with `AI_THEATER_PRIORITY=KGF` + dump JSON dumps — confirm Hawaii/W-US US-owned infantry counts stay ≥ floor across rounds 2-6; compare against PR-A baseline that showed Hawaii being stripped