### PR TITLE
feat(proai): PR-D — Phase 3B amphib commit + mass gate (map-room#2755)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -14,6 +14,7 @@ import games.strategy.triplea.ai.pro.data.ProTerritory;
 import games.strategy.triplea.ai.pro.data.ProTerritoryManager;
 import games.strategy.triplea.ai.pro.data.ProTransport;
 import games.strategy.triplea.ai.pro.logging.ProLogger;
+import games.strategy.triplea.ai.pro.util.ProAmphibCommitGate;
 import games.strategy.triplea.ai.pro.util.ProBattleUtils;
 import games.strategy.triplea.ai.pro.util.ProMatches;
 import games.strategy.triplea.ai.pro.util.ProMoveUtils;
@@ -1726,6 +1727,26 @@ public class ProCombatMoveAi {
         }
       }
       if (minWinTerritory != null) {
+        // Phase 3B amphib commit gate (map-room#2755): value * pWin < tCommit OR pWin < hard
+        // sanity floor → defer. Caller adds the transport to proData.getTransportsToHold()
+        // so NCM keeps it at its sea zone next turn instead of dispersing. Defaults of 0.0
+        // for both thresholds keep this a no-op until Phase 4A tuning raises them; US-only
+        // per spec §2 (other players bypass).
+        final ProBattleResult committingResult = attackMap.get(minWinTerritory).getBattleResult();
+        final double targetValue = attackMap.get(minWinTerritory).getValue();
+        if (!ProAmphibCommitGate.shouldCommit(
+            proData, minWinTerritory, targetValue, committingResult)) {
+          proData.getTransportsToHold().add(transport);
+          ProLogger.trace(
+              "Amphib commit gate deferred: target="
+                  + minWinTerritory
+                  + " value="
+                  + targetValue
+                  + " pWin="
+                  + (committingResult == null ? "?" : committingResult.getWinPercentage())
+                  + " transport held");
+          continue;
+        }
         if (minUnloadFromTerritory != null) {
           attackMap
               .get(minWinTerritory)

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
@@ -78,6 +78,14 @@ public final class ProData {
   @Setter private Map<Territory, Integer> dFloor = Map.of();
 
   /**
+   * Transports the combat-move amphib commit gate deferred this turn. NCM reads this and refuses to
+   * disperse — the transport sits at its current sea zone so it can mass with reinforcements next
+   * turn instead of dribbling its load into a losing assault. Phase 3B populates; cleared per
+   * request (sidecar is stateless per call).
+   */
+  @Setter private Set<Unit> transportsToHold = new HashSet<>();
+
+  /**
    * Lazy-cached strategic value field. Computed on first {@code findTerritoryValues}-style call
    * when {@code wStrat > 0}, then reused for the remainder of the request. Sidecar is stateless per
    * HTTP request, so the cache is scoped to one decision call — see plan §0 nuance.

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -978,6 +978,12 @@ class ProNonCombatMoveAi {
 
       // Loop through all my transports and see which territories they can defend from current list
       final List<Unit> alreadyMovedTransports = new ArrayList<>();
+      // Phase 3B (map-room#2755): the amphib commit gate marked these transports as "hold
+      // position next turn" so they can mass with reinforcements instead of dribbling their load
+      // into a losing assault. Seed the already-moved set with them so both the
+      // naval-defense and amphib-move loops below treat them as off-limits — the transport
+      // stays at its current sea zone. Empty set by default = no behavior change.
+      alreadyMovedTransports.addAll(proData.getTransportsToHold());
       if (!Properties.getTransportCasualtiesRestricted(data.getProperties())) {
         final Map<Unit, Set<Territory>> transportDefendOptions = new HashMap<>();
         for (final Unit unit : transportMoveMap.keySet()) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProAmphibCommitGate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProAmphibCommitGate.java
@@ -1,0 +1,105 @@
+package games.strategy.triplea.ai.pro.util;
+
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.AiTheaterPriority;
+import games.strategy.triplea.ai.pro.data.ProBattleResult;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Amphib commit gate for the SVF (map-room#2755 Phase 3B).
+ *
+ * <p>The strategic value field can make a beachhead look very attractive on paper. Without a commit
+ * gate ProAi will gladly drop two infantry on a 6-defender shoreline and lose the lot — exactly the
+ * "dribble into the meat grinder" failure mode spec §5 risk register predicted for unconstrained
+ * {@code wStrat}.
+ *
+ * <p>Two checks live here:
+ *
+ * <ol>
+ *   <li><b>Value gate:</b> {@code value(t) * pWin >= tCommit}. {@code tCommit} comes from {@link
+ *       ProData#getTCommitTargeted()} for targeted-theater beaches, {@link
+ *       ProData#getTCommitOffTheater()} otherwise. Default thresholds are {@code 0.0} so the gate
+ *       is a no-op at the Phase 1 ship; Phase 4A tuning raises them.
+ *   <li><b>Mass gate:</b> a hard win-percentage floor under which no commit happens regardless of
+ *       value. Holds the transport for next turn instead of dribbling. Default floor is {@code 0.0}
+ *       so this is also no-op at default; tuning can raise it (~0.55-0.70 per spec §"hard sanity
+ *       floor").
+ * </ol>
+ *
+ * <p>Spec §2 Phase 1 scopes SVF behavior to US-only — {@link #shouldCommit} returns true for any
+ * non-Americans player so their amphib commits are unaffected. Defaults are zero-impact, so a user
+ * who hasn't enabled the theater flag also sees no change.
+ *
+ * <p>"Should we commit" is the only judgment exposed; the caller decides what to do on a false
+ * (typically: skip {@code putAmphibAttackMap}, and add the transport to {@link
+ * ProData#getTransportsToHold()} so NCM keeps it at its sea zone).
+ */
+@UtilityClass
+public final class ProAmphibCommitGate {
+
+  /**
+   * Pacific axis is just Japan in the WW2 1940 Global scenario — mirrors {@link
+   * ProStrategicValueField}'s classifier so the gate and the field agree on which beaches are
+   * "in-theater."
+   */
+  private static final String PACIFIC_AXIS_NAME = "Japanese";
+
+  /** Hard mass-gate win-percentage floor — Phase 4A tuning raises above 0. */
+  private static final double MASS_GATE_MIN_WIN_PCT = 0.0;
+
+  /**
+   * Returns {@code true} if the amphib commit at {@code target} should proceed. {@code false} means
+   * the caller should hold the transport. Always {@code true} for non-Americans (spec §2).
+   *
+   * @param target the prospective amphib target territory (its enemy ownership feeds the theater
+   *     classifier)
+   * @param territoryValue the value of {@code target} per the active value map (post-SVF blend if
+   *     {@code wStrat > 0}; raw baseline otherwise)
+   * @param result the pre-commit battle estimate for {@code target}
+   */
+  public static boolean shouldCommit(
+      final ProData proData,
+      final Territory target,
+      final double territoryValue,
+      final ProBattleResult result) {
+    if (proData.getPlayer() == null || !"Americans".equals(proData.getPlayer().getName())) {
+      return true; // spec §2: SVF is US-only in Phase 1
+    }
+    if (result == null) {
+      return true; // no estimate available; fall back to legacy commit
+    }
+    final double pWin = result.getWinPercentage() / 100.0;
+    if (pWin < MASS_GATE_MIN_WIN_PCT) {
+      return false; // hard sanity floor
+    }
+    final double tCommit = pickTCommit(proData, target);
+    if (tCommit <= 0.0) {
+      return true; // zero threshold = gate off
+    }
+    final double commitScore = territoryValue * pWin;
+    return commitScore >= tCommit;
+  }
+
+  /**
+   * Returns the threshold to test against for {@code target}. Targeted-theater targets get {@link
+   * ProData#getTCommitTargeted()} — typically a *lower* bar because the goal is to throw force at
+   * Berlin/Tokyo. Off-theater targets get {@link ProData#getTCommitOffTheater()} — typically a
+   * higher bar so the AI doesn't dabble in non-decisive theaters.
+   */
+  private static double pickTCommit(final ProData proData, final Territory target) {
+    return inTargetedTheater(proData.getAiTheaterPriority(), target)
+        ? proData.getTCommitTargeted()
+        : proData.getTCommitOffTheater();
+  }
+
+  /**
+   * Classifies {@code target} as in/out of the targeted theater by its current owner's name. KGF
+   * targets non-Japanese axis (Germans, Italians, etc.); KJF targets Japanese.
+   */
+  private static boolean inTargetedTheater(final AiTheaterPriority flag, final Territory target) {
+    final boolean ownerIsPacific = PACIFIC_AXIS_NAME.equals(target.getOwner().getName());
+    final boolean targetingPacific = flag == AiTheaterPriority.KJF;
+    return ownerIsPacific == targetingPacific;
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphibCommitGateTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProAmphibCommitGateTest.java
@@ -1,0 +1,169 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.AiTheaterPriority;
+import games.strategy.triplea.ai.pro.data.ProBattleResult;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Phase 3B amphib commit gate tests (map-room#2755 PR-D). Pins the four decisions the gate makes:
+ * (1) non-US bypass per spec §2; (2) value gate fires only when tCommit > 0; (3) value gate
+ * actually defers when score is below threshold; (4) theater classifier picks the right tCommit.
+ */
+class ProAmphibCommitGateTest {
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer germans;
+  private ProData proData;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    germans = data.getPlayerList().getPlayerId("Germans");
+    proData = proDataFor(data, americans);
+  }
+
+  @Test
+  void shouldCommit_returnsTrue_forNonUsPlayer_regardlessOfThresholds() throws Exception {
+    proData = proDataFor(data, germans);
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setTCommitTargeted(1_000_000.0); // wildly high — would block any US commit
+    proData.setTCommitOffTheater(1_000_000.0);
+    final Territory target = data.getMap().getTerritoryOrThrow("Western Germany");
+    final ProBattleResult result = mock(ProBattleResult.class);
+    when(result.getWinPercentage()).thenReturn(90.0);
+
+    final boolean commit = ProAmphibCommitGate.shouldCommit(proData, target, 5.0, result);
+
+    assertThat(commit)
+        .as("Spec §2: SVF gate is US-only; Germans amphib commits must bypass")
+        .isTrue();
+  }
+
+  @Test
+  void shouldCommit_returnsTrue_atDefaultThresholds() {
+    // Defaults are tCommitTargeted=tCommitOffTheater=0.0 → gate off → always commit.
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    final Territory target = data.getMap().getTerritoryOrThrow("Western Germany");
+    final ProBattleResult result = mock(ProBattleResult.class);
+    when(result.getWinPercentage()).thenReturn(75.0);
+
+    final boolean commit = ProAmphibCommitGate.shouldCommit(proData, target, 5.0, result);
+
+    assertThat(commit)
+        .as("Default tCommit=0 must mean a zero-impact gate so PR-D is backward-compatible")
+        .isTrue();
+  }
+
+  @Test
+  void shouldCommit_returnsFalse_whenValueTimesPWinBelowTargetedThreshold() {
+    // Under KGF, Western Germany is an in-theater (non-Japanese) target — uses tCommitTargeted.
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setTCommitTargeted(10.0); // value*pWin must be >= 10
+    final Territory target = data.getMap().getTerritoryOrThrow("Western Germany");
+    final ProBattleResult result = mock(ProBattleResult.class);
+    when(result.getWinPercentage()).thenReturn(50.0); // 0.5
+
+    // value=10, pWin=0.5 → score=5 → below threshold of 10 → defer
+    final boolean commit = ProAmphibCommitGate.shouldCommit(proData, target, 10.0, result);
+
+    assertThat(commit)
+        .as("commit score below targeted-theater threshold must defer the commit")
+        .isFalse();
+  }
+
+  @Test
+  void shouldCommit_returnsTrue_whenValueTimesPWinAboveTargetedThreshold() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setTCommitTargeted(10.0);
+    final Territory target = data.getMap().getTerritoryOrThrow("Western Germany");
+    final ProBattleResult result = mock(ProBattleResult.class);
+    when(result.getWinPercentage()).thenReturn(80.0); // 0.8
+
+    // value=15, pWin=0.8 → score=12 → above threshold of 10 → commit
+    final boolean commit = ProAmphibCommitGate.shouldCommit(proData, target, 15.0, result);
+
+    assertThat(commit)
+        .as("commit score above targeted-theater threshold must let the commit proceed")
+        .isTrue();
+  }
+
+  @Test
+  void shouldCommit_offTheaterTarget_picksOffTheaterThreshold_underKGF() {
+    // Under KGF, a Japanese-owned target is OFF-theater — gate must use tCommitOffTheater.
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setTCommitTargeted(1.0); // small targeted bar
+    proData.setTCommitOffTheater(100.0); // high off-theater bar
+    final Territory japaneseTarget = data.getMap().getTerritoryOrThrow("Japan");
+    final ProBattleResult result = mock(ProBattleResult.class);
+    when(result.getWinPercentage()).thenReturn(80.0); // 0.8
+
+    // value=20, pWin=0.8 → score=16. Below off-theater bar of 100 → defer.
+    final boolean commit = ProAmphibCommitGate.shouldCommit(proData, japaneseTarget, 20.0, result);
+
+    assertThat(commit)
+        .as("KGF off-theater targets (Japanese-owned) must be judged against tCommitOffTheater")
+        .isFalse();
+  }
+
+  @Test
+  void shouldCommit_offTheaterTarget_picksOffTheaterThreshold_underKJF() {
+    // Under KJF, a German-owned target is OFF-theater. Symmetric flip of the previous test.
+    proData.setAiTheaterPriority(AiTheaterPriority.KJF);
+    proData.setTCommitTargeted(1.0);
+    proData.setTCommitOffTheater(100.0);
+    final Territory germanTarget = data.getMap().getTerritoryOrThrow("Western Germany");
+    final ProBattleResult result = mock(ProBattleResult.class);
+    when(result.getWinPercentage()).thenReturn(80.0);
+
+    final boolean commit = ProAmphibCommitGate.shouldCommit(proData, germanTarget, 20.0, result);
+
+    assertThat(commit)
+        .as("KJF off-theater targets (German-owned) must be judged against tCommitOffTheater")
+        .isFalse();
+  }
+
+  @Test
+  void shouldCommit_returnsTrue_whenResultIsNull_fallsBackToLegacyBehavior() {
+    // A missing battle result means the caller couldn't estimate; the legacy commit path is
+    // permissive in that case — don't introduce a new gate failure mode.
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setTCommitTargeted(50.0);
+    final Territory target = data.getMap().getTerritoryOrThrow("Western Germany");
+
+    final boolean commit = ProAmphibCommitGate.shouldCommit(proData, target, 100.0, null);
+
+    assertThat(commit)
+        .as("Null battle result must not synthesize a defer — fall through to legacy commit")
+        .isTrue();
+  }
+
+  // --- helpers ---
+
+  private static ProData proDataFor(final GameData gameData, final GamePlayer player)
+      throws Exception {
+    final ProData p = new ProData();
+    final Field dataField = ProData.class.getDeclaredField("data");
+    dataField.setAccessible(true);
+    dataField.set(p, gameData);
+    final Field playerField = ProData.class.getDeclaredField("player");
+    playerField.setAccessible(true);
+    playerField.set(p, player);
+    return p;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 3B of the SVF Theater Pull series — the amphib commit + mass gate that prevents the value field from making ProAi drop a 2-infantry "assault" on a 6-defender beach and lose the lot.

Companion to map-room#2755. Builds on PR-A (#133) on this integration branch; complementary to PR-C (#135). PR-D completes Phase 3.

## What this changes

**`ProAmphibCommitGate`** (new) — `shouldCommit(proData, target, territoryValue, result)` returns false when the commit should be deferred. Two checks:
- **Value gate**: `territoryValue * pWin >= tCommit`. In-theater target picks `tCommitTargeted` (low bar — we *want* force in Berlin); off-theater picks `tCommitOffTheater` (high bar — don't dabble).
- **Mass gate**: hard `pWin` floor under which no commit happens. Default `0.0` = no-op; Phase 4A tuning can raise to `~0.55-0.70` per spec §"hard sanity floor".

Both default to **0.0** so PR-D is backward-compatible.

**`ProData`** — new `transportsToHold: Set<Unit>` field (Lombok `@Getter`/`@Setter`).

**`ProCombatMoveAi.tryToAttackTerritories`** — wires the gate inside the `if (minWinTerritory != null)` block right before `putAmphibAttackMap`. A failed check:
- Records the transport via `proData.getTransportsToHold().add(transport)`
- `continue`s to the next transport (skips the commit + the unload assignment)
- Logs the deferred decision via `ProLogger.trace`

**`ProNonCombatMoveAi.moveUnitsToDefendTerritories`** — at the top of the transport-redistribution block, seeds `alreadyMovedTransports` with `proData.getTransportsToHold()`. Held transports are then transparently skipped by both the naval-defense and amphib-move loops — they stay at their current sea zone instead of being dispersed.

## Why both gates default to 0.0

PR-D ships dormant. The gate values come from Phase 4A tuning — until that harness lands and produces calibrated knobs, every commit decision proceeds exactly as it did pre-PR-D. The plumbing is in place so Phase 4A is purely a knob-flip on integration.

## Tests

`ProAmphibCommitGateTest` (new, 7 cases):
- `shouldCommit_returnsTrue_forNonUsPlayer_regardlessOfThresholds` — spec §2 enforcement
- `shouldCommit_returnsTrue_atDefaultThresholds` — backward compat
- `shouldCommit_returnsFalse_whenValueTimesPWinBelowTargetedThreshold` — value gate fires
- `shouldCommit_returnsTrue_whenValueTimesPWinAboveTargetedThreshold` — value gate passes
- `shouldCommit_offTheaterTarget_picksOffTheaterThreshold_underKGF` — Japanese-owned target under KGF uses tCommitOffTheater
- `shouldCommit_offTheaterTarget_picksOffTheaterThreshold_underKJF` — German-owned target under KJF uses tCommitOffTheater (symmetric)
- `shouldCommit_returnsTrue_whenResultIsNull_fallsBackToLegacyBehavior` — defensive null guard

## Test plan

- [x] `:game-app:game-core:spotlessCheck` clean
- [x] `:game-app:game-core:test` — full game-core suite green
- [x] `:game-app:game-core:test --tests "games.strategy.triplea.ai.pro.util.ProAmphibCommitGateTest"` — new tests green
- [ ] 🧑 Manual: AI-vs-AI under KGF with elevated tCommitTargeted (e.g. 8.0 via `AI_SVF_T_COMMIT_TARGETED` once the wire knob lands in Phase 4A); confirm US either lands a massed force in Europe or holds at SZ — no dribble commits