### PR TITLE
fix(proai): declare war on all coalition mates after primary war roll

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
@@ -95,6 +95,27 @@ class ProPoliticsAi {
     final List<PoliticalActionAttachment> results = new ArrayList<>();
     if (!enemyMap.isEmpty()) {
 
+      // Pre-roll: auto-declare on coalition mates of players we are already at war with.
+      // When a war globalizes on another player's turn (e.g. Japan attacks the US), the
+      // "declare war on Japan" action is no longer in enemyMap and the bystander's
+      // attackPercentage for distant axis coalition members hovers near zero, so without
+      // this pass the coalition would stay at peace indefinitely (map-room/map-room#2761).
+      final List<GamePlayer> existingEnemies = new ArrayList<>();
+      for (final GamePlayer other : data.getPlayerList().getPlayers()) {
+        if (!other.equals(player) && data.getRelationshipTracker().isAtWar(player, other)) {
+          existingEnemies.add(other);
+        }
+      }
+      if (!existingEnemies.isEmpty()) {
+        final List<PoliticalActionAttachment> preRollFollowUps =
+            findCoalitionFollowUps(existingEnemies, enemyMap, data.getRelationshipTracker());
+        for (final PoliticalActionAttachment action : preRollFollowUps) {
+          results.add(action);
+          ProLogger.debug(
+              "---Pre-roll coalition follow-up: declared war on " + enemyMap.get(action));
+        }
+      }
+
       // Find all attack options
       territoryManager.populatePotentialAttackOptions();
       final List<ProTerritory> attackOptions =
@@ -106,9 +127,12 @@ class ProPoliticsAi {
               + ", options="
               + attackOptions);
 
-      // Find attack options per war action
+      // Find attack options per war action — skip actions already claimed by pre-roll.
       final Map<PoliticalActionAttachment, Double> attackPercentageMap = new LinkedHashMap<>();
       for (final PoliticalActionAttachment action : enemyMap.keySet()) {
+        if (results.contains(action)) {
+          continue;
+        }
         int count = 0;
         final List<GamePlayer> enemyPlayers = enemyMap.get(action);
         for (final ProTerritory patd : attackOptions) {
@@ -139,16 +163,16 @@ class ProPoliticsAi {
         if (random <= warChance) {
           results.add(action);
           ProLogger.debug("---Declared war on " + enemyMap.get(action));
-          // Coalition follow-up: once a war is rolled, also declare on any other enemy
-          // actions whose targets are allied with the primary target. attackPercentage is
-          // per-player and the single-roll break above means coalition-mates would otherwise
-          // never get declared on after the war globalizes (map-room/map-room#2761).
+          // Post-roll coalition follow-up: also declare on the primary target's coalition
+          // (in case any aren't already in results from the pre-roll pass).
           final List<PoliticalActionAttachment> followUps =
-              findCoalitionFollowUps(action, enemyMap, data.getRelationshipTracker());
+              findCoalitionFollowUps(enemyMap.get(action), enemyMap, data.getRelationshipTracker());
           for (final PoliticalActionAttachment followUp : followUps) {
-            results.add(followUp);
-            ProLogger.debug(
-                "---Coalition follow-up: also declared war on " + enemyMap.get(followUp));
+            if (!results.contains(followUp)) {
+              results.add(followUp);
+              ProLogger.debug(
+                  "---Coalition follow-up: also declared war on " + enemyMap.get(followUp));
+            }
           }
           break;
         }
@@ -213,24 +237,20 @@ class ProPoliticsAi {
   }
 
   /**
-   * Returns enemy war actions (from {@code enemyMap}, excluding {@code primaryAction}) whose
-   * targets are allied with at least one target of {@code primaryAction} per the in-game {@link
-   * RelationshipTracker}. Used to follow up a successful war declaration with declarations on the
-   * primary target's coalition.
+   * Returns enemy war actions (from {@code enemyMap}) whose targets are allied per the in-game
+   * {@link RelationshipTracker} with at least one player in {@code anchorPlayers}. Pure lookup —
+   * the caller is responsible for skipping the anchor's own actions and deduplicating against any
+   * already-claimed results. Used both pre-roll (anchor = current enemies) and post-roll (anchor =
+   * primary target's players) to propagate war declarations across coalitions.
    */
   static List<PoliticalActionAttachment> findCoalitionFollowUps(
-      final PoliticalActionAttachment primaryAction,
+      final List<GamePlayer> anchorPlayers,
       final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap,
       final RelationshipTracker relationshipTracker) {
-    final List<GamePlayer> primaryTargets = enemyMap.get(primaryAction);
     final List<PoliticalActionAttachment> followUps = new ArrayList<>();
     for (final Map.Entry<PoliticalActionAttachment, List<GamePlayer>> entry : enemyMap.entrySet()) {
-      final PoliticalActionAttachment otherAction = entry.getKey();
-      if (otherAction.equals(primaryAction)) {
-        continue;
-      }
-      if (sharesAlliance(primaryTargets, entry.getValue(), relationshipTracker)) {
-        followUps.add(otherAction);
+      if (sharesAlliance(anchorPlayers, entry.getValue(), relationshipTracker)) {
+        followUps.add(entry.getKey());
       }
     }
     return followUps;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.ai.pro;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.RelationshipTracker;
 import games.strategy.engine.data.RelationshipType;
 import games.strategy.triplea.ai.AiPoliticalUtils;
 import games.strategy.triplea.ai.pro.data.ProTerritory;
@@ -138,6 +139,17 @@ class ProPoliticsAi {
         if (random <= warChance) {
           results.add(action);
           ProLogger.debug("---Declared war on " + enemyMap.get(action));
+          // Coalition follow-up: once a war is rolled, also declare on any other enemy
+          // actions whose targets are allied with the primary target. attackPercentage is
+          // per-player and the single-roll break above means coalition-mates would otherwise
+          // never get declared on after the war globalizes (map-room/map-room#2761).
+          final List<PoliticalActionAttachment> followUps =
+              findCoalitionFollowUps(action, enemyMap, data.getRelationshipTracker());
+          for (final PoliticalActionAttachment followUp : followUps) {
+            results.add(followUp);
+            ProLogger.debug(
+                "---Coalition follow-up: also declared war on " + enemyMap.get(followUp));
+          }
           break;
         }
       }
@@ -198,5 +210,43 @@ class ProPoliticsAi {
       ProLogger.debug("Performing action: " + action);
       politicsDelegate.attemptAction(action);
     }
+  }
+
+  /**
+   * Returns enemy war actions (from {@code enemyMap}, excluding {@code primaryAction}) whose
+   * targets are allied with at least one target of {@code primaryAction} per the in-game {@link
+   * RelationshipTracker}. Used to follow up a successful war declaration with declarations on the
+   * primary target's coalition.
+   */
+  static List<PoliticalActionAttachment> findCoalitionFollowUps(
+      final PoliticalActionAttachment primaryAction,
+      final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap,
+      final RelationshipTracker relationshipTracker) {
+    final List<GamePlayer> primaryTargets = enemyMap.get(primaryAction);
+    final List<PoliticalActionAttachment> followUps = new ArrayList<>();
+    for (final Map.Entry<PoliticalActionAttachment, List<GamePlayer>> entry : enemyMap.entrySet()) {
+      final PoliticalActionAttachment otherAction = entry.getKey();
+      if (otherAction.equals(primaryAction)) {
+        continue;
+      }
+      if (sharesAlliance(primaryTargets, entry.getValue(), relationshipTracker)) {
+        followUps.add(otherAction);
+      }
+    }
+    return followUps;
+  }
+
+  private static boolean sharesAlliance(
+      final List<GamePlayer> a,
+      final List<GamePlayer> b,
+      final RelationshipTracker relationshipTracker) {
+    for (final GamePlayer p1 : a) {
+      for (final GamePlayer p2 : b) {
+        if (relationshipTracker.isAllied(p1, p2)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPoliticsAiCoalitionWarTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPoliticsAiCoalitionWarTest.java
@@ -5,9 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.RelationshipTracker;
+import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.attachments.PoliticalActionAttachment;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.xml.TestMapGameData;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,17 +18,28 @@ import org.junit.jupiter.api.Test;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
 
 /**
- * Regression for map-room/map-room#2761: ProPoliticsAi declared war on only one coalition member
- * per turn, leaving the rest at peace even after the war globalized.
+ * Regression for map-room/map-room#2761: {@link ProPoliticsAi} declared war on only one coalition
+ * member per turn, leaving the rest at peace even after the war globalized — including the case
+ * (chase's review on triplea#137) where the war started on another player's turn and the
+ * primary-target action is no longer in {@code enemyMap}.
  *
- * <p>The fix is in {@link ProPoliticsAi#findCoalitionFollowUps}: after a successful war
- * declaration, the helper enumerates other enemy war actions whose targets share an in-game
- * alliance with the primary target, so the caller declares on them too without rerolling.
+ * <p>The fix is the static helper {@link ProPoliticsAi#findCoalitionFollowUps}: given a list of
+ * anchor players, it returns enemy actions whose targets share an in-game alliance with any anchor.
+ * The caller uses it twice per politics phase:
+ *
+ * <ul>
+ *   <li><b>Pre-roll</b> with anchors = the current player's existing enemies, so coalition partners
+ *       of a war that globalized on someone else's turn get declared on without waiting for a
+ *       successful per-player roll.
+ *   <li><b>Post-roll</b> with anchors = the rolled action's target players, propagating the
+ *       declaration across that target's coalition.
+ * </ul>
  */
 class ProPoliticsAiCoalitionWarTest {
 
   private GameData data;
   private RelationshipTracker relationshipTracker;
+  private GamePlayer americans;
   private GamePlayer japanese;
   private GamePlayer germans;
   private GamePlayer italians;
@@ -37,14 +50,16 @@ class ProPoliticsAiCoalitionWarTest {
     ClientSetting.setPreferences(new MemoryPreferences());
     data = TestMapGameData.GLOBAL1940.getGameData();
     relationshipTracker = data.getRelationshipTracker();
+    americans = data.getPlayerList().getPlayerId("Americans");
     japanese = data.getPlayerList().getPlayerId("Japanese");
     germans = data.getPlayerList().getPlayerId("Germans");
     italians = data.getPlayerList().getPlayerId("Italians");
     russians = data.getPlayerList().getPlayerId("Russians");
 
     // Sanity: the global-1940 starting state has axis players allied with each other and
-    // non-allied with at least one non-axis power. Hard-assert so a future map change
+    // non-allied with the relevant allied power(s). Hard-assert so a future map change
     // surfaces here rather than as misleading helper-output failures.
+    assertThat(americans).as("Americans player resolved").isNotNull();
     assertThat(japanese).as("Japanese player resolved").isNotNull();
     assertThat(germans).as("Germans player resolved").isNotNull();
     assertThat(italians).as("Italians player resolved").isNotNull();
@@ -61,18 +76,18 @@ class ProPoliticsAiCoalitionWarTest {
   }
 
   @Test
-  void primaryActionAgainstJapaneseAddsGermanAndItalianFollowUps() {
-    final PoliticalActionAttachment actionJapanese = namedAction("war-on-japanese");
+  void anchorAgainstJapaneseFindsGermanAndItalianFollowUps() {
+    // Post-roll-style call: anchor = [japanese] (the rolled target). enemyMap contains the
+    // remaining axis actions. Helper returns Germans + Italians (both allied with Japanese).
     final PoliticalActionAttachment actionGermans = namedAction("war-on-germans");
     final PoliticalActionAttachment actionItalians = namedAction("war-on-italians");
 
     final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap = new LinkedHashMap<>();
-    enemyMap.put(actionJapanese, List.of(japanese));
     enemyMap.put(actionGermans, List.of(germans));
     enemyMap.put(actionItalians, List.of(italians));
 
     final List<PoliticalActionAttachment> followUps =
-        ProPoliticsAi.findCoalitionFollowUps(actionJapanese, enemyMap, relationshipTracker);
+        ProPoliticsAi.findCoalitionFollowUps(List.of(japanese), enemyMap, relationshipTracker);
 
     assertThat(followUps)
         .as("declaring war on Japan should also declare war on Germany and Italy")
@@ -80,49 +95,107 @@ class ProPoliticsAiCoalitionWarTest {
   }
 
   @Test
-  void crossCoalitionTargetsAreNotFollowedUp() {
-    final PoliticalActionAttachment actionJapanese = namedAction("war-on-japanese");
+  void crossCoalitionTargetIsNotFollowedUp() {
     final PoliticalActionAttachment actionRussians = namedAction("war-on-russians");
 
     final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap = new LinkedHashMap<>();
-    enemyMap.put(actionJapanese, List.of(japanese));
     enemyMap.put(actionRussians, List.of(russians));
 
     final List<PoliticalActionAttachment> followUps =
-        ProPoliticsAi.findCoalitionFollowUps(actionJapanese, enemyMap, relationshipTracker);
+        ProPoliticsAi.findCoalitionFollowUps(List.of(japanese), enemyMap, relationshipTracker);
 
     assertThat(followUps).as("Russians are not coalition-mates of Japan — no follow-up").isEmpty();
   }
 
   @Test
-  void singleEnemyEnemyMapProducesNoFollowUps() {
-    final PoliticalActionAttachment actionJapanese = namedAction("war-on-japanese");
-
+  void emptyEnemyMapProducesNoFollowUps() {
     final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap = new LinkedHashMap<>();
-    enemyMap.put(actionJapanese, List.of(japanese));
 
     final List<PoliticalActionAttachment> followUps =
-        ProPoliticsAi.findCoalitionFollowUps(actionJapanese, enemyMap, relationshipTracker);
+        ProPoliticsAi.findCoalitionFollowUps(List.of(japanese), enemyMap, relationshipTracker);
 
     assertThat(followUps).isEmpty();
   }
 
   @Test
-  void actionsWithMultiPlayerTargetsMatchIfAnyTargetIsAllied() {
-    // Action A targets [Japanese, Russians] (mixed coalition — rare but legal in custom maps).
-    // Action B targets [Germans]. Since Japanese is allied with Germans, A and B share a
-    // coalition through the Japanese-Germans link.
-    final PoliticalActionAttachment actionMixed = namedAction("war-on-japanese-and-russians");
+  void emptyAnchorListProducesNoFollowUps() {
+    // Pre-roll edge case: a player with no current enemies has no anchors. The helper must
+    // return empty rather than scooping up unrelated actions.
     final PoliticalActionAttachment actionGermans = namedAction("war-on-germans");
-
     final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap = new LinkedHashMap<>();
-    enemyMap.put(actionMixed, List.of(japanese, russians));
     enemyMap.put(actionGermans, List.of(germans));
 
     final List<PoliticalActionAttachment> followUps =
-        ProPoliticsAi.findCoalitionFollowUps(actionMixed, enemyMap, relationshipTracker);
+        ProPoliticsAi.findCoalitionFollowUps(List.of(), enemyMap, relationshipTracker);
+
+    assertThat(followUps).isEmpty();
+  }
+
+  @Test
+  void multiAnchorAnyMatchTriggersFollowUp() {
+    // Anchor mixes coalitions ([japanese, russians]). Helper should add an action targeting
+    // Germans because the japanese member shares an alliance — even though russians does not.
+    final PoliticalActionAttachment actionGermans = namedAction("war-on-germans");
+
+    final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap = new LinkedHashMap<>();
+    enemyMap.put(actionGermans, List.of(germans));
+
+    final List<PoliticalActionAttachment> followUps =
+        ProPoliticsAi.findCoalitionFollowUps(
+            List.of(japanese, russians), enemyMap, relationshipTracker);
 
     assertThat(followUps).containsExactly(actionGermans);
+  }
+
+  @Test
+  void usAlreadyAtWarWithJapanFindsAxisCoalitionPreRoll() {
+    // chase's scenario (review on triplea#137): Japan declared war on US during Japan's turn,
+    // so by the time the US politics phase runs, "declare war on Japan" is no longer a valid
+    // war action — it's already war. The remaining axis (Germany, Italy) is in enemyMap with
+    // ~0 attackPercentage, so the existing roll loop never picks them up.
+    //
+    // The pre-roll pass derives the US's current enemies (Japan) from the relationship
+    // tracker and uses them as anchors. The helper then surfaces Germany + Italy from
+    // enemyMap as coalition follow-ups.
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            americans,
+            japanese,
+            relationshipTracker.getRelationshipType(americans, japanese),
+            data.getRelationshipTypeList().getRelationshipType("War")));
+    assertThat(relationshipTracker.isAtWar(americans, japanese))
+        .as("Setup: US-Japan must be at war for this scenario")
+        .isTrue();
+
+    final List<GamePlayer> existingEnemies = currentEnemiesOf(americans);
+    assertThat(existingEnemies).as("US's existing enemies after Japan attacks").contains(japanese);
+
+    final PoliticalActionAttachment actionGermans = namedAction("us-war-on-germans");
+    final PoliticalActionAttachment actionItalians = namedAction("us-war-on-italians");
+    final PoliticalActionAttachment actionRussians = namedAction("us-war-on-russians");
+
+    final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap = new LinkedHashMap<>();
+    enemyMap.put(actionGermans, List.of(germans));
+    enemyMap.put(actionItalians, List.of(italians));
+    enemyMap.put(actionRussians, List.of(russians));
+
+    final List<PoliticalActionAttachment> preRoll =
+        ProPoliticsAi.findCoalitionFollowUps(existingEnemies, enemyMap, relationshipTracker);
+
+    assertThat(preRoll)
+        .as(
+            "US at war with Japan → declare on Japan's axis coalition (Germany + Italy), not Russia")
+        .containsExactlyInAnyOrder(actionGermans, actionItalians);
+  }
+
+  private List<GamePlayer> currentEnemiesOf(final GamePlayer player) {
+    final List<GamePlayer> enemies = new ArrayList<>();
+    for (final GamePlayer other : data.getPlayerList().getPlayers()) {
+      if (!other.equals(player) && relationshipTracker.isAtWar(player, other)) {
+        enemies.add(other);
+      }
+    }
+    return enemies;
   }
 
   private PoliticalActionAttachment namedAction(final String name) {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPoliticsAiCoalitionWarTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPoliticsAiCoalitionWarTest.java
@@ -1,0 +1,134 @@
+package games.strategy.triplea.ai.pro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.RelationshipTracker;
+import games.strategy.triplea.attachments.PoliticalActionAttachment;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Regression for map-room/map-room#2761: ProPoliticsAi declared war on only one coalition member
+ * per turn, leaving the rest at peace even after the war globalized.
+ *
+ * <p>The fix is in {@link ProPoliticsAi#findCoalitionFollowUps}: after a successful war
+ * declaration, the helper enumerates other enemy war actions whose targets share an in-game
+ * alliance with the primary target, so the caller declares on them too without rerolling.
+ */
+class ProPoliticsAiCoalitionWarTest {
+
+  private GameData data;
+  private RelationshipTracker relationshipTracker;
+  private GamePlayer japanese;
+  private GamePlayer germans;
+  private GamePlayer italians;
+  private GamePlayer russians;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    relationshipTracker = data.getRelationshipTracker();
+    japanese = data.getPlayerList().getPlayerId("Japanese");
+    germans = data.getPlayerList().getPlayerId("Germans");
+    italians = data.getPlayerList().getPlayerId("Italians");
+    russians = data.getPlayerList().getPlayerId("Russians");
+
+    // Sanity: the global-1940 starting state has axis players allied with each other and
+    // non-allied with at least one non-axis power. Hard-assert so a future map change
+    // surfaces here rather than as misleading helper-output failures.
+    assertThat(japanese).as("Japanese player resolved").isNotNull();
+    assertThat(germans).as("Germans player resolved").isNotNull();
+    assertThat(italians).as("Italians player resolved").isNotNull();
+    assertThat(russians).as("Russians player resolved").isNotNull();
+    assertThat(relationshipTracker.isAllied(japanese, germans))
+        .as("Japanese-Germans starting alliance")
+        .isTrue();
+    assertThat(relationshipTracker.isAllied(japanese, italians))
+        .as("Japanese-Italians starting alliance")
+        .isTrue();
+    assertThat(relationshipTracker.isAllied(japanese, russians))
+        .as("Japanese-Russians starting alliance is false")
+        .isFalse();
+  }
+
+  @Test
+  void primaryActionAgainstJapaneseAddsGermanAndItalianFollowUps() {
+    final PoliticalActionAttachment actionJapanese = namedAction("war-on-japanese");
+    final PoliticalActionAttachment actionGermans = namedAction("war-on-germans");
+    final PoliticalActionAttachment actionItalians = namedAction("war-on-italians");
+
+    final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap = new LinkedHashMap<>();
+    enemyMap.put(actionJapanese, List.of(japanese));
+    enemyMap.put(actionGermans, List.of(germans));
+    enemyMap.put(actionItalians, List.of(italians));
+
+    final List<PoliticalActionAttachment> followUps =
+        ProPoliticsAi.findCoalitionFollowUps(actionJapanese, enemyMap, relationshipTracker);
+
+    assertThat(followUps)
+        .as("declaring war on Japan should also declare war on Germany and Italy")
+        .containsExactlyInAnyOrder(actionGermans, actionItalians);
+  }
+
+  @Test
+  void crossCoalitionTargetsAreNotFollowedUp() {
+    final PoliticalActionAttachment actionJapanese = namedAction("war-on-japanese");
+    final PoliticalActionAttachment actionRussians = namedAction("war-on-russians");
+
+    final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap = new LinkedHashMap<>();
+    enemyMap.put(actionJapanese, List.of(japanese));
+    enemyMap.put(actionRussians, List.of(russians));
+
+    final List<PoliticalActionAttachment> followUps =
+        ProPoliticsAi.findCoalitionFollowUps(actionJapanese, enemyMap, relationshipTracker);
+
+    assertThat(followUps).as("Russians are not coalition-mates of Japan — no follow-up").isEmpty();
+  }
+
+  @Test
+  void singleEnemyEnemyMapProducesNoFollowUps() {
+    final PoliticalActionAttachment actionJapanese = namedAction("war-on-japanese");
+
+    final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap = new LinkedHashMap<>();
+    enemyMap.put(actionJapanese, List.of(japanese));
+
+    final List<PoliticalActionAttachment> followUps =
+        ProPoliticsAi.findCoalitionFollowUps(actionJapanese, enemyMap, relationshipTracker);
+
+    assertThat(followUps).isEmpty();
+  }
+
+  @Test
+  void actionsWithMultiPlayerTargetsMatchIfAnyTargetIsAllied() {
+    // Action A targets [Japanese, Russians] (mixed coalition — rare but legal in custom maps).
+    // Action B targets [Germans]. Since Japanese is allied with Germans, A and B share a
+    // coalition through the Japanese-Germans link.
+    final PoliticalActionAttachment actionMixed = namedAction("war-on-japanese-and-russians");
+    final PoliticalActionAttachment actionGermans = namedAction("war-on-germans");
+
+    final Map<PoliticalActionAttachment, List<GamePlayer>> enemyMap = new LinkedHashMap<>();
+    enemyMap.put(actionMixed, List.of(japanese, russians));
+    enemyMap.put(actionGermans, List.of(germans));
+
+    final List<PoliticalActionAttachment> followUps =
+        ProPoliticsAi.findCoalitionFollowUps(actionMixed, enemyMap, relationshipTracker);
+
+    assertThat(followUps).containsExactly(actionGermans);
+  }
+
+  private PoliticalActionAttachment namedAction(final String name) {
+    // Real instance with distinct name — DefaultAttachment.equals/hashCode are final and
+    // compare name/attachedTo fields, so Mockito mocks (all-null fields) collapse into one
+    // map key. Attach to japanese as a stand-in; the helper only uses these as map keys.
+    return new PoliticalActionAttachment(name, japanese, data);
+  }
+}


### PR DESCRIPTION
Closes map-room/map-room#2761

## Summary

- `ProPoliticsAi` rolls a war declaration once per turn and `break`s, so when a war globalizes (Japan attacks US) the AI declares war on only the player it rolled against. Coalition mates stay at peace because `attackPercentage` is per-player and stays near zero for non-adjacent enemies (Germany/Italy from US).
- After a successful primary roll, enumerate any other enemy war actions whose targets are allied (per `RelationshipTracker.isAllied`, the in-game alliance source used elsewhere in ProAi — `AllianceTracker`'s own javadoc says it is *not* for in-game alliance checks) with the primary target, and append them to `results` without rerolling.
- Logic lives in a new static helper `ProPoliticsAi.findCoalitionFollowUps`, which is unit-tested against a real Global-1940 `RelationshipTracker`.

## Test plan

- [x] `./gradlew :game-app:game-core:test --tests 'games.strategy.triplea.ai.pro.*'` — full ProAi module green
- [x] `./gradlew :game-app:game-core:spotlessCheck` — formatting clean
- [x] New `ProPoliticsAiCoalitionWarTest` covers:
  - Japanese-primary → adds Germans + Italians follow-ups
  - Cross-coalition target (Russians) → no follow-up
  - Single-entry enemyMap → empty follow-ups
  - Mixed-coalition primary targets ([Japanese, Russians] vs [Germans]) → follow-up via the allied member
- [ ] 🧑 Manual: AI-vs-AI run, verify Japan-attacks-US → US declares war on all axis in the same politics phase

## Notes

- Implementation note buried in test: `PoliticalActionAttachment` inherits `DefaultAttachment`'s `final` equals/hashCode, which compares name/attachedTo fields. Mockito mocks of `PoliticalActionAttachment` all have null fields and therefore collapse into a single map key — the test uses real instances attached to the Japanese player as a placeholder.
- `map-room/map-room#2761` lives in the Map Room repo, so the `Closes` link won't auto-close on merge here. The Map Room side should be closed manually after this lands.