### PR TITLE
feat(proai): PR-E — Phase 3C off-theater scope filter + threat ring (map-room#2755)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/ProSvfKnobs.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/exec/ProSvfKnobs.java
@@ -2,6 +2,7 @@ package org.triplea.ai.sidecar.exec;
 
 import games.strategy.triplea.ai.pro.ProData;
 import games.strategy.triplea.ai.pro.data.AiTheaterPriority;
+import games.strategy.triplea.ai.pro.data.AiTheaterScopeMode;
 import javax.annotation.Nullable;
 import org.triplea.ai.sidecar.wire.WireState;
 
@@ -61,6 +62,25 @@ public final class ProSvfKnobs {
     applyDouble("AI_SVF_W_STRAT", "ai.svf.w.strat", proData::setWStrat);
     applyDouble("AI_SVF_ALPHA_OFF", "ai.svf.alpha.off", proData::setAlphaOff);
     applyDouble("AI_SVF_BETA_LAUNCH", "ai.svf.beta.launch", proData::setBetaLaunch);
+    applyScopeMode(proData);
+  }
+
+  /**
+   * Phase 3C (PR-E) knob — off-theater scope filter mode. Recognized values (case-insensitive):
+   * {@code off}, {@code strict}, {@code adaptive}. Default {@link AiTheaterScopeMode#OFF} preserves
+   * backward-compatible behavior. See {@code ProTheaterScopeFilter} for the policy each mode
+   * encodes.
+   */
+  private static void applyScopeMode(final ProData proData) {
+    final String raw = read("AI_THEATER_SCOPE_MODE", "ai.theater.scope.mode");
+    if (raw == null) {
+      return;
+    }
+    try {
+      proData.setAiTheaterScopeMode(AiTheaterScopeMode.valueOf(raw.trim().toUpperCase()));
+    } catch (final IllegalArgumentException e) {
+      // Silently keep the default — same convention as the numeric knobs.
+    }
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -22,6 +22,7 @@ import games.strategy.triplea.ai.pro.util.ProOddsCalculator;
 import games.strategy.triplea.ai.pro.util.ProPurchaseUtils;
 import games.strategy.triplea.ai.pro.util.ProSortMoveOptionsUtils;
 import games.strategy.triplea.ai.pro.util.ProTerritoryValueUtils;
+import games.strategy.triplea.ai.pro.util.ProTheaterScopeFilter;
 import games.strategy.triplea.ai.pro.util.ProTransportUtils;
 import games.strategy.triplea.ai.pro.util.ProUtils;
 import games.strategy.triplea.attachments.TerritoryAttachment;
@@ -85,6 +86,18 @@ public class ProCombatMoveAi {
     // Remove territories that aren't worth attacking and prioritize the remaining ones
     final List<ProTerritory> attackOptions =
         territoryManager.removeTerritoriesThatCantBeConquered();
+    // Phase 3C / PR-E (map-room#2755): under KGF/KJF scope mode, drop off-theater attack
+    // candidates so the value-blend has only theater-relevant targets to re-rank. The blend
+    // alone can't pull US toward Berlin — Berlin isn't reachable from Pacific staging — but
+    // by removing Pacific targets, the Pacific-commit feedback loop is broken: US sits
+    // defensively (Phase 3A floor protects garrisons) while purchase+NCM build up Atlantic
+    // staging across turns. ADAPTIVE mode keeps Pacific scope open for tripped tripwires so
+    // a Japan landing on Hawaii or Marshall Islands still gets counter-attacked. STRICT
+    // mode blocks all Pacific offense regardless. OFF (default) is backward compatible.
+    if (ProTheaterScopeFilter.isFilterActive(proData)) {
+      attackOptions.removeIf(
+          patd -> ProTheaterScopeFilter.shouldSkipAttackTarget(proData, patd.getTerritory()));
+    }
     List<Territory> clearedTerritories = new ArrayList<>();
     for (final ProTerritory patd : attackOptions) {
       clearedTerritories.add(patd.getTerritory());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
@@ -8,6 +8,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.ai.pro.data.AiTheaterPriority;
+import games.strategy.triplea.ai.pro.data.AiTheaterScopeMode;
 import games.strategy.triplea.ai.pro.data.ProPurchaseOption;
 import games.strategy.triplea.ai.pro.data.ProPurchaseOptionMap;
 import games.strategy.triplea.ai.pro.data.ProTerritory;
@@ -84,6 +85,13 @@ public final class ProData {
    * request (sidecar is stateless per call).
    */
   @Setter private Set<Unit> transportsToHold = new HashSet<>();
+
+  /**
+   * Off-theater scope filter mode. Phase 3C / PR-E. Default {@link AiTheaterScopeMode#OFF} keeps
+   * PR-E zero-impact until the user opts in via the wire / env knob. See {@code
+   * ProTheaterScopeFilter} for the policy each mode encodes.
+   */
+  @Setter private AiTheaterScopeMode aiTheaterScopeMode = AiTheaterScopeMode.OFF;
 
   /**
    * Lazy-cached strategic value field. Computed on first {@code findTerritoryValues}-style call

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -30,6 +30,7 @@ import games.strategy.triplea.ai.pro.util.ProOddsCalculator;
 import games.strategy.triplea.ai.pro.util.ProPurchaseUtils;
 import games.strategy.triplea.ai.pro.util.ProSortMoveOptionsUtils;
 import games.strategy.triplea.ai.pro.util.ProTerritoryValueUtils;
+import games.strategy.triplea.ai.pro.util.ProTheaterScopeFilter;
 import games.strategy.triplea.ai.pro.util.ProTransportUtils;
 import games.strategy.triplea.ai.pro.util.ProUtils;
 import games.strategy.triplea.attachments.TerritoryAttachment;
@@ -697,6 +698,23 @@ class ProNonCombatMoveAi {
     // Sort attack territories by value
     final List<ProTerritory> prioritizedTerritories = new ArrayList<>(moveMap.values());
     prioritizedTerritories.sort(Comparator.comparingDouble(ProTerritory::getValue).reversed());
+
+    // Phase 3C / PR-E (map-room#2755): under KGF/KJF scope mode, drop off-theater destinations
+    // from NCM consideration so the planner doesn't drift force toward the unfavored theater.
+    // Owned/allied territories are preserved (Phase 3A floor still defends them in place); only
+    // off-theater enemy/neutral destinations are filtered. ADAPTIVE mode keeps tripwire-engaged
+    // targets in scope so NCM can still stage a counter to a Japan landing.
+    if (ProTheaterScopeFilter.isFilterActive(proData)) {
+      prioritizedTerritories.removeIf(
+          patd -> {
+            final Territory t = patd.getTerritory();
+            // Never drop our own / allied territories — those are defense-in-place destinations.
+            if (t.isOwnedBy(player) || Matches.isTerritoryAllied(player).test(t)) {
+              return false;
+            }
+            return ProTheaterScopeFilter.shouldSkipAttackTarget(proData, t);
+          });
+    }
 
     // Remove territories that I'm not going to try to defend
     for (final Iterator<ProTerritory> it = prioritizedTerritories.iterator(); it.hasNext(); ) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/AiTheaterScopeMode.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/AiTheaterScopeMode.java
@@ -1,0 +1,33 @@
+package games.strategy.triplea.ai.pro.data;
+
+/**
+ * Off-theater scope filter mode for the KGF/KJF SVF (map-room#2755 Phase 3C / PR-E).
+ *
+ * <p>Controls how aggressively ProAi excludes off-theater targets from CM attack options and NCM
+ * defend options. The default is {@link #OFF} so PR-E is backward-compatible — no behavior change
+ * until the user opts in via {@code AI_THEATER_SCOPE_MODE} or wire field.
+ *
+ * <p>Rationale: the value-map blend can only re-rank candidates already in scope. Combat-move scope
+ * is reachability-first, so European candidates never enter scope for a Pacific-staged US — the
+ * blend has nothing to act on. The scope filter is the missing structural lever: it removes
+ * off-theater targets from the candidate set entirely.
+ */
+public enum AiTheaterScopeMode {
+  /** No filtering — backward-compatible default. SVF blend operates on its own. */
+  OFF,
+
+  /**
+   * Off-theater offense always blocked for the AI player. Strictest interpretation of the theater
+   * priority — under KGF the US never attacks Japanese-axis targets, period. Suitable when the user
+   * wants a hard "Germany first" simulation even at the cost of letting Japan eat Pacific islands.
+   */
+  STRICT,
+
+  /**
+   * Off-theater offense blocked UNLESS the threat ring trips — any off-theater axis unit in or
+   * occupying a tripwire territory unlocks engagement reach. Matches historical KGF doctrine: "hold
+   * Pacific minimally, throw everything at Germany — but counter if Japan crosses into the
+   * defensive perimeter." See {@code ProTheaterScopeFilter} for tripwire definitions.
+   */
+  ADAPTIVE
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTheaterScopeFilter.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTheaterScopeFilter.java
@@ -1,0 +1,225 @@
+package games.strategy.triplea.ai.pro.util;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.AiTheaterPriority;
+import games.strategy.triplea.ai.pro.data.AiTheaterScopeMode;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Off-theater scope filter for the KGF/KJF SVF (map-room#2755 Phase 3C / PR-E).
+ *
+ * <p>The value-map blend can only re-rank candidates already in scope. Combat-move scope is
+ * reachability-first: ProAi's attack options come from "what can my units hit this turn?". For a
+ * Pacific-staged US, only Pacific targets are reachable — European candidates never enter the list,
+ * so no {@code wStrat} value re-ranks them in. The scope filter is the missing structural lever: it
+ * removes off-theater targets from the candidate set so the Pacific-commit feedback loop is broken
+ * and the AI has nothing to do offensively in Pacific (defense in place via Phase 3A floor still
+ * applies).
+ *
+ * <p>Three modes, controlled by {@link ProData#getAiTheaterScopeMode()}:
+ *
+ * <ul>
+ *   <li>{@link AiTheaterScopeMode#OFF} — no filtering, backward-compatible default.
+ *   <li>{@link AiTheaterScopeMode#STRICT} — off-theater attacks always blocked. Hardest "Germany
+ *       first" interpretation; US never attacks Japanese axis even if Japan eats Pacific islands.
+ *   <li>{@link AiTheaterScopeMode#ADAPTIVE} — off-theater attacks blocked UNLESS the threat ring
+ *       trips. Any axis unit in (or owner of) a tripwire territory unlocks engagement: US can
+ *       attack the tripped tripwires + their immediate neighbors, but not Japan home / Korea /
+ *       Manchuria. Matches historical KGF doctrine.
+ * </ul>
+ *
+ * <p>Spec §2 US-only scope: filter returns false for any non-Americans player so other AI is not
+ * affected. Defaults to {@code OFF} so PR-E ships zero-impact.
+ */
+@UtilityClass
+public final class ProTheaterScopeFilter {
+
+  /** Same Pacific-axis name as {@code ProStrategicValueField} — keep the two in sync. */
+  private static final String PACIFIC_AXIS_NAME = "Japanese";
+
+  /**
+   * Tripwire territories for {@link AiTheaterPriority#KGF}. If any of these is owned by — or has a
+   * unit of — the Japanese axis, the ring is tripped and US may engage in Pacific (ADAPTIVE only).
+   * Covers the US-Pacific approach corridor + ANZAC defensive ring. Hardcoded by name per spec §2
+   * "Phase 1 KGF/KJF semantics live in tables."
+   */
+  private static final Set<String> KGF_TRIPWIRES =
+      Set.of(
+          "Aleutian Islands",
+          "Midway",
+          "Wake Island",
+          "Marshall Islands",
+          "Marianas",
+          "Gilbert Islands",
+          "Johnston Island",
+          "Hawaiian Islands",
+          "Western United States",
+          "Alaska",
+          "Solomon Islands",
+          "New Britain",
+          "Fiji",
+          "New Hebrides",
+          "Samoa",
+          "Queensland",
+          "New South Wales",
+          "Western Australia",
+          "Northern Territory",
+          "New Zealand");
+
+  /**
+   * Tripwire territories for {@link AiTheaterPriority#KJF}. European axis approach corridor toward
+   * US East Coast. Rarely trips in practice (German surface fleet doesn't reach the US East Coast
+   * in 1940 Global) — included for symmetry.
+   */
+  private static final Set<String> KJF_TRIPWIRES =
+      Set.of(
+          "Iceland",
+          "Greenland",
+          "Newfoundland Labrador",
+          "Eastern United States",
+          "Central United States",
+          "Brazil",
+          "French Guiana");
+
+  /**
+   * Returns {@code true} if the off-theater scope filter should remove {@code target} from CM
+   * attack consideration. Returns {@code false} for non-Americans (spec §2 US-only), when mode is
+   * {@link AiTheaterScopeMode#OFF}, or when {@code target} is in the targeted theater.
+   *
+   * <p>Under {@link AiTheaterScopeMode#STRICT} every off-theater target is filtered. Under {@link
+   * AiTheaterScopeMode#ADAPTIVE} an off-theater target is filtered unless it falls in the {@link
+   * #getEngagementSet engagement set} of the currently tripped ring.
+   */
+  public static boolean shouldSkipAttackTarget(final ProData proData, final Territory target) {
+    if (!isAmericans(proData)) {
+      return false;
+    }
+    final AiTheaterScopeMode mode = proData.getAiTheaterScopeMode();
+    if (mode == AiTheaterScopeMode.OFF) {
+      return false;
+    }
+    if (!isOffTheater(target, proData.getAiTheaterPriority())) {
+      return false;
+    }
+    if (mode == AiTheaterScopeMode.STRICT) {
+      return true;
+    }
+    // ADAPTIVE: allow if target is in the engagement set of a tripped ring.
+    return !getEngagementSet(proData).contains(target);
+  }
+
+  /**
+   * Returns the set of off-theater territories the AI is currently allowed to engage in. Computed
+   * from the tripped tripwires + their immediate neighbors so a Japan landing on Marshall Islands
+   * unlocks US engagement of Marshalls + adjacent sea zones — but does not unlock Japan home /
+   * Korea / Manchuria as side-effect attack scope.
+   *
+   * <p>Empty when mode is not {@link AiTheaterScopeMode#ADAPTIVE} or when no tripwire is currently
+   * occupied by off-theater axis. Computed fresh each call — the sidecar is stateless per HTTP
+   * request and there is no opportunity to cache across requests.
+   */
+  public static Set<Territory> getEngagementSet(final ProData proData) {
+    if (proData.getAiTheaterScopeMode() != AiTheaterScopeMode.ADAPTIVE) {
+      return Set.of();
+    }
+    final Set<Territory> trippedTripwires = getTrippedTripwires(proData);
+    if (trippedTripwires.isEmpty()) {
+      return Set.of();
+    }
+    final Set<Territory> engagement = new HashSet<>(trippedTripwires);
+    final GameData data = proData.getData();
+    for (final Territory t : trippedTripwires) {
+      engagement.addAll(data.getMap().getNeighbors(t));
+    }
+    return engagement;
+  }
+
+  /**
+   * Returns the tripwire territories currently occupied by — or owned by — off-theater axis. A
+   * tripwire is "tripped" when the threat has crossed into the perimeter; the AI may then engage.
+   * Visible for testing and logging.
+   */
+  static Set<Territory> getTrippedTripwires(final ProData proData) {
+    final AiTheaterPriority flag = proData.getAiTheaterPriority();
+    final Set<String> tripwireNames = flag == AiTheaterPriority.KJF ? KJF_TRIPWIRES : KGF_TRIPWIRES;
+    final GameData data = proData.getData();
+    final Set<Territory> tripped = new HashSet<>();
+    for (final String name : tripwireNames) {
+      final Territory t = data.getMap().getTerritoryOrNull(name);
+      if (t == null) {
+        continue;
+      }
+      if (hasOffTheaterAxis(t, flag, data)) {
+        tripped.add(t);
+      }
+    }
+    return tripped;
+  }
+
+  /**
+   * Returns true if territory is owned by — or has any unit belonging to — an off-theater axis
+   * power. Off-theater axis under KGF is the Japanese; under KJF is every axis power EXCEPT
+   * Japanese.
+   */
+  private static boolean hasOffTheaterAxis(
+      final Territory t, final AiTheaterPriority flag, final GameData data) {
+    final boolean ownerIsOffTheater = isOffTheaterPlayer(t.getOwner(), flag);
+    if (ownerIsOffTheater) {
+      return true;
+    }
+    return t.getUnits().stream().anyMatch(u -> isOffTheaterPlayer(u.getOwner(), flag));
+  }
+
+  /**
+   * Classifies a player as off-theater axis for the given priority flag. Under KGF, Japanese is
+   * off-theater. Under KJF, every axis power that is NOT Japanese is off-theater (Germans,
+   * Italians, etc.). True Neutrals and Allies are never off-theater axis.
+   */
+  private static boolean isOffTheaterPlayer(final GamePlayer player, final AiTheaterPriority flag) {
+    if (player == null) {
+      return false;
+    }
+    final boolean playerIsPacific = PACIFIC_AXIS_NAME.equals(player.getName());
+    final boolean targetingPacific = flag == AiTheaterPriority.KJF;
+    // Off-theater axis = the axis we are NOT targeting. Filter to actual axis players via the
+    // simple Pacific/non-Pacific split kept consistent with ProStrategicValueField.
+    if (!isAxisPlayer(player)) {
+      return false;
+    }
+    return playerIsPacific != targetingPacific;
+  }
+
+  /**
+   * Classifies a player as an axis combatant. Hardcoded to the 1940 Global roster — same approach
+   * as {@link ProStrategicValueField}. The set is closed in this scenario; adding scenarios will
+   * need its own theater map.
+   */
+  private static boolean isAxisPlayer(final GamePlayer player) {
+    final String name = player.getName();
+    return "Germans".equals(name) || "Italians".equals(name) || "Japanese".equals(name);
+  }
+
+  /** Classifies {@code target}'s owner as in the off-theater axis (mirror of the field code). */
+  private static boolean isOffTheater(final Territory target, final AiTheaterPriority flag) {
+    return isOffTheaterPlayer(target.getOwner(), flag);
+  }
+
+  private static boolean isAmericans(final ProData proData) {
+    final GamePlayer player = proData.getPlayer();
+    return player != null && "Americans".equals(player.getName());
+  }
+
+  /**
+   * Pluggable smoke-test entrypoint used by callers that want to short-circuit the boilerplate.
+   * Returns {@code true} if SVF is active (mode != OFF) for the AI player. Allows the wire site to
+   * skip the loop entirely when filtering wouldn't apply.
+   */
+  public static boolean isFilterActive(final ProData proData) {
+    return isAmericans(proData) && proData.getAiTheaterScopeMode() != AiTheaterScopeMode.OFF;
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProTheaterScopeFilterTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProTheaterScopeFilterTest.java
@@ -1,0 +1,238 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.AiTheaterPriority;
+import games.strategy.triplea.ai.pro.data.AiTheaterScopeMode;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Phase 3C off-theater scope filter tests (map-room#2755 PR-E). The filter is the missing
+ * structural lever that the value-blend alone can't pull: it removes off-theater attack candidates
+ * from CM scope so the Pacific-commit feedback loop breaks. Tests pin: spec §2 US-only gate, mode
+ * matrix (OFF / STRICT / ADAPTIVE), ring trip detection, engagement set bounds, theater
+ * classification under KGF and KJF.
+ */
+class ProTheaterScopeFilterTest {
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer germans;
+  private GamePlayer japanese;
+  private ProData proData;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    germans = data.getPlayerList().getPlayerId("Germans");
+    japanese = data.getPlayerList().getPlayerId("Japanese");
+    proData = proDataFor(data, americans);
+  }
+
+  @Test
+  void shouldSkipAttackTarget_returnsFalse_whenModeIsOff() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setAiTheaterScopeMode(AiTheaterScopeMode.OFF);
+    final Territory japan = data.getMap().getTerritoryOrThrow("Japan");
+
+    assertThat(ProTheaterScopeFilter.shouldSkipAttackTarget(proData, japan))
+        .as("Default mode OFF must not filter anything — PR-E ships zero-impact")
+        .isFalse();
+  }
+
+  @Test
+  void shouldSkipAttackTarget_returnsFalse_forNonUsPlayer() throws Exception {
+    final ProData germansData = proDataFor(data, germans);
+    germansData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    germansData.setAiTheaterScopeMode(AiTheaterScopeMode.STRICT);
+    final Territory japan = data.getMap().getTerritoryOrThrow("Japan");
+
+    assertThat(ProTheaterScopeFilter.shouldSkipAttackTarget(germansData, japan))
+        .as("Spec §2: SVF filter is US-only; Germans CM unaffected even under STRICT")
+        .isFalse();
+  }
+
+  @Test
+  void shouldSkipAttackTarget_strict_filtersJapaneseTarget_underKGF() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setAiTheaterScopeMode(AiTheaterScopeMode.STRICT);
+    final Territory japan = data.getMap().getTerritoryOrThrow("Japan");
+    final Territory korea = data.getMap().getTerritoryOrThrow("Korea");
+
+    assertThat(ProTheaterScopeFilter.shouldSkipAttackTarget(proData, japan))
+        .as("Japan home is off-theater under KGF — STRICT must filter it")
+        .isTrue();
+    assertThat(ProTheaterScopeFilter.shouldSkipAttackTarget(proData, korea))
+        .as("Korea is Japanese-owned under KGF — STRICT must filter it")
+        .isTrue();
+  }
+
+  @Test
+  void shouldSkipAttackTarget_strict_doesNotFilterInTheaterTarget_underKGF() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setAiTheaterScopeMode(AiTheaterScopeMode.STRICT);
+    final Territory germany = data.getMap().getTerritoryOrThrow("Germany");
+    final Territory italy = data.getMap().getTerritoryOrThrow("Southern Italy");
+
+    assertThat(ProTheaterScopeFilter.shouldSkipAttackTarget(proData, germany))
+        .as("Germany is in-theater under KGF — must not be filtered")
+        .isFalse();
+    assertThat(ProTheaterScopeFilter.shouldSkipAttackTarget(proData, italy))
+        .as("Italy is in-theater under KGF — must not be filtered")
+        .isFalse();
+  }
+
+  @Test
+  void shouldSkipAttackTarget_strict_filtersGermanyTarget_underKJF() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KJF);
+    proData.setAiTheaterScopeMode(AiTheaterScopeMode.STRICT);
+    final Territory germany = data.getMap().getTerritoryOrThrow("Germany");
+    final Territory japan = data.getMap().getTerritoryOrThrow("Japan");
+
+    assertThat(ProTheaterScopeFilter.shouldSkipAttackTarget(proData, germany))
+        .as("Germany is off-theater under KJF — STRICT must filter it")
+        .isTrue();
+    assertThat(ProTheaterScopeFilter.shouldSkipAttackTarget(proData, japan))
+        .as("Japan is in-theater under KJF — must not be filtered")
+        .isFalse();
+  }
+
+  @Test
+  void shouldSkipAttackTarget_adaptive_filtersWhenRingCold() {
+    // At round 1, no Japanese unit has moved out of Japan home — Marshall/Marianas/etc are
+    // Japanese-owned but Hawaii/Western US/Aleutians are American-owned with no Japanese
+    // presence. Several tripwires (Marshall, Marianas) ARE Japanese-owned at game start, so
+    // the ring is actually pre-tripped at round 1. To test the cold path, we use a Japanese
+    // home target that should be filtered regardless because Japan home isn't in the
+    // engagement set (it's not a tripwire neighbor in our table).
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setAiTheaterScopeMode(AiTheaterScopeMode.ADAPTIVE);
+    final Territory japanHome = data.getMap().getTerritoryOrThrow("Japan");
+    final Set<Territory> engagement = ProTheaterScopeFilter.getEngagementSet(proData);
+
+    // Japan home should NOT be in the engagement set even when ring is tripped — tripwires
+    // are Pacific approach territories, and their immediate neighbors don't include Japan.
+    assertThat(engagement)
+        .as("Japan home must not be in the engagement set — ADAPTIVE must protect against scope")
+        .doesNotContain(japanHome);
+    assertThat(ProTheaterScopeFilter.shouldSkipAttackTarget(proData, japanHome))
+        .as("Japan home is off-theater + not in engagement set — ADAPTIVE filters it")
+        .isTrue();
+  }
+
+  @Test
+  void shouldSkipAttackTarget_adaptive_unlocksTrippedTripwire() {
+    // Marshall Islands is Japanese-owned at game start (a tripwire). The ring trips automatically,
+    // and Marshalls itself enters the engagement set. ADAPTIVE must allow the attack.
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setAiTheaterScopeMode(AiTheaterScopeMode.ADAPTIVE);
+    final Territory marshalls = data.getMap().getTerritoryOrThrow("Marshall Islands");
+
+    // Sanity: Marshall Islands is Japanese-owned at round 1
+    assertThat(marshalls.getOwner().getName())
+        .as("Test relies on Marshall Islands being Japanese-owned at game start")
+        .isEqualTo("Japanese");
+
+    final Set<Territory> trippedTripwires = ProTheaterScopeFilter.getTrippedTripwires(proData);
+    assertThat(trippedTripwires)
+        .as("Marshall Islands (Japanese-owned) must register as a tripped tripwire")
+        .contains(marshalls);
+
+    assertThat(ProTheaterScopeFilter.shouldSkipAttackTarget(proData, marshalls))
+        .as("Tripped tripwire is in engagement set — ADAPTIVE allows the attack")
+        .isFalse();
+  }
+
+  @Test
+  void getEngagementSet_isEmptyWhenModeIsStrict() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setAiTheaterScopeMode(AiTheaterScopeMode.STRICT);
+
+    assertThat(ProTheaterScopeFilter.getEngagementSet(proData))
+        .as("STRICT mode means no engagement carve-out — the set is always empty")
+        .isEmpty();
+  }
+
+  @Test
+  void getEngagementSet_isEmptyWhenModeIsOff() {
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setAiTheaterScopeMode(AiTheaterScopeMode.OFF);
+
+    assertThat(ProTheaterScopeFilter.getEngagementSet(proData))
+        .as("OFF mode disables the entire filter, including engagement-set carve-outs")
+        .isEmpty();
+  }
+
+  @Test
+  void shouldSkipAttackTarget_neverFiltersAlliedOrTrueNeutral() {
+    // Allies and True Neutrals are never "off-theater axis" per the classifier — even under
+    // STRICT, an allied or neutral target should never be filtered.
+    proData.setAiTheaterPriority(AiTheaterPriority.KGF);
+    proData.setAiTheaterScopeMode(AiTheaterScopeMode.STRICT);
+    final Territory uk = data.getMap().getTerritoryOrThrow("United Kingdom");
+    final Territory persia = data.getMap().getTerritoryOrThrow("Persia");
+
+    assertThat(ProTheaterScopeFilter.shouldSkipAttackTarget(proData, uk))
+        .as("UK is allied — never filtered as off-theater")
+        .isFalse();
+    assertThat(ProTheaterScopeFilter.shouldSkipAttackTarget(proData, persia))
+        .as("Persia (True Neutral or Pro-Allies) — never filtered as off-theater axis")
+        .isFalse();
+  }
+
+  @Test
+  void isFilterActive_returnsFalseForNonUsAndOffMode() throws Exception {
+    proData.setAiTheaterScopeMode(AiTheaterScopeMode.OFF);
+    assertThat(ProTheaterScopeFilter.isFilterActive(proData))
+        .as("OFF mode means no filter overhead")
+        .isFalse();
+
+    proData.setAiTheaterScopeMode(AiTheaterScopeMode.STRICT);
+    final ProData japaneseData = proDataFor(data, japanese);
+    japaneseData.setAiTheaterScopeMode(AiTheaterScopeMode.STRICT);
+    assertThat(ProTheaterScopeFilter.isFilterActive(japaneseData))
+        .as("Non-US AI never has the filter active even with STRICT mode")
+        .isFalse();
+
+    assertThat(ProTheaterScopeFilter.isFilterActive(proData))
+        .as("US + non-OFF mode = filter active")
+        .isTrue();
+  }
+
+  // --- helpers ---
+
+  /**
+   * Counts player-owned units in a territory; debug helper kept around in case future tests need
+   * it.
+   */
+  @SuppressWarnings("unused")
+  private static long playerUnitsAt(final Collection<Unit> units, final GamePlayer player) {
+    return units.stream().filter(u -> u.getOwner().equals(player)).count();
+  }
+
+  private static ProData proDataFor(final GameData gameData, final GamePlayer player)
+      throws Exception {
+    final ProData p = new ProData();
+    final Field dataField = ProData.class.getDeclaredField("data");
+    dataField.setAccessible(true);
+    dataField.set(p, gameData);
+    final Field playerField = ProData.class.getDeclaredField("player");
+    playerField.setAccessible(true);
+    playerField.set(p, player);
+    return p;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 3C of the SVF Theater Pull — the **structural** off-theater scope filter that was missing from Phase 1-3B. Live-run evidence on the integration branch (with PR-A/B/C/D merged + `wStrat=4.0`, `gamma=0.92`, `alphaOff=0.02`, KGF) showed that the value blend alone can't break the Pacific feedback loop. PR-E is the lever that does.

Companion to map-room#2755. Builds on PR-A (#133), PR-B (#134), PR-C (#135), PR-D (#136) on the integration branch.

## Why this is needed (live-run diagnosis)

I checked all 10 round-3 Americans `findTerritoryValues` calls in `~/workcrew/ai-improve/`. **Every single one filters Europe out:**

| Call | Land territories | Germany in scope? |
|---|---|---|
| 1 (CM attack-options) | 56 | **No** |
| 2-10 | 1-56 | **No (all)** |

S(Germany)=75 in the strategic dumps, but the CM scope doesn't contain Germany — the blend has nothing to act on. Combat-move scope is reachability-first: only Pacific is reachable from Pacific-staged US units, so only Pacific candidates ever enter the ranking.

Spec §10 Finding 1 predicted this ("baseline lean — KGF must overcome the existing gradient") but the live run showed it's worse than a lean: it's a hard scope cutoff. No `wStrat` value adds Europe to a list that doesn't contain it.

## What this changes

**`AiTheaterScopeMode`** (new enum):
- `OFF` — no filtering, backward-compatible default
- `STRICT` — off-theater attacks always blocked. Hardest "Germany first" reading
- `ADAPTIVE` — off-theater attacks blocked UNLESS the threat ring trips (historical KGF doctrine)

**`ProTheaterScopeFilter`** (new util):
- `shouldSkipAttackTarget(proData, target)` — main filter, used at both CM and NCM wire sites
- `getEngagementSet(proData)` — territories the AI may engage when ring is tripped (tripped tripwires + immediate neighbors only; Japan home / Korea / Manchuria stay locked even when ring is hot)
- `getTrippedTripwires(proData)` — visible-for-testing helper
- Tripwire tables: KGF = US-Pacific approach + ANZAC ring; KJF = Atlantic approach (symmetric)
- US-only per spec §2; defaults to OFF mode

**Wire sites:**
- `ProCombatMoveAi.doCombatMove` — filter `attackOptions` before prioritization
- `ProNonCombatMoveAi.prioritizeDefendOptions` — drop off-theater defend destinations (owned + allied preserved; Phase 3A floor still defends them in place)

**`ProSvfKnobs.applyNumericKnobs`** — reads `AI_THEATER_SCOPE_MODE` env / sysprop (`off|strict|adaptive`, case-insensitive). OFF default.

## How to activate (for the user's docker-compose)

Add to `ai-sidecar.environment`:

```yaml
AI_THEATER_SCOPE_MODE: "adaptive"   # or "strict" for the harder block
```

With current run config (`wStrat=4.0`, `gCap=75`, `gamma=0.92`, `alphaOff=0.02`, KGF), expected behavior:
- Round 1-2: US has no Pacific attacks (no tripwires currently tripped beyond the round-1 default Japanese ownership of Marshall/Marianas — which counts as already-tripped, so US can engage those islands). Atlantic still out of scope (unreachable), so US sits.
- Round 2-N: NCM no longer drifts US East-Coast force west toward Pacific defense. Purchase + NCM accumulate Atlantic transports.
- Once Atlantic transports get a viable amphib commit (the Phase 3B amphib gate decides), Europe enters the CM scope and the SVF blend takes over.

## Tests

`ProTheaterScopeFilterTest` (new, 10 cases):
- `shouldSkipAttackTarget_returnsFalse_whenModeIsOff` — backward compat
- `shouldSkipAttackTarget_returnsFalse_forNonUsPlayer` — spec §2 US-only
- `shouldSkipAttackTarget_strict_filtersJapaneseTarget_underKGF`
- `shouldSkipAttackTarget_strict_doesNotFilterInTheaterTarget_underKGF`
- `shouldSkipAttackTarget_strict_filtersGermanyTarget_underKJF`
- `shouldSkipAttackTarget_adaptive_filtersWhenRingCold` — Japan home protected
- `shouldSkipAttackTarget_adaptive_unlocksTrippedTripwire` — Marshalls allowed
- `getEngagementSet_isEmptyWhenModeIsStrict` / `_whenModeIsOff`
- `shouldSkipAttackTarget_neverFiltersAlliedOrTrueNeutral`
- `isFilterActive_returnsFalseForNonUsAndOffMode`

## Test plan

- [x] `:game-app:game-core:spotlessCheck` clean
- [x] `:game-app:game-core:test` — full game-core suite green
- [x] `:game-app:ai-sidecar:test` — sidecar suite green
- [x] `:game-app:game-core:test --tests "*ProTheaterScopeFilterTest"` — new tests green
- [ ] 🧑 Manual: AI-vs-AI run with `AI_THEATER_SCOPE_MODE=adaptive`; confirm US round 3+ combat-move JSON dumps either contain European targets OR show empty offensive scope (no Pacific dribble). 10+ round soak.