### PR TITLE
diag(proai): PR-F — transport reachability dump for SVF debug (map-room#2755)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -1149,6 +1149,17 @@ public class ProTerritoryManager {
       transportMap.values().removeIf(Collection::isEmpty);
     }
 
+    // Phase 3C diagnostic (map-room#2755 PR-F): when AI_TRANSPORT_DIAG=1 (or sysprop
+    // ai.transport.diag=1) is set, dump per-transport reachability so we can debug why
+    // expected amphib targets (e.g. Morocco) aren't entering the attack scope. US-only
+    // by default to match the SVF scope; set AI_TRANSPORT_DIAG_ALL=1 for all players.
+    if (isTransportDiagEnabled()
+        && shouldDiagFor(player)
+        && isCombatMove
+        && !isCheckingEnemyAttacks) {
+      logTransportDiag(proData, player, transportMapList);
+    }
+
     // Add transport units to attack map
     for (final ProTransport proTransportData : transportMapList) {
       final Map<Territory, Set<Territory>> transportMap = proTransportData.getTransportMap();
@@ -1284,5 +1295,67 @@ public class ProTerritoryManager {
           return true;
         });
     return Optional.ofNullable(destination.getValue());
+  }
+
+  // ---------- PR-F transport-reachability diagnostic (map-room#2755) ----------
+
+  private static boolean isTransportDiagEnabled() {
+    final String env = System.getenv("AI_TRANSPORT_DIAG");
+    if (env != null && !env.isEmpty()) {
+      return true;
+    }
+    final String sys = System.getProperty("ai.transport.diag");
+    return sys != null && !sys.isEmpty();
+  }
+
+  private static boolean shouldDiagFor(final GamePlayer player) {
+    if (player == null) {
+      return false;
+    }
+    final String allEnv = System.getenv("AI_TRANSPORT_DIAG_ALL");
+    final String allSys = System.getProperty("ai.transport.diag.all");
+    final boolean allPlayers =
+        (allEnv != null && !allEnv.isEmpty()) || (allSys != null && !allSys.isEmpty());
+    return allPlayers || "Americans".equals(player.getName());
+  }
+
+  /**
+   * Dumps per-transport reachability for the active player: starting sea zone, getUnitRange result,
+   * count + first-N keys of the computed {@code transportMap} (= reachable amphib unload
+   * destinations). Grep with {@code grep '\[SVF-XPORT-DIAG\]'} to extract.
+   *
+   * <p>Designed for an Atlantic-vs-Pacific debug: under KGF, we want to see whether US transports
+   * at SZ 101 / SZ 102 are actually surfacing North-African / European unload destinations or only
+   * Caribbean / Pacific. Output format is one line per transport, one extra line per destination
+   * beyond the first 10, plus a summary header per player call.
+   */
+  private static void logTransportDiag(
+      final ProData proData, final GamePlayer player, final List<ProTransport> transportMapList) {
+    ProLogger.info(
+        "[SVF-XPORT-DIAG] player=" + player.getName() + " transports=" + transportMapList.size());
+    for (final ProTransport pt : transportMapList) {
+      final Unit transport = pt.getTransport();
+      final Territory startTerritory = proData.getUnitTerritory(transport);
+      final BigDecimal range = getUnitRange(transport, startTerritory, player, false);
+      final Map<Territory, Set<Territory>> tmap = pt.getTransportMap();
+      final List<String> destPreview = new ArrayList<>();
+      for (final Territory dest : tmap.keySet()) {
+        if (destPreview.size() >= 10) {
+          break;
+        }
+        destPreview.add(dest.getName());
+      }
+      ProLogger.info(
+          "[SVF-XPORT-DIAG]   transport id="
+              + transport.getId()
+              + " at="
+              + (startTerritory == null ? "?" : startTerritory.getName())
+              + " range="
+              + range
+              + " destCount="
+              + tmap.size()
+              + " destPreview="
+              + destPreview);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Diagnostic-only PR — no behavior change. Helps debug why US transports never surface Morocco (or other Mediterranean targets) as amphib attack candidates even though, by all static-analysis evidence, they should.

## Context from live run

Chase reported round 5 US never attacks Morocco despite:
- US at war with Italy ✓
- Morocco Italian-owned ✓
- US transports at SZ 101 East Coast ✓
- Route 101→102→103→91 unblocked (SZ 102 empty, SZ 103 empty, SZ 91 cleared by British R4) ✓
- Transports get +1 from Eastern US naval base = 3 movement ✓
- Morocco passes the unloadAmphibTerritoryMatch (Italian = enemy) ✓

All inputs say Morocco should be in the transport map. The 99-territory CM scope at round 5 doesn't contain it. Something is silently filtering it out.

Suspects: `getUnitRange` returning 2 instead of 3 (harbor bonus not firing — there have been related PRs #115 / #120), a route validation failure I haven't reproduced, or a wire-state owner sync issue.

## What this changes

Adds env-gated logging in `ProTerritoryManager.findAmphibMoveOptions` right after the transport-map building loop. For each US transport, dumps one line:

```
[SVF-XPORT-DIAG]   transport id=u244 at=101 Sea Zone range=3 destCount=12 destPreview=[Eastern United States, Newfoundland Labrador, ...]
```

If Morocco is in the `destPreview` for transports at SZ 101 → bug is downstream (probably the `removeTerritoriesThatCantBeConquered` filter or value-blend). If it's absent and `range=2` → harbor bonus issue. If absent and `range=3` → route or unload-match issue.

US-only by default (matches SVF spec §2 scope). Set `AI_TRANSPORT_DIAG_ALL=1` to dump all players. Only fires during combat-move (`isCombatMove && !isCheckingEnemyAttacks`) so enemy-attack simulations stay quiet.

## How to use

Add to `ai-sidecar` docker-compose env:
```yaml
AI_TRANSPORT_DIAG: \"1\"
```

After the next run, grep `gamelogs.log`:
```bash
grep '\[SVF-XPORT-DIAG\]' gamelogs.log
```

## Test plan

- [x] `:game-app:game-core:spotlessCheck` clean
- [x] `:game-app:game-core:test` — full game-core suite green
- [x] Default-off behavior verified (no logging unless env var set)
- [ ] 🧑 Manual: fresh AI-vs-AI run with `AI_TRANSPORT_DIAG=1`; verify the [SVF-XPORT-DIAG] lines appear, and check whether Morocco / Algeria / Tunisia surface as destinations for US transports at SZ 101 in round 5+