### PR TITLE
diag(proai): PR-H — per-zone gate probe for transport reachability (map-room#2755)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -1123,6 +1123,13 @@ public class ProTerritoryManager {
             if (movesLeft > 0) {
               final Predicate<Territory> canMove =
                   isCheckingEnemyAttacks ? canMoveSea : canMoveSeaThrough;
+              // PR-H gate diagnostic: log per-candidate-zone evaluation of canMoveSea and
+              // canMoveSeaThrough so we can see *which* sub-predicate is rejecting which
+              // Atlantic transit zones. Only the first iter (movesLeft at its initial
+              // value) emits — that's the broadest probe and avoids per-iter spam.
+              if (traceThisTransport && movesLeft == 3 && isGateProbeEnabled()) {
+                logGateProbe(map, from, movesLeft, player, canMoveSea, canMoveSeaThrough);
+              }
               for (final Territory to : map.getNeighbors(from, movesLeft, canMove)) {
                 if (map.getRouteForUnit(from, to, canMoveSeaThrough, transport, player)
                     .isPresent()) {
@@ -1410,6 +1417,63 @@ public class ProTerritoryManager {
             System.getenv("AI_TRANSPORT_TRACE_AT"), System.getProperty("ai.transport.trace.at"));
     final String filterAt = atName != null ? atName : "101 Sea Zone";
     return transportTerritory != null && filterAt.equals(transportTerritory.getName());
+  }
+
+  private static boolean isGateProbeEnabled() {
+    return firstNonEmpty(
+            System.getenv("AI_TRANSPORT_GATE"), System.getProperty("ai.transport.gate"))
+        != null;
+  }
+
+  /**
+   * Per-candidate gate probe. For every water territory within {@code movesLeft} hops of {@code
+   * from} (raw map adjacency, no predicate filter), evaluate the two predicates the reachability
+   * calc actually uses and log whether each gate accepted. Output one line per probed zone — grep
+   * with {@code grep '\[SVF-XPORT-GATE\]'}. The probed set is bounded by {@code movesLeft} so
+   * radius-3 BFS surfaces at most ~30 zones in practice.
+   */
+  private static void logGateProbe(
+      final GameMap map,
+      final Territory from,
+      final int movesLeft,
+      final GamePlayer player,
+      final Predicate<Territory> canMoveSea,
+      final Predicate<Territory> canMoveSeaThrough) {
+    // Raw radius-N adjacency — no predicate so we see ALL water neighbors, including those that
+    // are filtered out by the gates. This is the population over which the gates operate.
+    final Set<Territory> probeSet = map.getNeighbors(from, movesLeft);
+    int waterCount = 0;
+    for (final Territory z : probeSet) {
+      if (!z.isWater()) {
+        continue;
+      }
+      waterCount++;
+      final boolean canSea = canMoveSea.test(z);
+      final boolean canSeaThrough = canMoveSeaThrough.test(z);
+      final String owner = z.getOwner() == null ? "no-owner" : z.getOwner().getName();
+      final int enemyUnits =
+          (int) z.getUnits().stream().filter(u -> !u.getOwner().isAllied(player)).count();
+      ProLogger.info(
+          "[SVF-XPORT-GATE] from="
+              + from.getName()
+              + " zone="
+              + z.getName()
+              + " owner="
+              + owner
+              + " enemyUnits="
+              + enemyUnits
+              + " canMoveSea="
+              + canSea
+              + " canMoveSeaThrough="
+              + canSeaThrough);
+    }
+    ProLogger.info(
+        "[SVF-XPORT-GATE] summary from="
+            + from.getName()
+            + " probeRadius="
+            + movesLeft
+            + " waterCandidates="
+            + waterCount);
   }
 
   private static String firstNonEmpty(final String a, final String b) {


### PR DESCRIPTION
## Summary

Follow-up diagnostic to PR-G (#140). The PR-G trace showed US transports at SZ 101 see only 7 reachable sea zones (Caribbean + Pacific-via-Canal) with no Atlantic-east. PR-H lets us see WHICH sub-predicate of \`canMoveSeaThrough\` rejected each Atlantic-east zone.

## What this adds

For every water neighbor of \`from\` within \`movesLeft\` hops (raw map adjacency, no predicate filter), log gate evaluation:

\`\`\`
[SVF-XPORT-GATE] from=101 Sea Zone zone=91 Sea Zone owner=no-owner enemyUnits=2 canMoveSea=false canMoveSeaThrough=false
[SVF-XPORT-GATE] from=101 Sea Zone zone=103 Sea Zone owner=no-owner enemyUnits=0 canMoveSea=true canMoveSeaThrough=true
[SVF-XPORT-GATE] summary from=101 Sea Zone probeRadius=3 waterCandidates=23
\`\`\`

Reads:
- \`canMoveSea=false canMoveSeaThrough=false\` → base predicate rejected (relationship or restriction)
- \`canMoveSea=true canMoveSeaThrough=false\` → only the ignored-units sub-gate rejected
- both true → zone is reachable in principle, but \`getRouteForUnit\` may still strip it

The probed set is bounded by \`movesLeft\` so a radius-3 probe surfaces ~20-30 zones in practice. Logs only fire on the outermost iteration (movesLeft == 3 at start) to keep noise focused.

## How to use

Three env vars stacked:
\`\`\`yaml
AI_TRANSPORT_DIAG: \"1\"     # PR-F summary
AI_TRANSPORT_TRACE: \"1\"    # PR-G per-iter trace
AI_TRANSPORT_GATE: \"1\"     # PR-H per-zone gate probe
\`\`\`

Grep:
\`\`\`bash
grep '\\[SVF-XPORT-GATE\\]' gamelogs.log | head -40
\`\`\`

## Diagnostic decision tree

Given PR-G data showing 7 reachable zones with no Atlantic-east, PR-H tells us:
- \`zone=91 canMoveSea=false\` → base predicate rejected (relationship/restriction). Likely a Java-side neutrality rule we don't know about, or stale relationship state.
- \`zone=91 canMoveSea=true canMoveSeaThrough=false\` → \`territoryHasOnlyIgnoredUnits\` rejected (combat ship in zone).
- \`zone=91 canMoveSea=true canMoveSeaThrough=true\` → both gates accept; \`getRouteForUnit\` is stripping it during multi-hop validation. Look at intermediate zone gates.

## Test plan

- [x] \`:game-app:game-core:spotlessCheck\` clean
- [x] \`:game-app:game-core:test\` — full game-core suite green
- [ ] 🧑 Manual: re-run with \`AI_TRANSPORT_GATE=1\` added; check round 3+ US transport at SZ 101 gate output for SZ 91 / 103 / 92 / 87 / 100