### PR TITLE
fix(proai): PR-J — bypass stale XML movement restriction when at war (map-room#2755)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -204,8 +204,95 @@ public final class ProMatches {
               .and(
                   Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(
                       player, isCombatMove, false, true, false, false));
-      return match.test(t);
+      if (match.test(t)) {
+        return true;
+      }
+      // map-room#2755 PR-J: simulate the cleared-restriction state when at war with axis.
+      // 1940 Global encodes the US/Japan/Russia "neutrality act" as a static XML list
+      // (RulesAttachment.movementRestrictionTerritories) plus a TriggerAttachment that
+      // clears the list once at war with an axis power. The sidecar is stateless per
+      // HTTP request, so it never executes the game-step boundary the trigger fires on
+      // — the list persists. The live TS engine implements the same rule procedurally
+      // (movement-validator.ts:getUSNeutralityRestriction) and lifts it on war, so AI
+      // and engine disagree on Atlantic reachability for the US once at war. Override
+      // here: if the only thing blocking the move is the stale-XML restriction list AND
+      // the player is at war with an axis, accept.
+      return shouldBypassStaleMovementRestriction(player, t, properties, isCombatMove);
     };
+  }
+
+  /**
+   * Returns {@code true} if {@code t} is rejected SOLELY by the static-XML {@code
+   * movementRestrictionTerritories} list and the player has declared (or had declared on them) a
+   * war with at least one axis power. Mirrors the effect of the {@code
+   * triggerAttachment_Americans_Unrestricted_Movement} XML trigger that the stateless sidecar
+   * cannot fire. Returns false (= preserve the rejection) when the property isn't set, when the
+   * player isn't at war with any axis, or when the territory isn't in the restriction list. Also
+   * re-checks the non-restriction conditions of {@code
+   * territoryIsPassableAndNotRestrictedAndOkByRelationships} so a territory blocked for OTHER
+   * reasons (impassable, can't move into during CM, etc.) stays blocked.
+   */
+  private static boolean shouldBypassStaleMovementRestriction(
+      final GamePlayer player,
+      final Territory t,
+      final GameProperties properties,
+      final boolean isCombatMove) {
+    if (!Properties.getMovementByTerritoryRestricted(properties)) {
+      return false;
+    }
+    if (!isAtWarWithAnyAxis(player)) {
+      return false;
+    }
+    final games.strategy.triplea.attachments.RulesAttachment ra = player.getRulesAttachment();
+    if (ra == null) {
+      return false;
+    }
+    final String[] restrictionNames = ra.getMovementRestrictionTerritories();
+    if (restrictionNames == null || restrictionNames.length == 0) {
+      return false;
+    }
+    final java.util.Collection<Territory> listedTerritories =
+        ra.getListedTerritories(restrictionNames, true, true);
+    final boolean isInList = listedTerritories.contains(t);
+    final boolean isAllowedList = ra.isMovementRestrictionTypeAllowed();
+    // The restriction rejects iff (isAllowedList == isInList) is false — i.e. for a
+    // "disallowed" list, in-list = blocked; for an "allowed" list, not-in-list = blocked.
+    final boolean blockedByRestriction = isAllowedList ? !isInList : isInList;
+    if (!blockedByRestriction) {
+      return false;
+    }
+    // Re-check the non-restriction conditions so we don't over-bypass. For our scenario
+    // (US sea unit entering an empty Atlantic sea zone) these all pass; the guard exists
+    // to keep impassable / hostile-ownership / etc. cases from sneaking through.
+    if (Matches.territoryIsImpassable().test(t)) {
+      return false;
+    }
+    if (!Matches.territoryDoesNotCostMoneyToEnter(properties).test(t)) {
+      return false;
+    }
+    if (isCombatMove
+        && !player
+            .getData()
+            .getRelationshipTracker()
+            .canMoveIntoDuringCombatMove(player, t.getOwner())) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Returns true if {@code player} is currently at war with any of the three axis powers (Germans,
+   * Italians, Japanese). Hardcoded to the 1940 Global roster — matches the spec §2 / SVF scope.
+   */
+  private static boolean isAtWarWithAnyAxis(final GamePlayer player) {
+    final games.strategy.engine.data.PlayerList players = player.getData().getPlayerList();
+    for (final String axisName : new String[] {"Germans", "Italians", "Japanese"}) {
+      final GamePlayer axis = players.getPlayerId(axisName);
+      if (axis != null && player.isAtWar(axis)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public static Predicate<Territory> territoryCanMoveSeaUnitsThrough(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProMatchesStaleRestrictionTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProMatchesStaleRestrictionTest.java
@@ -1,0 +1,135 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * PR-J (map-room#2755): the stateless sidecar can't fire the XML trigger that clears the US's
+ * {@code movementRestrictionTerritories} list on war declaration, so the static list persists and
+ * blocks US transport reachability into Atlantic transit zones like SZ 103. This patches the AI's
+ * sea-movement predicate to bypass the stale-XML restriction when the player is at war with at
+ * least one axis power — mirroring what the live TS engine's {@code getUSNeutralityRestriction}
+ * does procedurally.
+ */
+class ProMatchesStaleRestrictionTest {
+
+  /**
+   * Sea zone in the 1940 Global US movement-restriction "disallowed" list — i.e. the AI's predicate
+   * rejects this for the US while neutral, even though it's empty water. After war the predicate
+   * should accept it.
+   */
+  private static final String RESTRICTED_ATLANTIC = "103 Sea Zone";
+
+  /**
+   * Sea zone NOT in the US restriction list — a control case that should be accepted regardless.
+   */
+  private static final String UNRESTRICTED_ATLANTIC = "102 Sea Zone";
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer germans;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    germans = data.getPlayerList().getPlayerId("Germans");
+  }
+
+  @Test
+  void restrictedAtlanticZone_blockedAtGameStart_whenUSNeutral() {
+    final Territory sz103 = data.getMap().getTerritoryOrThrow(RESTRICTED_ATLANTIC);
+    final Predicate<Territory> canMoveSea = ProMatches.territoryCanMoveSeaUnits(americans, true);
+
+    assertThat(canMoveSea.test(sz103))
+        .as("Baseline: at game start US is neutral with all axis — XML restriction stands")
+        .isFalse();
+  }
+
+  @Test
+  void restrictedAtlanticZone_acceptedAfterUSAtWarWithGermans() {
+    setRelationship(americans, germans, "War");
+    final Territory sz103 = data.getMap().getTerritoryOrThrow(RESTRICTED_ATLANTIC);
+    final Predicate<Territory> canMoveSea = ProMatches.territoryCanMoveSeaUnits(americans, true);
+
+    assertThat(canMoveSea.test(sz103))
+        .as(
+            "After war with Germans, the AI predicate must accept SZ 103 — the XML trigger that"
+                + " clears the restriction can't fire in the sidecar, so PR-J simulates it")
+        .isTrue();
+  }
+
+  @Test
+  void unrestrictedZone_acceptedRegardlessOfWarState() {
+    final Territory sz102 = data.getMap().getTerritoryOrThrow(UNRESTRICTED_ATLANTIC);
+    final Predicate<Territory> canMoveSea = ProMatches.territoryCanMoveSeaUnits(americans, true);
+    assertThat(canMoveSea.test(sz102))
+        .as("SZ 102 is NOT in the restriction list — accepted at game start")
+        .isTrue();
+
+    setRelationship(americans, germans, "War");
+    assertThat(canMoveSea.test(sz102))
+        .as("SZ 102 still accepted post-war — PR-J doesn't affect non-restricted zones")
+        .isTrue();
+  }
+
+  @Test
+  void otherPlayer_notAffectedByBypass() {
+    // Bypass is keyed off the player's own restriction list + their own war state. A different
+    // player asking about the same SZ shouldn't be affected, since they have a different
+    // restriction list (or none).
+    setRelationship(americans, germans, "War"); // Americans at war, irrelevant to Germans
+    final Territory sz103 = data.getMap().getTerritoryOrThrow(RESTRICTED_ATLANTIC);
+    final Predicate<Territory> germansCanMove = ProMatches.territoryCanMoveSeaUnits(germans, true);
+
+    // Germans don't have SZ 103 in their restriction list and aren't subject to neutrality
+    // act — they pass the base predicate without needing the bypass.
+    assertThat(germansCanMove.test(sz103))
+        .as("Other players' reachability isn't widened by US's bypass")
+        .isTrue();
+  }
+
+  @Test
+  void impassableTerritory_stillBlockedEvenAtWar() {
+    // The bypass only relaxes the restriction-list check. Impassable territories must stay
+    // blocked. Lake Baikal (impassable) is the canonical test fixture for this.
+    setRelationship(americans, germans, "War");
+    final Territory impassable = findFirstImpassable();
+    if (impassable == null) {
+      return; // No impassable in scenario — skip silently
+    }
+    final Predicate<Territory> canMoveSea = ProMatches.territoryCanMoveSeaUnits(americans, true);
+    assertThat(canMoveSea.test(impassable))
+        .as("PR-J must not bypass the impassable check")
+        .isFalse();
+  }
+
+  // --- helpers ---
+
+  private void setRelationship(final GamePlayer a, final GamePlayer b, final String relName) {
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            a,
+            b,
+            data.getRelationshipTracker().getRelationshipType(a, b),
+            data.getRelationshipTypeList().getRelationshipType(relName)));
+  }
+
+  private Territory findFirstImpassable() {
+    return data.getMap().getTerritories().stream()
+        .filter(t -> games.strategy.triplea.delegate.Matches.territoryIsImpassable().test(t))
+        .findFirst()
+        .orElse(null);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the root cause of the "US never attacks Atlantic targets" symptom that PRs A-I diagnosed. The Java sidecar's transport reachability has been silently blocking US from entering 16 sea zones (103, 106, 116, 117, etc.) post-war-declaration because the XML trigger that clears the US's \`movementRestrictionTerritories\` list never fires on the stateless sidecar.

## Root cause (from PR-I diagnostics)

\`\`\`
[SVF-XPORT-RA] player=Americans movementRestrictionType=disallowed count=16 
  territories=[65, 66, 85, 86, 88, 90, 103, 106, 107, 116, 117, 120, 122, 19, 20, 36] Sea Zone
\`\`\`

This list is **identical across rounds 1, 2, 3, 5, 6** in the user's run — US has been at war with Italy + Japan since round 1, but the static-XML list never clears. The XML's \`triggerAttachment_Americans_Unrestricted_Movement\` says "before:americansCombatMove, clear the list once at war with at least one axis" — but the sidecar never executes that step boundary.

The TS engine has no XML trigger evaluator either; it implements the same rule procedurally in \`getUSNeutralityRestriction\` (movement-validator.ts:320). So Java and TS diverge once US enters war: TS lets US sail through SZ 103, Java keeps blocking.

## What this changes

\`ProMatches.territoryCanMoveSeaUnits\`: when the base predicate rejects a territory, check if the rejection is solely due to the player's static \`movementRestrictionTerritories\` list AND the player is at war with at least one axis. If yes, override to accept. Re-tests the non-restriction conditions (impassable, money cost, canMoveIntoDuringCombatMove relationship gate) so non-restriction blockers stay enforced.

\`\`\`java
final boolean blockedByRestriction = isAllowedList ? !isInList : isInList;
if (!blockedByRestriction) return false;
// Re-check other gates...
return true;
\`\`\`

## What it doesn't change

- US round 1 BEFORE any war declaration: SZ 103 still blocked (US really is neutral then — correct behavior)
- Non-US players: unaffected (different restriction lists or none; same code path but the war-with-axis check is keyed on the asking player)
- Other stale trigger effects: production bonuses, France-fall cascades, victory flags. Those remain Path B (systemic trigger evaluator) work.

## Tests

\`ProMatchesStaleRestrictionTest\` (5 cases):
- baseline blocking when US neutral
- accepting after war with Germans (the headline fix)
- unrestricted zone accepted regardless
- other players unaffected
- impassable territory still blocked

## Test plan

- [x] \`:game-app:game-core:spotlessCheck\` clean
- [x] \`:game-app:game-core:test\` full suite green
- [x] New \`ProMatchesStaleRestrictionTest\` — 5/5 pass
- [ ] 🧑 Manual: fresh AI-vs-AI run with PRs A-J merged. Check round 3+ \`[SVF-XPORT-TRACE]\` for US transports at SZ 101 — sea zones reachable should now include SZ 103, 91, 87. Combat-move attack-options should surface Morocco / Algeria / Tunisia / Western Germany / Holland Belgium once Atlantic transit zones are reachable.