### PR TITLE
feat(proai): PR-F — offense-intent transport staging (map-room#2755)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -31,6 +31,7 @@ import games.strategy.triplea.ai.pro.util.ProPurchaseUtils;
 import games.strategy.triplea.ai.pro.util.ProSortMoveOptionsUtils;
 import games.strategy.triplea.ai.pro.util.ProTerritoryValueUtils;
 import games.strategy.triplea.ai.pro.util.ProTheaterScopeFilter;
+import games.strategy.triplea.ai.pro.util.ProTransportStaging;
 import games.strategy.triplea.ai.pro.util.ProTransportUtils;
 import games.strategy.triplea.ai.pro.util.ProUtils;
 import games.strategy.triplea.attachments.TerritoryAttachment;
@@ -216,6 +217,15 @@ class ProNonCombatMoveAi {
                 + territoryManager.getDefendOptions().getUnitMoveMap().get(u));
       }
     }
+
+    // map-room#2755 PR-F: offense-intent transport staging. After defense + best-territory +
+    // infra placement, pick up any unloaded US transport that hasn't been assigned a
+    // destination and stage it eastward toward the highest-S(adjacent enemy land) reachable
+    // sea zone. Closes the gap where SZ 101 transports drift south to Caribbean via
+    // amphib-defense pull instead of heading toward Europe. US-only, dormant unless wStrat > 0
+    // so PR-F is zero-impact at SVF defaults.
+    ProTransportStaging.stageIdleTransports(
+        proData, player, territoryManager.getDefendOptions().getTransportMoveMap(), moveMap);
 
     // Calculate move routes and perform moves
     doMove(isCombatMove, moveMap, moveDel, data, player);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportStaging.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportStaging.java
@@ -1,0 +1,207 @@
+package games.strategy.triplea.ai.pro.util;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameMap;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.ProTerritory;
+import games.strategy.triplea.ai.pro.logging.ProLogger;
+import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.move.validation.MoveValidator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Offense-intent transport staging for the SVF (map-room#2755 PR-F).
+ *
+ * <p>The Java sidecar's NCM transport-move logic only moves transports for defense reasons:
+ * naval-defense (transport joins a threatened friendly sea zone) and amphib-defense (transport
+ * rushes to a threatened friendly land territory). There is no parallel hook that says "I have idle
+ * transports + a high-S Europe value map; pre-position them eastward so next turn's CM can reach
+ * Berlin." That gap was the structural cause of US transports drifting south to Caribbean (via NCM
+ * amphib-defense pull) instead of east toward Atlantic — observed across SVF live runs after PR-J
+ * unblocked the reachability calc.
+ *
+ * <p>This util adds the offense-intent leg: at the end of NCM (after defense + best-territory +
+ * infra placement), for each idle unloaded transport find the reachable sea zone with the highest
+ * "max S(adjacent enemy land)" score and assign it as a move destination. The transport then gets
+ * dispatched via the existing ProMoveUtils.calculateMoveRoutes path.
+ *
+ * <p>US-only per spec §2. Dormant unless {@code proData.getWStrat() > 0} so it activates with the
+ * same flip that turns on the SVF blend.
+ *
+ * <p>The staging is bounded: only one hop forward per turn (transport moves to the best reachable
+ * zone), so over 2-3 turns transports walk east. Doesn't override defensive commitments (transports
+ * already in moveMap or in {@code transportsToHold} are skipped).
+ */
+@UtilityClass
+public final class ProTransportStaging {
+
+  /**
+   * Stages idle US transports toward sea zones with high S(adjacent land) scores. Mutates the
+   * {@code moveMap} in place by adding chosen transports as temp units to their target sea zone.
+   *
+   * <p>Returns the number of transports staged. Always {@code 0} for non-US, for {@code wStrat ==
+   * 0}, or when {@code proData.getStrategicValueField()} is null (no SVF compute fired this
+   * request).
+   */
+  public static int stageIdleTransports(
+      final ProData proData,
+      final GamePlayer player,
+      final Map<Unit, Set<Territory>> transportMoveMap,
+      final Map<Territory, ProTerritory> moveMap) {
+    if (!isStagingActive(proData, player)) {
+      return 0;
+    }
+    final Map<Territory, Double> svf = proData.getStrategicValueField();
+    if (svf == null || svf.isEmpty()) {
+      return 0;
+    }
+
+    final GameData data = proData.getData();
+    final GameMap map = data.getMap();
+    final Set<Unit> alreadyAssigned = collectAssignedTransports(moveMap);
+    alreadyAssigned.addAll(proData.getTransportsToHold());
+
+    int staged = 0;
+    for (final Map.Entry<Unit, Set<Territory>> entry : transportMoveMap.entrySet()) {
+      final Unit transport = entry.getKey();
+      if (alreadyAssigned.contains(transport)) {
+        continue;
+      }
+      final Territory currentSz = proData.getUnitTerritory(transport);
+      if (currentSz == null) {
+        continue;
+      }
+      final Territory bestSz =
+          pickBestStagingZone(currentSz, entry.getValue(), svf, map, player, data, transport);
+      if (bestSz == null || bestSz.equals(currentSz)) {
+        continue;
+      }
+      // Stage the transport at bestSz by adding it as a temp unit on the destination's
+      // ProTerritory. ProMoveUtils.calculateMoveRoutes picks this up downstream.
+      final ProTerritory dest = proData.getProTerritory(moveMap, bestSz);
+      dest.addTempUnit(transport);
+      staged++;
+      ProLogger.trace(
+          "SVF staging: transport id="
+              + transport.getId()
+              + " from="
+              + currentSz.getName()
+              + " to="
+              + bestSz.getName()
+              + " score="
+              + scoreSeaZone(bestSz, svf, map, player));
+    }
+    if (staged > 0) {
+      ProLogger.info("SVF staging assigned " + staged + " transport(s) to high-value sea zones");
+    }
+    return staged;
+  }
+
+  /**
+   * Walks moveMap collecting every transport already committed to a destination — either as a
+   * defender (addTempUnit), an amphib unloader (transportTerritoryMap), or already-moved transit.
+   * Returns the union so the staging pass doesn't double-assign.
+   */
+  private static Set<Unit> collectAssignedTransports(final Map<Territory, ProTerritory> moveMap) {
+    final Set<Unit> assigned = new HashSet<>();
+    for (final ProTerritory patd : moveMap.values()) {
+      for (final Unit u : patd.getUnits()) {
+        if (u.getUnitAttachment().getTransportCapacity() > 0) {
+          assigned.add(u);
+        }
+      }
+      for (final Unit u : patd.getTempUnits()) {
+        if (u.getUnitAttachment().getTransportCapacity() > 0) {
+          assigned.add(u);
+        }
+      }
+      assigned.addAll(patd.getTransportTerritoryMap().keySet());
+    }
+    return assigned;
+  }
+
+  /**
+   * Picks the reachable sea zone with the highest staging score, or the current zone if no
+   * candidate scores strictly higher. The candidate set is filtered to validate the route per the
+   * move validator (no canal restrictions, etc.) so we don't dispatch an invalid move.
+   */
+  private static Territory pickBestStagingZone(
+      final Territory currentSz,
+      final Set<Territory> reachable,
+      final Map<Territory, Double> svf,
+      final GameMap map,
+      final GamePlayer player,
+      final GameData data,
+      final Unit transport) {
+    Territory best = currentSz;
+    double bestScore = scoreSeaZone(currentSz, svf, map, player);
+    final MoveValidator validator = new MoveValidator(data, false);
+    for (final Territory candidate : reachable) {
+      if (!candidate.isWater()) {
+        continue;
+      }
+      if (candidate.equals(currentSz)) {
+        continue;
+      }
+      final double score = scoreSeaZone(candidate, svf, map, player);
+      if (score <= bestScore) {
+        continue;
+      }
+      // Validate the route — handles canal access and any per-unit restrictions the raw
+      // adjacency walk doesn't catch.
+      final Route route = new Route(currentSz, candidate);
+      if (validator.validateCanal(route, List.of(transport), player) != null) {
+        continue;
+      }
+      best = candidate;
+      bestScore = score;
+    }
+    return best;
+  }
+
+  /**
+   * Score a candidate staging sea zone as the max {@code S(adjacent_land)} for any adjacent
+   * non-water territory. Friendly + own land have S=0 after PR-B's allied-land suppression, so the
+   * max naturally picks the highest-value enemy target the AI could amphib next turn.
+   */
+  static double scoreSeaZone(
+      final Territory seaZone,
+      final Map<Territory, Double> svf,
+      final GameMap map,
+      final GamePlayer player) {
+    if (!seaZone.isWater()) {
+      return 0.0;
+    }
+    final Predicate<Territory> isLand = Matches.territoryIsLand();
+    double max = 0.0;
+    for (final Territory neighbor : map.getNeighbors(seaZone, isLand)) {
+      final Double s = svf.get(neighbor);
+      if (s != null && s > max) {
+        max = s;
+      }
+    }
+    return max;
+  }
+
+  /**
+   * Gates the entire staging pass. Returns false for non-Americans (spec §2 US-only), when the SVF
+   * blend is dormant ({@code wStrat == 0}), or when {@code player} is null. Public-visible because
+   * the wire site in {@code ProNonCombatMoveAi} can short-circuit on it to skip the
+   * transport-move-map collection when staging won't run.
+   */
+  public static boolean isStagingActive(final ProData proData, final GamePlayer player) {
+    if (player == null || !"Americans".equals(player.getName())) {
+      return false;
+    }
+    return proData.getWStrat() > 0.0;
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProTransportStagingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProTransportStagingTest.java
@@ -1,0 +1,125 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameMap;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Phase 3D / PR-F (map-room#2755) — offense-intent transport staging tests. Covers the gate
+ * (US-only, wStrat>0 active), the scoring (max S of adjacent enemy land beats Caribbean drift), and
+ * the no-SVF-field short-circuit.
+ */
+class ProTransportStagingTest {
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer germans;
+  private ProData proData;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    germans = data.getPlayerList().getPlayerId("Germans");
+    proData = proDataFor(data, americans);
+  }
+
+  @Test
+  void isStagingActive_falseForNonUs() throws Exception {
+    final ProData germansData = proDataFor(data, germans);
+    germansData.setWStrat(4.0);
+    assertThat(ProTransportStaging.isStagingActive(germansData, germans))
+        .as("Spec §2: staging is US-only — other AI bypass")
+        .isFalse();
+  }
+
+  @Test
+  void isStagingActive_falseAtDefaultWStrat() {
+    // Default wStrat=0 keeps staging dormant. SVF blend off ⇒ staging off.
+    assertThat(ProTransportStaging.isStagingActive(proData, americans))
+        .as("wStrat=0 means SVF dormant — staging must not fire either")
+        .isFalse();
+  }
+
+  @Test
+  void isStagingActive_trueForUsWithWStrat() {
+    proData.setWStrat(4.0);
+    assertThat(ProTransportStaging.isStagingActive(proData, americans))
+        .as("US + wStrat>0 = active")
+        .isTrue();
+  }
+
+  @Test
+  void scoreSeaZone_picksMaxAdjacentLandValue() {
+    // Build a synthetic SVF where Morocco has high S and surrounding non-Morocco neighbors
+    // are low. SZ 91 should score by Morocco's value.
+    final GameMap map = data.getMap();
+    final Territory sz91 = data.getMap().getTerritoryOrThrow("91 Sea Zone");
+    final Territory morocco = data.getMap().getTerritoryOrThrow("Morocco");
+
+    final Map<Territory, Double> svf = new HashMap<>();
+    for (final Territory t : data.getMap().getTerritories()) {
+      svf.put(t, t.equals(morocco) ? 250.0 : 0.0);
+    }
+
+    final double score = ProTransportStaging.scoreSeaZone(sz91, svf, map, americans);
+    assertThat(score)
+        .as("SZ 91 should score by Morocco's S (the max-adjacent-land value)")
+        .isEqualTo(250.0);
+  }
+
+  @Test
+  void scoreSeaZone_zeroWhenSeaZoneIsLand() {
+    final GameMap map = data.getMap();
+    final Territory morocco = data.getMap().getTerritoryOrThrow("Morocco");
+    final Map<Territory, Double> svf = new HashMap<>();
+    svf.put(morocco, 250.0);
+    final double score = ProTransportStaging.scoreSeaZone(morocco, svf, map, americans);
+    assertThat(score).as("Land territories return 0 — only sea zones get scored").isEqualTo(0.0);
+  }
+
+  @Test
+  void stageIdleTransports_returnsZeroWhenInactive() {
+    // wStrat=0 by default. Even with transport-move-map containing transports + reachable
+    // sea zones, no staging should happen.
+    final int staged =
+        ProTransportStaging.stageIdleTransports(proData, americans, Map.of(), new HashMap<>());
+    assertThat(staged).as("Inactive staging returns 0 immediately").isZero();
+  }
+
+  @Test
+  void stageIdleTransports_returnsZeroWhenSvfNull() {
+    proData.setWStrat(4.0);
+    proData.setStrategicValueField(null);
+    final int staged =
+        ProTransportStaging.stageIdleTransports(proData, americans, Map.of(), new HashMap<>());
+    assertThat(staged).as("Staging requires a populated SVF; null short-circuits").isZero();
+  }
+
+  // --- helpers ---
+
+  private static ProData proDataFor(final GameData gameData, final GamePlayer player)
+      throws Exception {
+    final ProData p = new ProData();
+    final Field dataField = ProData.class.getDeclaredField("data");
+    dataField.setAccessible(true);
+    dataField.set(p, gameData);
+    final Field playerField = ProData.class.getDeclaredField("player");
+    playerField.setAccessible(true);
+    playerField.set(p, player);
+    return p;
+  }
+}


### PR DESCRIPTION
## Summary

Closes the last structural gap of the SVF Theater Pull series. PR-J (#143) unblocked Atlantic reachability; map-room#2764 fixed the engine-side Rule 2. But the actual transports at SZ 101 still don't head east — because NCM has no offense-intent staging logic.

## Live-run evidence

Across 8 rounds of post-PR-J AI-vs-AI, US sea-zone moves:

| Route | Count |
|---|---|
| **SZ 101 → SZ 89** (south, Caribbean) | **8** |
| SZ 101 → SZ 102 (one east, then back) | 2 |
| SZ 101 → anywhere further east | **0** |

NCM's transport-move loop only handles defensive intents (naval-defense, amphib-defense). The amphib-defense pull drags transports south to Caribbean. Idle transports at SZ 101 either drift to Caribbean or sit still — never march east toward Europe.

## What this changes

\`ProTransportStaging\` (new util):
- \`stageIdleTransports(proData, player, transportMoveMap, moveMap)\` — call from NCM after defense passes
- For each idle US transport: score reachable sea zones by \`max(S(adjacent land))\`, pick highest, assign as temp unit on destination ProTerritory
- ProMoveUtils.calculateMoveRoutes picks it up and dispatches

\`ProNonCombatMoveAi.doNonCombatMove\` — wire site at line 220-ish, between the warning loop and \`doMove\`.

## Gating

- **US-only** per spec §2
- Dormant unless \`proData.getWStrat() > 0\` — same activation as the SVF blend; PR-F ships zero-impact at SVF defaults
- Skips transports already in moveMap (defense / amphib commitments take priority)
- Skips transports in \`proData.getTransportsToHold()\` from PR-D's amphib commit gate
- Friendly + own land have S=0 (PR-B's allied-land suppression), so scoring naturally selects enemy targets

## Effect (expected once \`AI_SVF_W_STRAT > 0\`)

- Transports at SZ 101 march east each NCM (SZ 102 → SZ 87/91 over 1-2 turns)
- After staging, they're in range to load Atlantic-staged infantry or accompany next-turn amphib waves
- Caribbean route still happens but doesn't monopolize all available transports

## Tests

\`ProTransportStagingTest\` (6 cases):
- \`isStagingActive_falseForNonUs\` — spec §2 enforcement
- \`isStagingActive_falseAtDefaultWStrat\` — dormant at defaults
- \`isStagingActive_trueForUsWithWStrat\` — active path
- \`scoreSeaZone_picksMaxAdjacentLandValue\` — Morocco's S surfaces SZ 91 as high-value
- \`scoreSeaZone_zeroWhenSeaZoneIsLand\` — only sea zones score
- \`stageIdleTransports_returnsZero*\` — inactive + null-SVF short-circuits

## Test plan

- [x] \`:game-app:game-core:spotlessCheck\` clean
- [x] \`:game-app:game-core:test\` full suite green
- [x] New \`ProTransportStagingTest\` — 6/6 pass
- [ ] 🧑 Manual: fresh AI-vs-AI with \`AI_SVF_W_STRAT=4\` + \`AI_THEATER_PRIORITY=KGF\`. Run 8 rounds. Tally US sea-zone moves — expect SZ 101 → SZ 102 / 87 / 91 transitions (not just SZ 89 Caribbean).