### PR TITLE
fix(ai): clear Japan movement restriction after declaring war on US (map-room#2766)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -10,7 +10,9 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.properties.GameProperties;
+import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
@@ -196,6 +198,29 @@ public final class ProMatches {
           if (player.getData().getMap().getNeighbors(t).stream()
               .anyMatch(adj -> !adj.isWater() && adj.isOwnedBy(japanese))) {
             return false;
+          }
+        }
+      }
+      // Japan Pacific-reach restriction (Global 1940): Japan's RulesAttachment starts with
+      // movementRestrictionType=disallowed listing 8 sea zones near the US mainland.
+      // triggerAttachment_Japanese_Unrestricted_Movement clears movementRestrictionType once Japan
+      // is at war with the US — but the sidecar never fires triggers. Bypass the stale restriction
+      // list explicitly so Japan AI can plan Pacific offensives (Pearl Harbor, West Coast, etc.).
+      // Mirrors engine movement-validator.ts JAPAN_US_RESTRICTED_SEA_ZONES lifted by areAtWar.
+      if (t.isWater() && "Japanese".equals(player.getName())) {
+        final GamePlayer american = player.getData().getPlayerList().getPlayerId("Americans");
+        if (american != null && player.isAtWar(american)) {
+          final RulesAttachment ra = RulesAttachment.get(player, Constants.RULES_ATTACHMENT_NAME);
+          if (ra != null && ra.isMovementRestrictionTypeDisallowed()) {
+            final String[] restricted = ra.getMovementRestrictionTerritories();
+            if (restricted != null) {
+              for (final String restrictedName : restricted) {
+                if (t.getName().equals(restrictedName)) {
+                  // At war with the US: this zone was restricted only during neutrality. Allow it.
+                  return true;
+                }
+              }
+            }
           }
         }
       }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProJapanMovementRestrictionTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProJapanMovementRestrictionTest.java
@@ -1,0 +1,147 @@
+package games.strategy.triplea.ai.pro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.triplea.Constants;
+import games.strategy.triplea.ai.pro.util.ProMatches;
+import games.strategy.triplea.attachments.RulesAttachment;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Regression test for map-room#2766: Japan's movementRestrictionTerritories (8 Pacific sea zones
+ * near the US mainland) are never cleared by triggerAttachment_Japanese_Unrestricted_Movement
+ * because the sidecar never fires triggers. ProMatches.territoryCanMoveSeaUnits must bypass the
+ * stale restriction list when Japan is at war with the US, mirroring engine movement-validator.ts
+ * JAPAN_US_RESTRICTED_SEA_ZONES which is lifted by the areAtWar check.
+ */
+public class ProJapanMovementRestrictionTest {
+
+  private GameData data;
+  private GamePlayer japanese;
+  private GamePlayer americans;
+  private List<Territory> japanRestrictedZones;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    japanese = data.getPlayerList().getPlayerId("Japanese");
+    americans = data.getPlayerList().getPlayerId("Americans");
+
+    final RulesAttachment ra = RulesAttachment.get(japanese, Constants.RULES_ATTACHMENT_NAME);
+    assumeTrue(ra != null, "Japanese player must have a RulesAttachment in G40");
+    assumeTrue(
+        ra.isMovementRestrictionTypeDisallowed(),
+        "Japanese RulesAttachment must have movementRestrictionType=disallowed in G40");
+    final String[] restricted = ra.getMovementRestrictionTerritories();
+    assumeTrue(
+        restricted != null && restricted.length > 0,
+        "Japanese RulesAttachment must have movementRestrictionTerritories in G40");
+
+    japanRestrictedZones =
+        Arrays.stream(restricted)
+            .map(name -> data.getMap().getTerritoryOrNull(name))
+            .filter(t -> t != null && t.isWater())
+            .toList();
+    assumeTrue(
+        !japanRestrictedZones.isEmpty(),
+        "At least one restricted territory must be a sea zone in G40");
+  }
+
+  /**
+   * Regression guard: while neutral with the US, Japan's movementRestrictionTerritories must remain
+   * blocked by the predicate. This was already correct behaviour before #2766; this test ensures
+   * the fix does not regress it.
+   */
+  @Test
+  void seaUnitPredicateBlocksRestrictedZonesWhileNeutral() {
+    assumeFalse(
+        japanese.isAtWar(americans), "This test only applies when Japan is neutral with the US");
+
+    final Predicate<Territory> canMoveSea = ProMatches.territoryCanMoveSeaUnits(japanese, true);
+    for (final Territory sz : japanRestrictedZones) {
+      assertThat(canMoveSea.test(sz))
+          .as(
+              "territoryCanMoveSeaUnits must block restricted zone '%s' while Japan is neutral"
+                  + " with the US (movementRestrictionType=disallowed should apply)",
+              sz.getName())
+          .isFalse();
+    }
+  }
+
+  /**
+   * Core fix: once Japan is at war with the US, Japan's movementRestrictionTerritories must become
+   * reachable. The trigger that would clear movementRestrictionType on war entry
+   * (triggerAttachment_Japanese_Unrestricted_Movement) never fires on the sidecar.
+   *
+   * <p>Before the fix: the predicate returns {@code false} for all restricted zones even at war —
+   * Japan AI cannot plan Pearl Harbor approach, West Coast attacks, or Central Pacific operations.
+   * After the fix: the predicate returns {@code true} for those zones.
+   */
+  @Test
+  void seaUnitPredicateAllowsRestrictedZonesWhenJapanAtWarWithUs() {
+    // Establish war between Japan and the US.
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            japanese,
+            americans,
+            data.getRelationshipTracker().getRelationshipType(japanese, americans),
+            data.getRelationshipTypeList().getRelationshipType("War")));
+    assertThat(japanese.isAtWar(americans))
+        .as("Precondition: Japan must be at war with Americans after change")
+        .isTrue();
+
+    final Predicate<Territory> canMoveSea = ProMatches.territoryCanMoveSeaUnits(japanese, true);
+    for (final Territory sz : japanRestrictedZones) {
+      assertThat(canMoveSea.test(sz))
+          .as(
+              "territoryCanMoveSeaUnits must allow restricted zone '%s' once Japan is at war with"
+                  + " the US (movementRestrictionType bypass for war entry)",
+              sz.getName())
+          .isTrue();
+    }
+  }
+
+  /**
+   * Non-regression: the US–Japan neutrality check for Americans (map-room#2619 / commit c21271a2)
+   * must not be affected by the Japan fix. Americans neutral with Japan must still be blocked from
+   * sea zones adjacent to Japanese-controlled territories.
+   */
+  @Test
+  void usNeutralityRuleNotAffectedByJapanFix() {
+    assumeFalse(
+        americans.isAtWar(japanese), "This test only applies when Americans is neutral with Japan");
+
+    final List<Territory> japanAdjacentSeaZones =
+        data.getMap().getTerritories().stream()
+            .filter(t -> !t.isWater() && t.isOwnedBy(japanese))
+            .flatMap(t -> data.getMap().getNeighbors(t).stream())
+            .filter(Territory::isWater)
+            .distinct()
+            .toList();
+    assumeTrue(!japanAdjacentSeaZones.isEmpty(), "G40 must have sea zones adjacent to Japan");
+
+    final Predicate<Territory> canMoveSeaUs = ProMatches.territoryCanMoveSeaUnits(americans, false);
+    for (final Territory sz : japanAdjacentSeaZones) {
+      assertThat(canMoveSeaUs.test(sz))
+          .as(
+              "US neutrality Rule 1 must still block Americans from Japan-adjacent zone '%s'"
+                  + " (Japan fix must not affect the US-side predicate)",
+              sz.getName())
+          .isFalse();
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`triggerAttachment_Japanese_Unrestricted_Movement` fires before `japaneseCombatMove` when Japan is at war with the US, clearing `RulesAttachment.movementRestrictionType` so Japan sea units can enter 8 Pacific sea zones near the US mainland. The sidecar never fires triggers — the restriction stays permanently in Java even after war.

**Result**: Japan AI cannot plan Pearl Harbor approach, West Coast attacks, or Central Pacific operations. All 8 zones (SZ 1–3, 8–12) are permanently blocked by the stale restriction list.

## Fix

`ProMatches.territoryCanMoveSeaUnits`: when player is Japanese and at war with Americans, bypass the static `movementRestrictionTerritories` check. Reads Japan's actual restriction list from RulesAttachment (no hardcoded zone names).

Same pattern as map-room#2619 fix (commit c21271a2).

## Tests

`ProJapanMovementRestrictionTest` (3 cases):
- zones blocked while neutral — regression guard ✓
- zones allowed at war — core fix, was failing before ✓  
- US Rule 1 (map-room#2619) unaffected by this change ✓

## Mirror

TS engine: `movement-validator.ts JAPAN_US_RESTRICTED_SEA_ZONES` lifted by `areAtWar` check. No TS changes needed.

Companion: map-room#2762 (US Atlantic restriction, same pattern).
Audit ref: `docs/ai-sidecar/trigger-attachment-audit.md` §3.8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)