### PR TITLE
fix(proai): extend stale-restriction bypass to air movement predicates (#2767)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -56,15 +56,34 @@ public final class ProMatches {
 
   public static Predicate<Territory> territoryCanMoveAirUnits(
       final GameState data, final GamePlayer player, final boolean isCombatMove) {
-    return Matches.territoryDoesNotCostMoneyToEnter(data.getProperties())
-        .and(
-            Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(
-                player, isCombatMove, false, false, true, false));
+    final GameProperties properties = data.getProperties();
+    return t -> {
+      final boolean passable =
+          Matches.territoryDoesNotCostMoneyToEnter(properties)
+              .and(
+                  Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(
+                      player, isCombatMove, false, false, true, false))
+              .test(t);
+      if (passable) {
+        return true;
+      }
+      return shouldBypassStaleMovementRestriction(player, t, properties, isCombatMove);
+    };
   }
 
   public static Predicate<Territory> territoryCanPotentiallyMoveAirUnits(final GamePlayer player) {
-    return Matches.territoryDoesNotCostMoneyToEnter(player.getData().getProperties())
-        .and(Matches.territoryIsPassableAndNotRestricted(player));
+    final GameProperties properties = player.getData().getProperties();
+    return t -> {
+      final boolean passable =
+          Matches.territoryDoesNotCostMoneyToEnter(properties)
+              .and(Matches.territoryIsPassableAndNotRestricted(player))
+              .test(t);
+      if (passable) {
+        return true;
+      }
+      // isCombatMove=false: potential check has no combat-phase relationship constraint
+      return shouldBypassStaleMovementRestriction(player, t, properties, false);
+    };
   }
 
   public static Predicate<Territory> territoryCanMoveAirUnitsAndNoAa(
@@ -204,8 +223,85 @@ public final class ProMatches {
               .and(
                   Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(
                       player, isCombatMove, false, true, false, false));
-      return match.test(t);
+      if (match.test(t)) {
+        return true;
+      }
+      // map-room#2755 PR-J: simulate the cleared-restriction state when at war with axis.
+      // 1940 Global encodes the US/Japan/Russia "neutrality act" as a static XML list
+      // (RulesAttachment.movementRestrictionTerritories) plus a TriggerAttachment that
+      // clears the list once at war with an axis power. The sidecar is stateless per
+      // HTTP request, so it never executes the game-step boundary the trigger fires on
+      // — the list persists. The live TS engine implements the same rule procedurally
+      // (movement-validator.ts:getUSNeutralityRestriction) and lifts it on war, so AI
+      // and engine disagree on Atlantic reachability for the US once at war. Override
+      // here: if the only thing blocking the move is the stale-XML restriction list AND
+      // the player is at war with an axis, accept.
+      return shouldBypassStaleMovementRestriction(player, t, properties, isCombatMove);
     };
+  }
+
+  /**
+   * Returns {@code true} if {@code t} is rejected SOLELY by the static-XML {@code
+   * movementRestrictionTerritories} list and the player is at war with at least one axis power.
+   * Mirrors the effect of the {@code triggerAttachment_Americans_Unrestricted_Movement} XML trigger
+   * that the stateless sidecar cannot fire. Returns false (= preserve the rejection) when the
+   * property isn't set, when the player isn't at war with any axis, or when the territory isn't in
+   * the restriction list. Re-checks the non-restriction conditions (impassable, money cost,
+   * canMoveIntoDuringCombatMove) so territories blocked for OTHER reasons stay blocked.
+   */
+  private static boolean shouldBypassStaleMovementRestriction(
+      final GamePlayer player,
+      final Territory t,
+      final GameProperties properties,
+      final boolean isCombatMove) {
+    if (!Properties.getMovementByTerritoryRestricted(properties)) {
+      return false;
+    }
+    if (!isAtWarWithAnyAxis(player)) {
+      return false;
+    }
+    final games.strategy.triplea.attachments.RulesAttachment ra = player.getRulesAttachment();
+    if (ra == null) {
+      return false;
+    }
+    final String[] restrictionNames = ra.getMovementRestrictionTerritories();
+    if (restrictionNames == null || restrictionNames.length == 0) {
+      return false;
+    }
+    final java.util.Collection<Territory> listedTerritories =
+        ra.getListedTerritories(restrictionNames, true, true);
+    final boolean isInList = listedTerritories.contains(t);
+    final boolean isAllowedList = ra.isMovementRestrictionTypeAllowed();
+    final boolean blockedByRestriction = isAllowedList ? !isInList : isInList;
+    if (!blockedByRestriction) {
+      return false;
+    }
+    if (Matches.territoryIsImpassable().test(t)) {
+      return false;
+    }
+    if (!Matches.territoryDoesNotCostMoneyToEnter(properties).test(t)) {
+      return false;
+    }
+    if (isCombatMove
+        && !player
+            .getData()
+            .getRelationshipTracker()
+            .canMoveIntoDuringCombatMove(player, t.getOwner())) {
+      return false;
+    }
+    return true;
+  }
+
+  /** Returns true if {@code player} is at war with any of the Axis powers (1940 Global roster). */
+  private static boolean isAtWarWithAnyAxis(final GamePlayer player) {
+    final games.strategy.engine.data.PlayerList players = player.getData().getPlayerList();
+    for (final String axisName : new String[] {"Germans", "Italians", "Japanese"}) {
+      final GamePlayer axis = players.getPlayerId(axisName);
+      if (axis != null && player.isAtWar(axis)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public static Predicate<Territory> territoryCanMoveSeaUnitsThrough(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProMatchesStaleRestrictionTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProMatchesStaleRestrictionTest.java
@@ -1,0 +1,171 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Verifies that ProMatches bypasses the stale {@code movementRestrictionTerritories} XML list for
+ * sea and air movement predicates. The sidecar never fires TriggerAttachments, so the list (which
+ * the trigger would clear on war declaration) persists and incorrectly blocks AI planning.
+ *
+ * <p>Covers both code paths that read {@code movementRestrictionTerritories} in ProMatches:
+ *
+ * <ul>
+ *   <li>{@code territoryCanMoveSeaUnits} — via {@code
+ *       territoryIsPassableAndNotRestrictedAndOkByRelationships}
+ *   <li>{@code territoryCanMoveAirUnits} — same predicate, separate call site
+ *   <li>{@code territoryCanPotentiallyMoveAirUnits} — via {@code
+ *       territoryIsPassableAndNotRestricted}
+ * </ul>
+ *
+ * <p>See map-room#2755 (PR-J bypass) and map-room#2767 (air-path gap follow-up).
+ */
+class ProMatchesStaleRestrictionTest {
+
+  /** Atlantic sea zone in the US disallowed list — blocked while neutral. */
+  private static final String RESTRICTED_ATLANTIC = "103 Sea Zone";
+
+  /** Atlantic sea zone NOT in the restriction list — control case. */
+  private static final String UNRESTRICTED_ATLANTIC = "102 Sea Zone";
+
+  private GameData data;
+  private GamePlayer americans;
+  private GamePlayer germans;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+    germans = data.getPlayerList().getPlayerId("Germans");
+  }
+
+  private void setAtWarWithGermans() {
+    data.performChange(
+        games.strategy.engine.data.changefactory.ChangeFactory.relationshipChange(
+            americans,
+            germans,
+            data.getRelationshipTracker().getRelationshipType(americans, germans),
+            data.getRelationshipTypeList().getRelationshipType("War")));
+  }
+
+  // ── Sea unit tests (restores map-room#2755 / triplea#143 coverage) ──────────
+
+  @Nested
+  class SeaUnits {
+
+    @Test
+    void restrictedZoneBlockedAtGameStart() {
+      final Territory sz103 = data.getMap().getTerritoryOrThrow(RESTRICTED_ATLANTIC);
+      final Predicate<Territory> canMoveSea = ProMatches.territoryCanMoveSeaUnits(americans, true);
+
+      assertThat(canMoveSea.test(sz103))
+          .as("Baseline: US neutral, XML restriction blocks SZ 103")
+          .isFalse();
+    }
+
+    @Test
+    void restrictedZoneAcceptedAfterWarWithGermans() {
+      setAtWarWithGermans();
+      final Territory sz103 = data.getMap().getTerritoryOrThrow(RESTRICTED_ATLANTIC);
+      final Predicate<Territory> canMoveSea = ProMatches.territoryCanMoveSeaUnits(americans, true);
+
+      assertThat(canMoveSea.test(sz103))
+          .as("After war with Germans, AI bypass must accept SZ 103 for sea units")
+          .isTrue();
+    }
+
+    @Test
+    void unrestrictedZoneAcceptedRegardlessOfWarState() {
+      final Territory sz102 = data.getMap().getTerritoryOrThrow(UNRESTRICTED_ATLANTIC);
+      final Predicate<Territory> canMoveSea = ProMatches.territoryCanMoveSeaUnits(americans, true);
+
+      assertThat(canMoveSea.test(sz102))
+          .as("SZ 102 not in restriction list — accepted neutral")
+          .isTrue();
+
+      setAtWarWithGermans();
+      assertThat(canMoveSea.test(sz102)).as("SZ 102 still accepted post-war").isTrue();
+    }
+  }
+
+  // ── Air unit tests (map-room#2767 — gap not covered by triplea#143) ─────────
+
+  @Nested
+  class AirUnits {
+
+    @Test
+    void restrictedZoneBlockedAtGameStart() {
+      final Territory sz103 = data.getMap().getTerritoryOrThrow(RESTRICTED_ATLANTIC);
+      final Predicate<Territory> canMoveAir =
+          ProMatches.territoryCanMoveAirUnits(data, americans, true);
+
+      assertThat(canMoveAir.test(sz103))
+          .as("Baseline: US neutral, XML restriction blocks SZ 103 for air units")
+          .isFalse();
+    }
+
+    @Test
+    void restrictedZoneAcceptedAfterWarWithGermans() {
+      setAtWarWithGermans();
+      final Territory sz103 = data.getMap().getTerritoryOrThrow(RESTRICTED_ATLANTIC);
+      final Predicate<Territory> canMoveAir =
+          ProMatches.territoryCanMoveAirUnits(data, americans, true);
+
+      assertThat(canMoveAir.test(sz103))
+          .as("After war with Germans, AI bypass must accept SZ 103 for air units")
+          .isTrue();
+    }
+
+    @Test
+    void unrestrictedZoneAcceptedRegardlessOfWarState() {
+      final Territory sz102 = data.getMap().getTerritoryOrThrow(UNRESTRICTED_ATLANTIC);
+      final Predicate<Territory> canMoveAir =
+          ProMatches.territoryCanMoveAirUnits(data, americans, true);
+
+      assertThat(canMoveAir.test(sz102)).as("SZ 102 not in list — accepted neutral").isTrue();
+
+      setAtWarWithGermans();
+      assertThat(canMoveAir.test(sz102)).as("SZ 102 still accepted post-war").isTrue();
+    }
+  }
+
+  // ── Potential air unit tests ─────────────────────────────────────────────────
+
+  @Nested
+  class PotentialAirUnits {
+
+    @Test
+    void restrictedZoneBlockedAtGameStart() {
+      final Territory sz103 = data.getMap().getTerritoryOrThrow(RESTRICTED_ATLANTIC);
+      final Predicate<Territory> canPotentiallyMoveAir =
+          ProMatches.territoryCanPotentiallyMoveAirUnits(americans);
+
+      assertThat(canPotentiallyMoveAir.test(sz103))
+          .as("Baseline: potential air check blocks SZ 103 while US neutral")
+          .isFalse();
+    }
+
+    @Test
+    void restrictedZoneAcceptedAfterWarWithGermans() {
+      setAtWarWithGermans();
+      final Territory sz103 = data.getMap().getTerritoryOrThrow(RESTRICTED_ATLANTIC);
+      final Predicate<Territory> canPotentiallyMoveAir =
+          ProMatches.territoryCanPotentiallyMoveAirUnits(americans);
+
+      assertThat(canPotentiallyMoveAir.test(sz103))
+          .as("After war, potential air check must accept SZ 103 so path-planning is not blocked")
+          .isTrue();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Verification of triplea#143 (PR-J, merged 2026-05-27) found two gaps:

1. **Air-unit bypass missing.** #143 patched `territoryCanMoveSeaUnits` but two additional ProMatches predicates also read `movementRestrictionTerritories` without a bypass:
   - `territoryCanMoveAirUnits` — the real air movement reachability check
   - `territoryCanPotentiallyMoveAirUnits` — the path-planning pre-filter (if this returns false, the real check is never reached)

   US bombers/fighters routing through restricted Atlantic sea zones (SZ 103, 106, etc.) were incorrectly blocked by the stale XML list even after declaring war on an Axis power.

2. **#143's bypass code was accidentally wiped.** When PR #146 (Japan-side fix) was reverted, the revert commit undid `shouldBypassStaleMovementRestriction` + `isAtWarWithAnyAxis` and the sea-unit bypass from #143. Those helpers are restored here.

## Changes

- Restore `shouldBypassStaleMovementRestriction` / `isAtWarWithAnyAxis` helpers (erased by #146 revert)
- Restore bypass in `territoryCanMoveSeaUnits` (erased by #146 revert)
- Extend bypass to `territoryCanMoveAirUnits` (new — #2767 gap)
- Extend bypass to `territoryCanPotentiallyMoveAirUnits` (new — #2767 gap)
- Restore + expand `ProMatchesStaleRestrictionTest` with 7 cases across all three predicates

## Test plan

- [x] `ProMatchesStaleRestrictionTest` — 7 tests: sea/air/potential-air × blocked-neutral / accepted-at-war / unrestricted-control
- [x] Spotless applied, build clean

Related: map-room#2755 (PR-J epic), map-room#2767 (verification issue), triplea#143 (US sea-unit fix)

Note: Japan-side bypass (#2766 / triplea#146) was also erased by the revert — that is a separate issue.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>