### PR TITLE
fix(proai): PR-F transport staging — use TransportList not TransportMoveMap (map-room#2755)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -225,7 +225,7 @@ class ProNonCombatMoveAi {
     // amphib-defense pull instead of heading toward Europe. US-only, dormant unless wStrat > 0
     // so PR-F is zero-impact at SVF defaults.
     ProTransportStaging.stageIdleTransports(
-        proData, player, territoryManager.getDefendOptions().getTransportMoveMap(), moveMap);
+        proData, player, territoryManager.getDefendOptions().getTransportList(), moveMap);
 
     // Calculate move routes and perform moves
     doMove(isCombatMove, moveMap, moveDel, data, player);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportStaging.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportStaging.java
@@ -8,6 +8,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.ai.pro.ProData;
 import games.strategy.triplea.ai.pro.data.ProTerritory;
+import games.strategy.triplea.ai.pro.data.ProTransport;
 import games.strategy.triplea.ai.pro.logging.ProLogger;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
@@ -55,12 +56,10 @@ public final class ProTransportStaging {
   public static int stageIdleTransports(
       final ProData proData,
       final GamePlayer player,
-      final Map<Unit, Set<Territory>> transportMoveMap,
+      final List<ProTransport> transportList,
       final Map<Territory, ProTerritory> moveMap) {
     // PR-F diagnostic: one summary line per call so we can see exactly which gate is firing
     // (or whether the gate passes but no transports get staged because all are committed).
-    // Always emits when player is US, regardless of activation state — so a missing wStrat
-    // shows up in logs as "active=false" rather than no log at all.
     final boolean isUs = player != null && "Americans".equals(player.getName());
     if (!isStagingActive(proData, player)) {
       if (isUs) {
@@ -87,13 +86,13 @@ public final class ProTransportStaging {
     final Set<Unit> alreadyAssigned = collectAssignedTransports(moveMap);
     alreadyAssigned.addAll(proData.getTransportsToHold());
 
-    int totalTransports = transportMoveMap.size();
+    int totalTransports = transportList.size();
     int skippedAssigned = 0;
     int skippedNullSource = 0;
     int skippedNoImprovement = 0;
     int staged = 0;
-    for (final Map.Entry<Unit, Set<Territory>> entry : transportMoveMap.entrySet()) {
-      final Unit transport = entry.getKey();
+    for (final ProTransport pt : transportList) {
+      final Unit transport = pt.getTransport();
       if (alreadyAssigned.contains(transport)) {
         skippedAssigned++;
         continue;
@@ -103,8 +102,13 @@ public final class ProTransportStaging {
         skippedNullSource++;
         continue;
       }
+      // ProTransport.seaTransportMap keys are sea zones reachable by this transport. The
+      // values are the load-from territories — we don't need them here since staging is a
+      // sea-only move. Empty seaTransportMap (e.g. for a fully-blocked transport) falls
+      // through as no-improvement.
+      final Set<Territory> reachableSeaZones = pt.getSeaTransportMap().keySet();
       final Territory bestSz =
-          pickBestStagingZone(currentSz, entry.getValue(), svf, map, player, data, transport);
+          pickBestStagingZone(currentSz, reachableSeaZones, svf, map, player, data, transport);
       if (bestSz == null || bestSz.equals(currentSz)) {
         skippedNoImprovement++;
         continue;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProTransportStagingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProTransportStagingTest.java
@@ -11,6 +11,7 @@ import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,7 +97,7 @@ class ProTransportStagingTest {
     // wStrat=0 by default. Even with transport-move-map containing transports + reachable
     // sea zones, no staging should happen.
     final int staged =
-        ProTransportStaging.stageIdleTransports(proData, americans, Map.of(), new HashMap<>());
+        ProTransportStaging.stageIdleTransports(proData, americans, List.of(), new HashMap<>());
     assertThat(staged).as("Inactive staging returns 0 immediately").isZero();
   }
 
@@ -105,7 +106,7 @@ class ProTransportStagingTest {
     proData.setWStrat(4.0);
     proData.setStrategicValueField(null);
     final int staged =
-        ProTransportStaging.stageIdleTransports(proData, americans, Map.of(), new HashMap<>());
+        ProTransportStaging.stageIdleTransports(proData, americans, List.of(), new HashMap<>());
     assertThat(staged).as("Staging requires a populated SVF; null short-circuits").isZero();
   }
 


### PR DESCRIPTION
Diagnostic from PR-F+ revealed staging was reading the wrong data source: `defendOptions.getTransportMoveMap()` holds non-transport sea units. Transports live in `defendOptions.getTransportList()` as `ProTransport` objects with `seaTransportMap.keySet()` for reachable zones.

Changes the signature + wire site + test to use the right data structure. No behavior change beyond the staging hook actually firing now.