### PR TITLE
fix(ai-sidecar): activate SupportAttachment for Improved Mech Inf tech (#2768)

### DIFF
--- a/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
+++ b/game-app/ai-sidecar/src/main/java/org/triplea/ai/sidecar/wire/WireStateApplier.java
@@ -83,6 +83,14 @@ public final class WireStateApplier {
       gameData.performChange(changes);
     }
 
+    // Some techs activate a UnitSupportAttachment via a TriggerAttachment that the stateless
+    // sidecar never fires (map-room#2768). After tech flags are live in GameData, apply the
+    // support-list changes directly — mirroring what TriggerAttachment.triggerSupportChange()
+    // would do. Multiple players with the same tech must be batched into a single change per
+    // support attachment so that each player's activation reads the cumulative current-players
+    // list.
+    applyTechSupportActivations(gameData, wire);
+
     // Hydrate RelationshipTracker directly — must happen before the politics step (Task 8) runs
     // on this same GameData so that invokePoliticsForSidecar sees the current relationship graph.
     // Direct setter is used (not ChangeFactory.relationshipChange) to ensure in-memory visibility
@@ -666,4 +674,79 @@ public final class WireStateApplier {
           Map.entry("mechanizedInfantry", "mechanizedInfantry"),
           Map.entry("aaRadar", "aaRadar"),
           Map.entry("shipyards", "shipyards"));
+
+  // TechAttachment property name -> UnitSupportAttachment name.
+  // Each entry here is a tech whose activation fires a TriggerAttachment that adds the player
+  // to a UnitSupportAttachment.players list. The sidecar never fires triggers, so we apply
+  // the effect directly. Source: ww2global40_2nd_edition.xml
+  // §triggerAttachment_*_Improved_Mech_Inf.
+  private static final Map<String, String> TECH_TO_SUPPORT_ATTACHMENT =
+      Map.of("mechanizedInfantry", "supportAttachmentMechanizedTechnology");
+
+  /**
+   * For each UnitSupportAttachment that any player's tech list activates, adds all such players to
+   * the attachment's {@code players} field in one atomic change. Multiple players with the same
+   * tech must be batched together: individual calls would each read the pre-applied players list
+   * and overwrite each other. Running this after the main {@link GameData#performChange} ensures
+   * the tech flags are live and the current players list is up to date.
+   */
+  private static void applyTechSupportActivations(final GameData gameData, final WireState wire) {
+    final Map<String, List<GamePlayer>> supportToPlayers = new HashMap<>();
+    for (final WirePlayer wp : wire.players()) {
+      if (wp.tech() == null || wp.tech().isEmpty()) {
+        continue;
+      }
+      final GamePlayer player = gameData.getPlayerList().getPlayerId(wp.playerId());
+      if (player == null) {
+        continue;
+      }
+      for (final String techName : wp.tech()) {
+        final String property = TECH_PROPERTY_NAMES.get(techName);
+        if (property == null) {
+          continue;
+        }
+        final String supportName = TECH_TO_SUPPORT_ATTACHMENT.get(property);
+        if (supportName != null) {
+          supportToPlayers.computeIfAbsent(supportName, k -> new ArrayList<>()).add(player);
+        }
+      }
+    }
+    if (supportToPlayers.isEmpty()) {
+      return;
+    }
+    final CompositeChange supportChanges = new CompositeChange();
+    for (final Map.Entry<String, List<GamePlayer>> entry : supportToPlayers.entrySet()) {
+      final String supportName = entry.getKey();
+      final List<GamePlayer> newPlayers = entry.getValue();
+      boolean found = false;
+      for (final UnitType ut : gameData.getUnitTypeList()) {
+        final games.strategy.engine.data.IAttachment raw = ut.getAttachment(supportName);
+        if (!(raw instanceof games.strategy.triplea.attachments.UnitSupportAttachment usa)) {
+          continue;
+        }
+        final List<GamePlayer> combined = new ArrayList<>(usa.getPlayers());
+        for (final GamePlayer p : newPlayers) {
+          if (!combined.contains(p)) {
+            combined.add(p);
+          }
+        }
+        if (combined.size() != usa.getPlayers().size()) {
+          supportChanges.add(ChangeFactory.attachmentPropertyChange(usa, combined, "players"));
+        }
+        found = true;
+        break;
+      }
+      if (!found) {
+        LOG.log(
+            Level.WARNING,
+            () ->
+                "Tech support activation: support attachment '"
+                    + supportName
+                    + "' not found in game data — skipping");
+      }
+    }
+    if (!supportChanges.isEmpty()) {
+      gameData.performChange(supportChanges);
+    }
+  }
 }

--- a/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTechSupportTest.java
+++ b/game-app/ai-sidecar/src/test/java/org/triplea/ai/sidecar/wire/WireStateApplierTechSupportTest.java
@@ -1,0 +1,154 @@
+package org.triplea.ai.sidecar.wire;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.attachments.TechAttachment;
+import games.strategy.triplea.attachments.UnitSupportAttachment;
+import games.strategy.triplea.settings.ClientSetting;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.ai.sidecar.CanonicalGameData;
+
+/**
+ * Verifies that WireStateApplier activates the {@code supportAttachmentMechanizedTechnology}
+ * UnitSupportAttachment for any player whose wire tech list includes {@code "mechanizedInfantry"}.
+ *
+ * <p>The sidecar never fires TriggerAttachments (stateless per HTTP request), so the support
+ * attachment's {@code players} list — initially empty in the XML — is never populated by the
+ * trigger. WireStateApplier must apply the effect directly. Without this fix, ProAi battle
+ * simulation ignores the armor-vs-mech-infantry +1 offence bonus even when the tech is researched.
+ *
+ * <p>See map-room#2768.
+ */
+class WireStateApplierTechSupportTest {
+
+  private static final String SUPPORT_ATTACHMENT = "supportAttachmentMechanizedTechnology";
+
+  private static CanonicalGameData canonical;
+
+  @BeforeAll
+  static void initPrefs() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    canonical = CanonicalGameData.load();
+  }
+
+  private GameData fresh() {
+    return canonical.cloneForSession();
+  }
+
+  private ConcurrentMap<String, UUID> freshIdMap() {
+    return new ConcurrentHashMap<>();
+  }
+
+  private UnitSupportAttachment findMechTechSupport(final GameData gd) {
+    final UnitType armour = gd.getUnitTypeList().getUnitType("armour").orElse(null);
+    assertThat(armour).as("armour unit type must exist in game data").isNotNull();
+    return UnitSupportAttachment.get(armour).stream()
+        .filter(usa -> SUPPORT_ATTACHMENT.equals(usa.getName()))
+        .findFirst()
+        .orElseThrow(
+            () -> new AssertionError(SUPPORT_ATTACHMENT + " not found on armour unit type"));
+  }
+
+  @Test
+  void mechanizedInfantryTech_addsPlayerToSupportAttachment() {
+    final GameData gd = fresh();
+    final WireState wire =
+        new WireState(
+            List.of(),
+            List.of(new WirePlayer("Germans", 40, List.of("mechanizedInfantry"), false)),
+            1,
+            "combat",
+            "Germans",
+            List.of());
+
+    WireStateApplier.apply(gd, wire, freshIdMap());
+
+    final GamePlayer germans = gd.getPlayerList().getPlayerId("Germans");
+    final UnitSupportAttachment usa = findMechTechSupport(gd);
+
+    assertThat(usa.getPlayers())
+        .as("Germans must be in supportAttachmentMechanizedTechnology.players after tech applied")
+        .contains(germans);
+  }
+
+  @Test
+  void mechanizedInfantryTech_alsoSetsTechAttachmentFlag() {
+    final GameData gd = fresh();
+    final WireState wire =
+        new WireState(
+            List.of(),
+            List.of(new WirePlayer("Americans", 40, List.of("mechanizedInfantry"), false)),
+            1,
+            "combat",
+            "Americans",
+            List.of());
+
+    WireStateApplier.apply(gd, wire, freshIdMap());
+
+    final TechAttachment ta = gd.getPlayerList().getPlayerId("Americans").getTechAttachment();
+    assertThat(ta.getMechanizedInfantry())
+        .as("TechAttachment.mechanizedInfantry must be true after wire apply")
+        .isTrue();
+  }
+
+  @Test
+  void withoutTech_playerNotInSupportAttachment() {
+    final GameData gd = fresh();
+    final WireState wire =
+        new WireState(
+            List.of(),
+            List.of(new WirePlayer("Russians", 40, List.of(), false)),
+            1,
+            "combat",
+            "Russians",
+            List.of());
+
+    WireStateApplier.apply(gd, wire, freshIdMap());
+
+    final GamePlayer russians = gd.getPlayerList().getPlayerId("Russians");
+    final UnitSupportAttachment usa = findMechTechSupport(gd);
+
+    assertThat(usa.getPlayers())
+        .as("Russians must NOT be in support attachment when tech is absent")
+        .doesNotContain(russians);
+  }
+
+  @Test
+  void multiplePlayersWithTech_allAddedToSupportAttachment() {
+    final GameData gd = fresh();
+    final WireState wire =
+        new WireState(
+            List.of(),
+            List.of(
+                new WirePlayer("Germans", 40, List.of("mechanizedInfantry"), false),
+                new WirePlayer("Japanese", 40, List.of("mechanizedInfantry"), false),
+                new WirePlayer("Italians", 40, List.of(), false)),
+            1,
+            "combat",
+            "Germans",
+            List.of());
+
+    WireStateApplier.apply(gd, wire, freshIdMap());
+
+    final UnitSupportAttachment usa = findMechTechSupport(gd);
+    final GamePlayer german = gd.getPlayerList().getPlayerId("Germans");
+    final GamePlayer japanese = gd.getPlayerList().getPlayerId("Japanese");
+    final GamePlayer italian = gd.getPlayerList().getPlayerId("Italians");
+
+    assertThat(usa.getPlayers())
+        .as("Both tech-holders must be in support attachment")
+        .contains(german, japanese);
+    assertThat(usa.getPlayers())
+        .as("Non-tech-holder must not be in support attachment")
+        .doesNotContain(italian);
+  }
+}


### PR DESCRIPTION
## Problem

`WireStateApplier` sets `TechAttachment.mechanizedInfantry = true` but never
adds the player to `supportAttachmentMechanizedTechnology.players`. The sidecar
is stateless per HTTP request and never fires `TriggerAttachment`s — the trigger
that normally populates the players list never runs.

`SupportCalculator` skips any support rule whose players list is empty, so the
armour-vs-mech-infantry +1 offence bonus is invisible to ProAi battle simulation
even when the tech is researched.

## Fix

After tech flags are committed to `GameData`, call a new
`applyTechSupportActivations()` batch method that:

1. Collects all players whose wire tech list maps to a support attachment name.
2. Reads the attachment's current players list (already-activated players from
   prior rounds/calls are preserved).
3. Issues a **single** `ChangeFactory.attachmentPropertyChange` per attachment
   with the full combined list — avoiding the sequential-override bug where
   the second player's activation would silently overwrite the first.

The `TECH_TO_SUPPORT_ATTACHMENT` map is the extension point for any future
tech that activates a support attachment via trigger.

## Tests

`WireStateApplierTechSupportTest` (4 cases):
- Single player with tech → added to `supportAttachmentMechanizedTechnology.players`
- `TechAttachment.getMechanizedInfantry()` also returns true
- Player without tech → not added
- Two players with tech + one without → both added, non-tech-holder excluded

## Gates

- [x] `spotlessCheck` passes
- [x] `WireStateApplierTechSupportTest` — all 4 tests pass
- [x] Full `ai-sidecar:test` suite — BUILD SUCCESSFUL

Closes map-room/map-room#2768

🤖 Generated with [Claude Code](https://claude.com/claude-code)