### PR TITLE
fix(ai): claimFriendlyNeutralTerritories handles sea-isolated Pro-Allies via amphib

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -419,6 +419,7 @@ class ProNonCombatMoveAi {
     // This mirrors sortUnitMoveOptions tie-breaking and guarantees every reachable
     // Friendly_Neutral gets a unit if one is available (#2195).
     final Set<Unit> usedUnits = new HashSet<>();
+    final Set<Territory> landClaimed = new HashSet<>();
     for (final Territory t : toClaim) {
       final Unit chosen =
           candidates.get(t).stream()
@@ -434,7 +435,76 @@ class ProNonCombatMoveAi {
       moveMap.get(t).addUnit(chosen);
       unitMoveMap.remove(chosen);
       usedUnits.add(chosen);
+      landClaimed.add(t);
       ProLogger.debug(t + ", claimed Friendly_Neutral with: " + chosen);
+    }
+
+    // Amphib pass: for sea-isolated friendly neutrals not reachable by land, assign one
+    // infantry+transport pair from the transport map (Brazil, Liberia, Saudi Arabia, etc.).
+    // Prefer land path when available — only run for territories the land loop left unclaimed.
+    final List<ProTransport> transportMapList =
+        territoryManager.getDefendOptions().getTransportList();
+    final Map<Unit, Set<Territory>> transportMoveMap =
+        territoryManager.getDefendOptions().getTransportMoveMap();
+    final Set<Unit> usedTransports = new HashSet<>();
+    for (final Territory dest : toClaim) {
+      if (landClaimed.contains(dest)) {
+        continue;
+      }
+      Unit committedTransport = null;
+      for (final ProTransport pt : transportMapList) {
+        final Unit transport = pt.getTransport();
+        if (usedTransports.contains(transport)) {
+          continue;
+        }
+        final Set<Territory> loadFromTerritories = pt.getTransportMap().get(dest);
+        if (loadFromTerritories == null || loadFromTerritories.isEmpty()) {
+          continue;
+        }
+        // Find an adjacent sea zone this transport can reach.
+        Territory seaZone = null;
+        for (final Territory sz : data.getMap().getNeighbors(dest)) {
+          if (sz.isWater() && pt.getSeaTransportMap().containsKey(sz)) {
+            seaZone = sz;
+            break;
+          }
+        }
+        if (seaZone == null) {
+          continue;
+        }
+        // Get one transportable infantry not already committed.
+        final List<Unit> amphibUnits =
+            ProTransportUtils.getUnitsToTransportFromTerritories(
+                player, transport, loadFromTerritories, usedUnits);
+        if (amphibUnits.isEmpty()) {
+          continue;
+        }
+        final List<Unit> claimUnits = List.of(amphibUnits.get(0));
+        moveMap.get(dest).addUnit(claimUnits.get(0));
+        moveMap.get(dest).getTransportTerritoryMap().put(transport, seaZone);
+        moveMap.get(dest).putAmphibAttackMap(transport, claimUnits);
+        usedUnits.add(claimUnits.get(0));
+        usedTransports.add(transport);
+        unitMoveMap.remove(claimUnits.get(0));
+        unitMoveMap.remove(transport);
+        committedTransport = transport;
+        ProLogger.debug(
+            dest
+                + ", claimed sea-isolated Friendly_Neutral via amphib: "
+                + claimUnits.get(0)
+                + " on "
+                + transport
+                + " via "
+                + seaZone);
+        break;
+      }
+      // Remove the committed transport from all shared move maps so later NCM phases
+      // (moveUnitsToBestTerritories) don't re-assign it to a different destination.
+      if (committedTransport != null) {
+        final Unit finalTransport = committedTransport;
+        transportMapList.removeIf(pt -> pt.getTransport().equals(finalTransport));
+        transportMoveMap.remove(finalTransport);
+      }
     }
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProAmphibClaimFriendlyNeutralTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProAmphibClaimFriendlyNeutralTest.java
@@ -1,0 +1,196 @@
+package games.strategy.triplea.ai.pro;
+
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.MoveDescription;
+import games.strategy.engine.data.RelationshipType;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.player.PlayerBridge;
+import games.strategy.triplea.delegate.remote.IMoveDelegate;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Regression tests for {@link ProNonCombatMoveAi#claimFriendlyNeutralTerritories} amphib path
+ * (triplea#144).
+ *
+ * <p>Before the fix the claim step only iterated {@code unitMoveMap} (land-adjacent moves), so
+ * sea-isolated Friendly_Neutral territories — Brazil, Liberia, Saudi Arabia, Pacific Pro-Allies —
+ * were never claimed even when a transport with loaded capacity was within range.
+ *
+ * <p>After the fix a parallel loop over {@code transportMapList} assigns one infantry+transport
+ * pair to any sea-isolated Friendly_Neutral destination that has no land candidate.
+ */
+public class ProAmphibClaimFriendlyNeutralTest {
+
+  private GameData data;
+  private GamePlayer americans;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    americans = data.getPlayerList().getPlayerId("Americans");
+  }
+
+  /**
+   * With a US transport at SZ 87 and a US infantry at Liberia (adjacent to SZ 87, NOT adjacent to
+   * Brazil), the noncombat planner must dispatch an amphib move that ends in Brazil.
+   *
+   * <p>Setup topology:
+   *
+   * <pre>
+   *   Liberia ──── 87 Sea Zone ──── 86 Sea Zone ──── Brazil
+   *                                                (Neutral_Allies)
+   * </pre>
+   *
+   * <p>Brazil has no land-adjacent Allied territory with a player unit, so the land loop in {@link
+   * ProNonCombatMoveAi#claimFriendlyNeutralTerritories} leaves it unclaimed. The amphib pass must
+   * pick it up (regression: triplea#144).
+   */
+  @Test
+  void claimsSeaIsolatedBrazilViaAmphibMove() {
+    final Territory liberia = data.getMap().getTerritoryOrThrow("Liberia");
+    final Territory sz87 = data.getMap().getTerritoryOrThrow("87 Sea Zone");
+    final Territory sz86 = data.getMap().getTerritoryOrThrow("86 Sea Zone");
+    final Territory brazil = data.getMap().getTerritoryOrThrow("Brazil");
+
+    // Preconditions: confirm the topology this test relies on.
+    assertThat(data.getMap().getNeighbors(sz87)).as("SZ 87 must border Liberia").contains(liberia);
+    assertThat(data.getMap().getNeighbors(sz87)).as("SZ 87 must border SZ 86").contains(sz86);
+    assertThat(data.getMap().getNeighbors(sz86)).as("SZ 86 must border Brazil").contains(brazil);
+    assertThat(data.getMap().getNeighbors(liberia))
+        .as("Liberia must NOT be adjacent to Brazil (so no land path exists)")
+        .doesNotContain(brazil);
+
+    // Advance to post-war state: change Americans-Neutral_Allies to Friendly_Neutral.
+    // In round 1 the relationship is "Neutrality" — the bug only manifests once the US is at war
+    // and Neutral_Allies territories become claimable (Friendly_Neutral has archeType="allied").
+    final GamePlayer neutralAllies = data.getPlayerList().getPlayerId("Neutral_Allies");
+    final RelationshipType friendlyNeutral =
+        data.getRelationshipTypeList().getRelationshipType("Friendly_Neutral");
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            americans,
+            neutralAllies,
+            data.getRelationshipTracker().getRelationshipType(americans, neutralAllies),
+            friendlyNeutral));
+
+    // Set Americans at war with Germans so the US Neutrality Act movement restriction is bypassed.
+    // ProMatches.shouldBypassStaleMovementRestriction only lifts the XML
+    // movementRestrictionTerritories
+    // list when isAtWarWithAnyAxis(player)=true; without this, SZ 86 fails canMoveSeaThrough and
+    // Brazil never enters moveMap, so toClaim is empty and the amphib pass never runs.
+    final GamePlayer germans = data.getPlayerList().getPlayerId("Germans");
+    final RelationshipType war = data.getRelationshipTypeList().getRelationshipType("War");
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            americans,
+            germans,
+            data.getRelationshipTracker().getRelationshipType(americans, germans),
+            war));
+
+    // Place a US transport at SZ 87 and a US infantry at Liberia.
+    final UnitType infantryType = data.getUnitTypeList().getUnitTypeOrThrow("infantry");
+    final UnitType transportType = data.getUnitTypeList().getUnitTypeOrThrow("transport");
+    final Unit usInfantry = infantryType.create(1, americans).get(0);
+    final Unit usTransport = transportType.create(1, americans).get(0);
+    data.performChange(ChangeFactory.addUnits(liberia, List.of(usInfantry)));
+    data.performChange(ChangeFactory.addUnits(sz87, List.of(usTransport)));
+
+    // Initialize ProAi for Americans.
+    newDelegateBridge(americans);
+    final PlayerBridge playerBridgeMock = Mockito.mock(PlayerBridge.class);
+    when(playerBridgeMock.getGameData()).thenReturn(data);
+    final ProAi proAi = new ProAi("test-Americans", "Americans");
+    proAi.initialize(playerBridgeMock, americans);
+
+    // Capture every MoveDescription dispatched by the noncombat planner.
+    final List<MoveDescription> dispatched = new ArrayList<>();
+    final IMoveDelegate moveDelegate = Mockito.mock(IMoveDelegate.class);
+    when(moveDelegate.performMove(any()))
+        .then(
+            inv -> {
+              dispatched.add(inv.getArgument(0));
+              return Optional.empty();
+            });
+
+    data.getSequence().setRoundAndStep(1, "Non Combat Move", americans);
+    proAi.invokeNonCombatMoveForSidecar(moveDelegate, data, americans);
+
+    // The planner must have dispatched at least one move that ends in Brazil.
+    final boolean hasBrazilMove =
+        dispatched.stream().anyMatch(m -> m.getRoute().getEnd().equals(brazil));
+    assertThat(hasBrazilMove)
+        .as(
+            "ProAi NCM must dispatch an amphib move targeting Brazil when a US transport at "
+                + "SZ 87 + infantry at Liberia are available (regression: triplea#144). "
+                + "All dispatched moves: "
+                + dispatched)
+        .isTrue();
+  }
+
+  /**
+   * Regression guard for the land-path case: German infantry in Romania must still claim Bulgaria
+   * (land-adjacent Friendly_Neutral) via the existing land loop. The amphib pass must not
+   * interfere.
+   *
+   * <p>This is a re-assertion of the map-room#2195 regression test at a different level.
+   */
+  @Test
+  void landAdjacentFriendlyNeutralBulgariaStillClaimedByGermans() {
+    final GamePlayer germans = data.getPlayerList().getPlayerId("Germans");
+    final Territory romania = data.getMap().getTerritoryOrThrow("Romania");
+    final Territory bulgaria = data.getMap().getTerritoryOrThrow("Bulgaria");
+
+    assertThat(data.getMap().getNeighbors(romania))
+        .as("Romania must be adjacent to Bulgaria")
+        .contains(bulgaria);
+
+    final UnitType infantryType = data.getUnitTypeList().getUnitTypeOrThrow("infantry");
+    final Unit germanInfantry = infantryType.create(1, germans).get(0);
+    data.performChange(ChangeFactory.addUnits(romania, List.of(germanInfantry)));
+
+    newDelegateBridge(germans);
+    final PlayerBridge playerBridgeMock = Mockito.mock(PlayerBridge.class);
+    when(playerBridgeMock.getGameData()).thenReturn(data);
+    final ProAi proAi = new ProAi("test-Germans", "Germans");
+    proAi.initialize(playerBridgeMock, germans);
+
+    final List<MoveDescription> dispatched = new ArrayList<>();
+    final IMoveDelegate moveDelegate = Mockito.mock(IMoveDelegate.class);
+    when(moveDelegate.performMove(any()))
+        .then(
+            inv -> {
+              dispatched.add(inv.getArgument(0));
+              return Optional.empty();
+            });
+
+    data.getSequence().setRoundAndStep(1, "Non Combat Move", germans);
+    proAi.invokeNonCombatMoveForSidecar(moveDelegate, data, germans);
+
+    final boolean hasBulgariaMove =
+        dispatched.stream().anyMatch(m -> m.getRoute().getEnd().equals(bulgaria));
+    assertThat(hasBulgariaMove)
+        .as(
+            "ProAi NCM must dispatch a land move targeting Bulgaria when a German infantry is in "
+                + "Romania (regression: map-room#2195). All dispatched: "
+                + dispatched)
+        .isTrue();
+  }
+}


### PR DESCRIPTION
Closes map-room/map-room#144

## Problem

`claimFriendlyNeutralTerritories` only iterated `unitMoveMap` (land-adjacent NCM moves). Sea-isolated `Friendly_Neutral` territories — Brazil, Liberia, Saudi Arabia, Pacific Pro-Allies — were never claimed even when a transport with loaded capacity was within two sea zones.

## Fix

Added a parallel loop over `transportMapList` that assigns one infantry+transport pair to any `Friendly_Neutral` destination that the land loop left unclaimed. Land-claimed territories are skipped; committed transports are removed from `transportMoveMap` so `moveUnitsToBestTerritories` doesn't reassign them.

## Test

`ProAmphibClaimFriendlyNeutralTest.claimsSeaIsolatedBrazilViaAmphibMove`:
- US transport placed at SZ 87, US infantry at Liberia
- Topology: Liberia — SZ 87 — SZ 86 — Brazil (Friendly_Neutral, no land path to any Allied territory)
- Test sets Americans→Neutral_Allies = Friendly_Neutral and Americans→Germans = War so the US Neutrality Act restriction on SZ 86 is bypassed (`shouldBypassStaleMovementRestriction` requires `isAtWarWithAnyAxis=true`)
- Asserts planner dispatches at least one NCM move whose route ends at Brazil

`landAdjacentFriendlyNeutralBulgariaStillClaimedByGermans` (pre-existing regression guard for #2195) continues to pass.

## Test plan

- [x] `ProAmphibClaimFriendlyNeutralTest` — both tests pass
- [x] Full `game-core` test suite passes
- [x] `spotlessApply` + `spotlessCheck` clean