### PR TITLE
fix(ai): spread placement buys across factories using diminishing-returns scoring (map-room#2638)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -69,6 +69,11 @@ public abstract class AbstractProAi extends AbstractAi {
   private final ProCombatMoveAi combatMoveAi;
   private final ProNonCombatMoveAi nonCombatMoveAi;
   private final ProPurchaseAi purchaseAi;
+
+  ProPurchaseAi getPurchaseAi() {
+    return purchaseAi;
+  }
+
   private final ProRetreatAi retreatAi;
   private final ProScrambleAi scrambleAi;
   private final ProPoliticsAi politicsAi;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -57,6 +57,14 @@ import org.triplea.java.collections.IntegerMap;
 /** Pro purchase AI. */
 class ProPurchaseAi {
 
+  /**
+   * Diminishing-returns multiplier applied to each additional unit placed at the same factory in
+   * one turn: adjusted priority = basePriority / (1 + alreadyPlaced * PLACEMENT_SPREAD_FACTOR). Set
+   * to 0 to disable spreading (pure priority order, original behaviour). Package-private so tests
+   * can override it.
+   */
+  static double PLACEMENT_SPREAD_FACTOR = 0.5;
+
   private final AbstractProAi ai;
   private final ProOddsCalculator calc;
   private final ProData proData;
@@ -395,6 +403,11 @@ class ProPurchaseAi {
 
     // Add factory purchase territory to list
     purchaseTerritories.putAll(factoryPurchaseTerritories);
+
+    // Redistribute land unit allocations across available factories using diminishing-returns
+    // soft-cap so all buys don't concentrate at the single highest-priority factory
+    // (map-room#2638).
+    redistributeLandPlacementUnits(purchaseTerritories, prioritizedLandTerritories);
 
     // Determine final count of each production rule
     final IntegerMap<ProductionRule> purchaseMap =
@@ -2560,32 +2573,49 @@ class ProPurchaseAi {
       final Predicate<Unit> unitMatch) {
     ProLogger.info("Place units=" + player.getUnits());
 
-    // Loop through prioritized territories and place units
-    for (final ProPlaceTerritory placeTerritory : prioritizedTerritories) {
-      final Territory t = placeTerritory.getTerritory();
-      ProLogger.debug("Checking place for " + t.getName());
+    // Place one unit at a time to the territory with the highest adjusted priority,
+    // applying diminishing returns so all remaining units don't concentrate at the
+    // single top-ranked factory (map-room#2638).
+    final int n = prioritizedTerritories.size();
+    final Map<Territory, Integer> placedCounts = new HashMap<>();
+    boolean progress = true;
+    while (progress) {
+      progress = false;
+      ProPlaceTerritory best = null;
+      PlaceableUnits bestPlaceable = null;
+      double bestScore = Double.NEGATIVE_INFINITY;
 
-      // Check if any units can be placed
-      final PlaceableUnits placeableUnits =
-          placeDelegate.getPlaceableUnits(player.getMatches(unitMatch), t);
-      if (placeableUnits.isError()) {
-        ProLogger.trace(t + " can't place units with error: " + placeableUnits.getErrorMessage());
-        continue;
+      for (int i = 0; i < n; i++) {
+        final ProPlaceTerritory ppt = prioritizedTerritories.get(i);
+        final Territory t = ppt.getTerritory();
+        final PlaceableUnits pu = placeDelegate.getPlaceableUnits(player.getMatches(unitMatch), t);
+        if (pu.isError() || pu.getUnits().isEmpty()) {
+          continue;
+        }
+        int remaining = pu.getMaxUnits();
+        if (remaining == -1) {
+          remaining = Integer.MAX_VALUE;
+        }
+        if (remaining == 0) {
+          continue;
+        }
+        final int placed = placedCounts.getOrDefault(t, 0);
+        final double score = (double) (n - i) / (1.0 + placed * PLACEMENT_SPREAD_FACTOR);
+        if (score > bestScore) {
+          bestScore = score;
+          best = ppt;
+          bestPlaceable = pu;
+        }
       }
 
-      // Find remaining unit production
-      int remainingUnitProduction = placeableUnits.getMaxUnits();
-      if (remainingUnitProduction == -1) {
-        remainingUnitProduction = Integer.MAX_VALUE;
+      if (best != null && bestPlaceable != null) {
+        final Territory t = best.getTerritory();
+        final List<Unit> units = new ArrayList<>(bestPlaceable.getUnits());
+        ProLogger.trace(t + ", placedUnit=" + units.get(0));
+        doPlace(t, units.subList(0, 1), placeDelegate);
+        placedCounts.merge(t, 1, Integer::sum);
+        progress = true;
       }
-      ProLogger.trace(t + ", remainingUnitProduction=" + remainingUnitProduction);
-
-      // Place as many units as possible
-      final List<Unit> unitsThatCanBePlaced = new ArrayList<>(placeableUnits.getUnits());
-      final int placeCount = Math.min(remainingUnitProduction, unitsThatCanBePlaced.size());
-      final List<Unit> unitsToPlace = unitsThatCanBePlaced.subList(0, placeCount);
-      ProLogger.trace(t + ", placedUnits=" + unitsToPlace);
-      doPlace(t, unitsToPlace, placeDelegate);
     }
   }
 
@@ -2662,6 +2692,80 @@ class ProPurchaseAi {
       }
     }
     return territories;
+  }
+
+  /**
+   * Redistributes temp land-unit allocations across available factories using a diminishing-returns
+   * soft-cap, preventing all units from concentrating at the single highest-priority factory
+   * (map-room#2638).
+   *
+   * <p>Units are placed one at a time in the territory with the highest adjusted score {@code (n −
+   * index) / (1 + allocated × PLACEMENT_SPREAD_FACTOR)}, where {@code index} is the territory's
+   * rank in the priority list (0 = highest) and {@code allocated} is the count already assigned to
+   * that territory this turn. Factory capacity ({@link ProPurchaseTerritory#getUnitProduction}) is
+   * respected; territories at capacity are skipped.
+   */
+  void redistributeLandPlacementUnits(
+      final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
+      final List<ProPlaceTerritory> prioritizedLandTerritories) {
+    if (prioritizedLandTerritories.isEmpty()) {
+      return;
+    }
+    // Collect attack-unit allocations only; defender allocations in other territories are
+    // untouched.
+    final List<Unit> allUnits = new ArrayList<>();
+    for (final ProPlaceTerritory ppt : prioritizedLandTerritories) {
+      allUnits.addAll(ppt.getPlaceUnits());
+      ppt.getPlaceUnits().clear();
+    }
+    if (allUnits.isEmpty()) {
+      return;
+    }
+    // Build destination list from ALL factory territories, not just the front-line subset, so
+    // spreading isn't artificially constrained by the prioritizeLandTerritories filter.
+    final List<ProPlaceTerritory> destinations = new ArrayList<>();
+    for (final ProPurchaseTerritory ppt : purchaseTerritories.values()) {
+      for (final ProPlaceTerritory placePpt : ppt.getCanPlaceTerritories()) {
+        if (!placePpt.getTerritory().isWater()) {
+          destinations.add(placePpt);
+          break;
+        }
+      }
+    }
+    destinations.sort(Comparator.comparingDouble(ProPlaceTerritory::getStrategicValue).reversed());
+    if (destinations.isEmpty()) {
+      prioritizedLandTerritories.get(0).getPlaceUnits().addAll(allUnits);
+      return;
+    }
+    final int n = destinations.size();
+    final Map<Territory, Integer> allocatedCounts = new HashMap<>();
+    for (final Unit unit : allUnits) {
+      ProPlaceTerritory best = null;
+      double bestScore = Double.NEGATIVE_INFINITY;
+      for (int i = 0; i < n; i++) {
+        final ProPlaceTerritory dest = destinations.get(i);
+        final Territory t = dest.getTerritory();
+        final ProPurchaseTerritory purchTerritory = purchaseTerritories.get(t);
+        if (purchTerritory == null) {
+          continue;
+        }
+        final int allocated = allocatedCounts.getOrDefault(t, 0);
+        final int remaining = purchTerritory.getRemainingUnitProduction() - allocated;
+        if (remaining <= 0) {
+          continue;
+        }
+        final double score = (double) (n - i) / (1.0 + allocated * PLACEMENT_SPREAD_FACTOR);
+        if (score > bestScore) {
+          bestScore = score;
+          best = dest;
+        }
+      }
+      if (best == null) {
+        best = destinations.get(0);
+      }
+      best.getPlaceUnits().add(unit);
+      allocatedCounts.merge(best.getTerritory(), 1, Integer::sum);
+    }
   }
 
   private static void doPlace(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPlacementConcentrationTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPlacementConcentrationTest.java
@@ -1,0 +1,132 @@
+package games.strategy.triplea.ai.pro;
+
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.RelationshipType;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.player.PlayerBridge;
+import games.strategy.triplea.delegate.PlaceDelegate;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Regression tests for map-room#2638: {@link ProPurchaseAi#placeUnits} must spread buys across
+ * available factories using diminishing-returns scoring instead of concentrating all units at the
+ * top-priority territory.
+ *
+ * <p>Before the fix, {@code placeUnits} filled the first territory in its priority list to capacity
+ * before moving to the next, so Germans with 9 infantry and two factories (Germany + Western
+ * Germany) would stack all 9 at whichever factory appeared first. After the fix a
+ * diminishing-returns priority score (adjusted by units already placed this turn) guarantees at
+ * least two factories receive units when two are available.
+ */
+public class ProPlacementConcentrationTest {
+
+  private GameData data;
+  private GamePlayer germans;
+  private GamePlayer russians;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    germans = data.getPlayerList().getPlayerId("Germans");
+    russians = data.getPlayerList().getPlayerId("Russians");
+  }
+
+  /**
+   * Regression (map-room#2638): with Germany factory_major (production=10) and Western Germany
+   * factory_minor (production=3) available, placing 9 infantry must spread across at least 2
+   * factories.
+   *
+   * <p>Setup: Germans at war with Russians (so proximity scoring puts both factories in the
+   * prioritized list). 9 infantry in player's unit pool (the bought-but-unplaced state). No prior
+   * {@code purchase()} call so {@code storedPurchaseTerritories} is null, forcing the fallback
+   * {@code placeUnits} path during {@code place()}.
+   *
+   * <p>Counter-regression: all 9 infantry must actually be placed (no units dropped).
+   */
+  @Test
+  void infantrySpreadAcrossGermanyAndWesternGermany() {
+    final Territory germany = data.getMap().getTerritoryOrThrow("Germany");
+    final Territory westernGermany = data.getMap().getTerritoryOrThrow("Western Germany");
+
+    assertThat(germany.getOwner()).as("Germany must be German-owned").isEqualTo(germans);
+    assertThat(westernGermany.getOwner())
+        .as("Western Germany must be German-owned")
+        .isEqualTo(germans);
+
+    // Set Germans at war with Russians so proximity scoring puts both factories in the
+    // prioritized list (enemy territories within 9 hexes → both qualify for placement).
+    final RelationshipType war = data.getRelationshipTypeList().getRelationshipType("War");
+    data.performChange(
+        ChangeFactory.relationshipChange(
+            germans,
+            russians,
+            data.getRelationshipTracker().getRelationshipType(germans, russians),
+            war));
+
+    // Add 9 infantry to Germans' unit pool (simulates a R1 purchase of 27 IPCs).
+    final UnitType infantryType = data.getUnitTypeList().getUnitTypeOrThrow("infantry");
+    final List<Unit> infantry = infantryType.create(9, germans);
+    data.performChange(ChangeFactory.addUnits(germans, infantry));
+
+    // Record unit counts BEFORE placement to detect newly placed units.
+    final int germanyBefore =
+        (int) germany.getUnits().stream().filter(u -> u.getOwner().equals(germans)).count();
+    final int westernGermanyBefore =
+        (int) westernGermany.getUnits().stream().filter(u -> u.getOwner().equals(germans)).count();
+
+    // Set up ProAi and PlaceDelegate.
+    final IDelegateBridge bridge = newDelegateBridge(germans);
+    final PlaceDelegate placeDelegate = (PlaceDelegate) data.getDelegate("place");
+    placeDelegate.setDelegateBridgeAndPlayer(bridge);
+    placeDelegate.start();
+
+    final PlayerBridge playerBridgeMock = Mockito.mock(PlayerBridge.class);
+    when(playerBridgeMock.getGameData()).thenReturn(data);
+    final ProAi proAi = new ProAi("test-Germans", "Germans");
+    proAi.initialize(playerBridgeMock, germans);
+
+    data.getSequence().setRoundAndStep(1, "Place Units", germans);
+
+    // Call place() with storedPurchaseTerritories=null → exercises the fallback placeUnits path.
+    proAi.place(false, placeDelegate, data, germans);
+
+    // Assert: all 9 infantry must have been placed (counter-regression: no units dropped).
+    assertThat(germans.getUnits())
+        .as("All 9 infantry must be placed; none should remain in the player pool")
+        .isEmpty();
+
+    // Assert: at least 2 factories received units (primary regression: no concentration).
+    final int germanyAfter =
+        (int) germany.getUnits().stream().filter(u -> u.getOwner().equals(germans)).count();
+    final int westernGermanyAfter =
+        (int) westernGermany.getUnits().stream().filter(u -> u.getOwner().equals(germans)).count();
+
+    final boolean germanyGotUnits = germanyAfter > germanyBefore;
+    final boolean westernGermanyGotUnits = westernGermanyAfter > westernGermanyBefore;
+
+    assertThat(germanyGotUnits && westernGermanyGotUnits)
+        .as(
+            "ProAi must spread 9 infantry across Germany AND Western Germany when both factories"
+                + " are available (regression: map-room#2638). Before: Germany=%d,"
+                + " WesternGermany=%d. After: Germany=%d, WesternGermany=%d."
+                    .formatted(
+                        germanyBefore, westernGermanyBefore, germanyAfter, westernGermanyAfter))
+        .isTrue();
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPurchaseAiPlacementSpreadTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProPurchaseAiPlacementSpreadTest.java
@@ -1,0 +1,215 @@
+package games.strategy.triplea.ai.pro;
+
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.player.PlayerBridge;
+import games.strategy.triplea.ai.pro.data.ProPlaceTerritory;
+import games.strategy.triplea.ai.pro.data.ProPurchaseTerritory;
+import games.strategy.triplea.delegate.PurchaseDelegate;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Verifies that {@link ProPurchaseAi} distributes land-unit allocations across multiple factories
+ * rather than concentrating everything at the highest-priority territory (map-room#2638).
+ *
+ * <p>Three scenarios:
+ *
+ * <ul>
+ *   <li>Large buy (40 PU Germany R1) → ≥2 distinct land factories receive units.
+ *   <li>Small buy (3 PU) → ≤2 factories (no scattering of tiny buys).
+ *   <li>{@link ProPurchaseAi#PLACEMENT_SPREAD_FACTOR} = 0 via direct call to {@code
+ *       redistributeLandPlacementUnits} → all units concentrate at the top-priority factory.
+ * </ul>
+ */
+class ProPurchaseAiPlacementSpreadTest {
+
+  private double savedSpreadFactor;
+  private GameData gameData;
+  private GamePlayer german;
+  private ProAi proAi;
+  private PurchaseDelegate purchaseDelegate;
+
+  @BeforeEach
+  void setUp() {
+    savedSpreadFactor = ProPurchaseAi.PLACEMENT_SPREAD_FACTOR;
+    ProPurchaseAi.PLACEMENT_SPREAD_FACTOR = 0.5;
+    ClientSetting.setPreferences(new MemoryPreferences());
+    gameData = TestMapGameData.GLOBAL1940.getGameData();
+    german = gameData.getPlayerList().getPlayerId("Germans");
+    proAi = new ProAi("Test German", "German Test Player");
+    final IDelegateBridge bridge = newDelegateBridge(german);
+    purchaseDelegate = (PurchaseDelegate) gameData.getDelegate("purchase");
+    purchaseDelegate.setDelegateBridgeAndPlayer(bridge);
+    final PlayerBridge playerBridgeMock = Mockito.mock(PlayerBridge.class);
+    proAi.initialize(playerBridgeMock, german);
+    when(playerBridgeMock.getGameData()).thenReturn(gameData);
+    proAi.getProData().setSeed(42L);
+  }
+
+  @AfterEach
+  void restoreSpreadFactor() {
+    ProPurchaseAi.PLACEMENT_SPREAD_FACTOR = savedSpreadFactor;
+  }
+
+  @Test
+  void largeBuy_spreadsAcrossMultipleFactories() {
+    // Germany R1 has 40 PUs → typically buys 9+ ground units; the redistribution must spread
+    // them across at least 2 distinct land factories (regression: before the fix, placements=1
+    // every round because all units concentrated at the single top-priority territory).
+    proAi.purchase(false, 40, purchaseDelegate, gameData, german);
+
+    final Map<Territory, ProPurchaseTerritory> stored = proAi.getStoredPurchaseTerritories();
+    final long distinctLandFactoriesWithUnits =
+        stored == null
+            ? 0
+            : stored.values().stream()
+                .flatMap(ppt -> ppt.getCanPlaceTerritories().stream())
+                .filter(pt -> !pt.getTerritory().isWater())
+                .filter(pt -> !pt.getPlaceUnits().isEmpty())
+                .count();
+
+    assertThat(distinctLandFactoriesWithUnits)
+        .as("German 40-PU buy must spread across at least 2 land factories")
+        .isGreaterThanOrEqualTo(2);
+  }
+
+  @Test
+  void smallBuy_staysAtTopPriorityTerritory() {
+    // 3 PUs → 1 infantry. Single-unit buys must still go to the highest-priority territory;
+    // the soft-cap must not scatter a tiny buy across territories.
+    proAi.purchase(false, 3, purchaseDelegate, gameData, german);
+
+    final Map<Territory, ProPurchaseTerritory> stored = proAi.getStoredPurchaseTerritories();
+    final long distinctLandFactoriesWithUnits =
+        stored == null
+            ? 0
+            : stored.values().stream()
+                .flatMap(ppt -> ppt.getCanPlaceTerritories().stream())
+                .filter(pt -> !pt.getTerritory().isWater())
+                .filter(pt -> !pt.getPlaceUnits().isEmpty())
+                .count();
+
+    // 2 is acceptable: purchaseDefenders() may legitimately place a unit at a second factory
+    // before purchaseLandUnits() runs; the spread guard is against 9-unit concentration, not
+    // this normal defender-allocation pattern.
+    assertThat(distinctLandFactoriesWithUnits)
+        .as("3-PU buy must not scatter across many factories; ≤2 allows one defender territory")
+        .isLessThanOrEqualTo(2);
+  }
+
+  @Test
+  void spreadFactorZero_concentratesRedistributionAtTopFactory() {
+    // Directly exercise redistributeLandPlacementUnits with SPREAD_FACTOR=0: all units must stay
+    // at the highest-priority territory (the original concentrated behaviour is restored when the
+    // knob is turned off). Tests the knob in isolation — the full purchase() flow is not used here
+    // because purchaseDefenders() places defenders independently of the redistribution logic.
+    ProPurchaseAi.PLACEMENT_SPREAD_FACTOR = 0;
+    final ProPurchaseAi purchaseAi = proAi.getPurchaseAi();
+
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+    final Territory wg = gameData.getMap().getTerritoryOrThrow("Western Germany");
+    final Territory romania = gameData.getMap().getTerritoryOrThrow("Romania");
+
+    final ProPurchaseTerritory germanyPpt =
+        new ProPurchaseTerritory(germany, gameData, german, Integer.MAX_VALUE);
+    final ProPurchaseTerritory wgPpt = new ProPurchaseTerritory(wg, gameData, german, 3);
+    final ProPurchaseTerritory romaniaPpt = new ProPurchaseTerritory(romania, gameData, german, 3);
+
+    final Map<Territory, ProPurchaseTerritory> purchaseTerritories = new HashMap<>();
+    purchaseTerritories.put(germany, germanyPpt);
+    purchaseTerritories.put(wg, wgPpt);
+    purchaseTerritories.put(romania, romaniaPpt);
+
+    final ProPlaceTerritory germanyPlace = germanyPpt.getCanPlaceTerritories().get(0);
+    final ProPlaceTerritory wgPlace = wgPpt.getCanPlaceTerritories().get(0);
+    final ProPlaceTerritory romaniaPlace = romaniaPpt.getCanPlaceTerritories().get(0);
+
+    // Strategic values must be set explicitly so the sort inside redistributeLandPlacementUnits
+    // produces a deterministic order (HashMap iteration order is otherwise arbitrary).
+    germanyPlace.setStrategicValue(100.0);
+    wgPlace.setStrategicValue(50.0);
+    romaniaPlace.setStrategicValue(25.0);
+
+    final List<ProPlaceTerritory> prioritized =
+        new ArrayList<>(List.of(germanyPlace, wgPlace, romaniaPlace));
+
+    final games.strategy.engine.data.UnitType infantry =
+        gameData.getUnitTypeList().getUnitType("infantry").orElseThrow();
+    for (int i = 0; i < 9; i++) {
+      germanyPlace.getPlaceUnits().add(infantry.createTemp(1, german).get(0));
+    }
+
+    purchaseAi.redistributeLandPlacementUnits(purchaseTerritories, prioritized);
+
+    // With SPREAD_FACTOR=0 the adjusted score for each territory is simply (n - index), which
+    // never decreases. Germany is at index 0 after sorting by strategic value → base score = 3,
+    // WG = 2, Romania = 1. Germany wins every round → all 9 units placed there.
+    assertThat(germanyPlace.getPlaceUnits().size())
+        .as("All units must concentrate at Germany with SPREAD_FACTOR=0")
+        .isEqualTo(9);
+    assertThat(wgPlace.getPlaceUnits()).as("Western Germany must be empty").isEmpty();
+    assertThat(romaniaPlace.getPlaceUnits()).as("Romania must be empty").isEmpty();
+  }
+
+  // ── Unit-level tests for redistributeLandPlacementUnits ──────────────────────────────────────
+
+  @Test
+  void redistribute_ninteenUnitsAcrossThreeFactories_spreads() {
+    // Directly exercise redistributeLandPlacementUnits with controlled inputs.
+    // Three factories: Germany (cap=MAX), Western Germany (cap=3), Romania (cap=3)
+    final ProPurchaseAi purchaseAi = proAi.getPurchaseAi();
+
+    final Territory germany = gameData.getMap().getTerritoryOrThrow("Germany");
+    final Territory wg = gameData.getMap().getTerritoryOrThrow("Western Germany");
+    final Territory romania = gameData.getMap().getTerritoryOrThrow("Romania");
+
+    final ProPurchaseTerritory germanyPpt =
+        new ProPurchaseTerritory(germany, gameData, german, Integer.MAX_VALUE);
+    final ProPurchaseTerritory wgPpt = new ProPurchaseTerritory(wg, gameData, german, 3);
+    final ProPurchaseTerritory romaniaPpt = new ProPurchaseTerritory(romania, gameData, german, 3);
+
+    final Map<Territory, ProPurchaseTerritory> purchaseTerritories = new HashMap<>();
+    purchaseTerritories.put(germany, germanyPpt);
+    purchaseTerritories.put(wg, wgPpt);
+    purchaseTerritories.put(romania, romaniaPpt);
+
+    // Prioritized order: Germany > W.Germany > Romania
+    final ProPlaceTerritory germanyPlace = germanyPpt.getCanPlaceTerritories().get(0);
+    final ProPlaceTerritory wgPlace = wgPpt.getCanPlaceTerritories().get(0);
+    final ProPlaceTerritory romaniaPlace = romaniaPpt.getCanPlaceTerritories().get(0);
+    final List<ProPlaceTerritory> prioritized =
+        new ArrayList<>(List.of(germanyPlace, wgPlace, romaniaPlace));
+
+    // Seed all 9 units at Germany (simulating the concentration bug)
+    final games.strategy.engine.data.UnitType infantry =
+        gameData.getUnitTypeList().getUnitType("infantry").orElseThrow();
+    for (int i = 0; i < 9; i++) {
+      germanyPlace.getPlaceUnits().add(infantry.createTemp(1, german).get(0));
+    }
+
+    purchaseAi.redistributeLandPlacementUnits(purchaseTerritories, prioritized);
+
+    final long factories = prioritized.stream().filter(pt -> !pt.getPlaceUnits().isEmpty()).count();
+    assertThat(factories)
+        .as("9 units across Germany(MAX), W.Germany(3), Romania(3) must spread to ≥3 factories")
+        .isGreaterThanOrEqualTo(3);
+    final int total = prioritized.stream().mapToInt(pt -> pt.getPlaceUnits().size()).sum();
+    assertThat(total).as("Total unit count must be preserved after redistribution").isEqualTo(9);
+  }
+}


### PR DESCRIPTION
Closes map-room/map-room#2638

## Problem

`ProPurchaseAi.placeUnits` iterated `prioritizedTerritories` in priority order and filled the first territory to its full production capacity before moving to the next. With Germany factory_major (10 slots) and Western Germany factory_minor (3 slots), all 9 bought infantry absorbed at one territory — `placements=1` in the sidecar log every round.

The planned allocations in `ProPlaceTerritory.placeUnits` (which feed `setAiPendingPlacements`) were also concentrated: `purchaseLandUnits` assigned every unit to the single top-priority territory, so the NCM planner had no spread signal either.

## Fix

**`placeUnits` (place phase):** Replace the single-pass fill with a score-based one-unit-at-a-time loop. Each territory's adjusted score is:

```
(n − index) / (1 + alreadyPlaced × PLACEMENT_SPREAD_FACTOR)
```

With `PLACEMENT_SPREAD_FACTOR=0.5` (default), the top territory's advantage halves after each unit placed there, guaranteeing meaningful distribution across available factories.

**`redistributeLandPlacementUnits` (purchase phase):** New method called from `purchase()` to spread the planning-level allocations (`ProPlaceTerritory.placeUnits`). This ensures `setAiPendingPlacements` reports `placements >= 2` and the NCM planner receives a spread signal.

`PLACEMENT_SPREAD_FACTOR` is a package-visible static field so tests can override it without mocks.

## Acceptance criteria

- [x] `ProPurchaseAiPlacementSpreadTest.largeBuy_spreadsAcrossMultipleFactories` — German 40-PU buy → ≥2 distinct land factories in `storedPurchaseTerritories`
- [x] `ProPurchaseAiPlacementSpreadTest.smallBuy_staysAtTopPriorityTerritory` — 3-PU buy stays at ≤2 factories (no scattering of tiny buys)
- [x] `ProPurchaseAiPlacementSpreadTest.spreadFactorZero_concentratesRedistributionAtTopFactory` — direct unit test verifying SPREAD_FACTOR=0 disables spreading
- [x] `ProPurchaseAiPlacementSpreadTest.redistribute_ninteenUnitsAcrossThreeFactories_spreads` — direct unit test: 9 units across Germany(MAX)+WG(3)+Romania(3) → ≥3 factories
- [x] `ProPlacementConcentrationTest.infantrySpreadAcrossGermanyAndWesternGermany` — 9 infantry via `place()` spread across Germany AND Western Germany
- [x] Full `./gradlew :game-app:game-core:test` — BUILD SUCCESSFUL
- [x] `spotlessApply` + `spotlessCheck` clean
- [ ] 🧑 Manual: Compare German R1–3 sidecar logs against main to confirm `placements>=2` in real sidecar runs

## Test plan

- [x] 5 targeted tests pass (verified above)
- [x] Full game-core suite green
- [x] Spotless clean