### PR TITLE
fix(ai): block neutral-territory air transit in territoryCanMoveAirUnits (map-room#2876)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -60,6 +60,11 @@ public final class ProMatches {
       final GameState data, final GamePlayer player, final boolean isCombatMove) {
     final GameProperties properties = data.getProperties();
     return t -> {
+      // Air units cannot overfly any neutral territory (strict/pro-Axis/pro-Allies), mirroring
+      // engine movement-validator.ts createTraversalFilter air branch (map-room#2876).
+      if (ProUtils.isNeutralLand(t)) {
+        return false;
+      }
       final boolean passable =
           Matches.territoryDoesNotCostMoneyToEnter(properties)
               .and(
@@ -76,6 +81,11 @@ public final class ProMatches {
   public static Predicate<Territory> territoryCanPotentiallyMoveAirUnits(final GamePlayer player) {
     final GameProperties properties = player.getData().getProperties();
     return t -> {
+      // Air units cannot overfly any neutral territory (strict/pro-Axis/pro-Allies), mirroring
+      // engine movement-validator.ts createTraversalFilter air branch (map-room#2876).
+      if (ProUtils.isNeutralLand(t)) {
+        return false;
+      }
       final boolean passable =
           Matches.territoryDoesNotCostMoneyToEnter(properties)
               .and(Matches.territoryIsPassableAndNotRestricted(player))

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProAirNeutralOverflyTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ai/pro/ProAirNeutralOverflyTest.java
@@ -1,0 +1,129 @@
+package games.strategy.triplea.ai.pro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.ai.pro.util.ProMatches;
+import games.strategy.triplea.ai.pro.util.ProUtils;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.Set;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Regression tests for map-room#2876: {@link ProMatches#territoryCanMoveAirUnits} must block
+ * neutral territories (Neutral_True / Neutral_Axis / Neutral_Allies) as air-movement waypoints,
+ * mirroring the engine's {@code createTraversalFilter} air branch (movement-validator.ts:278-282).
+ *
+ * <p>Repro: British tactical_bomber planned Caucasus → Syria via Turkey (2 hops). Turkey is a
+ * Neutral_True territory in round 1. The engine costs the path at 3 (Turkey non-traversable →
+ * detour via NW Persia → Iraq → Syria). The sidecar previously costed it at 2, causing a
+ * soft-rejected move.
+ *
+ * <p>Tests:
+ *
+ * <ul>
+ *   <li>Predicate-level: {@code territoryCanMoveAirUnits} returns {@code false} for Turkey (any
+ *       neutral territory).
+ *   <li>Predicate-level counter-regression: non-neutral Allied territory (Caucasus) returns {@code
+ *       true}.
+ *   <li>BFS-level: British air at Caucasus cannot reach Syria in 2 hops — Turkey (the only direct
+ *       2-hop route) is blocked by the fix.
+ * </ul>
+ */
+public class ProAirNeutralOverflyTest {
+
+  private GameData data;
+  private GamePlayer british;
+  private Territory turkey;
+  private Territory caucasus;
+  private Territory unitedKingdom;
+
+  @BeforeEach
+  void setUp() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    data = TestMapGameData.GLOBAL1940.getGameData();
+    british = data.getPlayerList().getPlayerId("British");
+    turkey = data.getMap().getTerritoryOrThrow("Turkey");
+    caucasus = data.getMap().getTerritoryOrThrow("Caucasus");
+    unitedKingdom = data.getMap().getTerritoryOrThrow("United Kingdom");
+  }
+
+  /**
+   * Predicate-level regression (map-room#2876): {@code territoryCanMoveAirUnits} must return {@code
+   * false} for Turkey, which is owned by the {@code Neutral_True} player in the G40 initial setup.
+   */
+  @Test
+  void airMovePredicate_blocksNeutralTerritoryTransit() {
+    assumeTrue(
+        ProUtils.isNeutralLand(turkey),
+        "Precondition: Turkey must be neutral land in G40 round-1 setup");
+
+    final Predicate<Territory> canMoveAir =
+        ProMatches.territoryCanMoveAirUnits(data, british, true);
+
+    assertThat(canMoveAir.test(turkey))
+        .as("territoryCanMoveAirUnits must block Turkey (Neutral_True) as an air waypoint")
+        .isFalse();
+  }
+
+  /**
+   * Counter-regression: a British-owned territory (United Kingdom) must still be traversable by
+   * British air — the neutral check must not block own territory.
+   */
+  @Test
+  void airMovePredicate_allowsOwnedTerritoryTransit() {
+    assumeFalse(
+        ProUtils.isNeutralLand(unitedKingdom),
+        "Precondition: United Kingdom must NOT be neutral land in G40 round-1 setup");
+
+    final Predicate<Territory> canMoveAir =
+        ProMatches.territoryCanMoveAirUnits(data, british, true);
+
+    assertThat(canMoveAir.test(unitedKingdom))
+        .as("territoryCanMoveAirUnits must allow United Kingdom (British-owned) as an air waypoint")
+        .isTrue();
+  }
+
+  /**
+   * BFS-level regression (map-room#2876): British air at Caucasus must NOT be able to reach Syria
+   * in 2 hops.
+   *
+   * <p>Turkey sits directly between Caucasus and Syria (Caucasus ↔ Turkey ↔ Syria = 2 hops). With
+   * Turkey blocked, the 2-hop path is impossible. This is the exact geometry of the soft-reject
+   * repro in the issue.
+   */
+  @Test
+  void airBfs_cannotReachSyriaInTwoHopsViaTurkey() {
+    // Verify the G40 geometry preconditions before asserting.
+    final Territory syria = data.getMap().getTerritoryOrThrow("Syria");
+    assumeTrue(
+        ProUtils.isNeutralLand(turkey), "Precondition: Turkey must be neutral land in G40 setup");
+    assumeTrue(
+        data.getMap().getNeighbors(caucasus).contains(turkey),
+        "Precondition: Caucasus must be adjacent to Turkey");
+    assumeTrue(
+        data.getMap().getNeighbors(turkey).contains(syria),
+        "Precondition: Turkey must be adjacent to Syria");
+    assumeFalse(
+        data.getMap().getNeighbors(caucasus).contains(syria),
+        "Precondition: Caucasus must NOT be directly adjacent to Syria (requires 2+ hops)");
+
+    final Predicate<Territory> canMoveAir =
+        ProMatches.territoryCanMoveAirUnits(data, british, true);
+    final Set<Territory> twoHopReach = data.getMap().getNeighbors(caucasus, 2, canMoveAir);
+
+    assertThat(twoHopReach)
+        .as(
+            "British air from Caucasus must not reach Syria in 2 hops — Turkey (neutral) blocks"
+                + " the direct path")
+        .doesNotContain(syria);
+  }
+}


### PR DESCRIPTION
Closes map-room/map-room#2876

## Problem

`ProMatches.territoryCanMoveAirUnits` allowed air units to traverse through neutral territories (Neutral_True / Neutral_Axis / Neutral_Allies), producing paths the engine rejects.

Root cause: Java's `isTerritoryNeutral()` only matches territories where `owner.isNull()`. Territories owned by *named* neutral players (e.g. `Neutral_True`, `Neutral_Axis`) have a non-null owner and are not caught by that check. The engine's `createTraversalFilter` air branch uses a separate `getNeutralType(terr.owner)` check that correctly identifies all three neutral player types.

Repro from the issue: British tactical_bomber at Caucasus planned a 2-hop NCM landing flight via Turkey (Neutral_True/Neutral_Axis) to Syria. The engine requires 3 hops (Turkey non-traversable → detour NW Persia → Iraq → Syria) and soft-rejected the move.

## Fix

Add `ProUtils.isNeutralLand(t)` guard to both:
- `territoryCanMoveAirUnits` — used in combat/NCM path planning
- `territoryCanPotentiallyMoveAirUnits` — used for enemy attack estimation

Both now return `false` for any territory owned by a neutral player, mirroring the engine's `createTraversalFilter` air branch exactly.

## Tests (ProAirNeutralOverflyTest)

- **Predicate**: `territoryCanMoveAirUnits(data, british, true)` returns `false` for Turkey (Neutral_True in G40 setup)
- **Counter-regression**: returns `true` for United Kingdom (British-owned)
- **BFS**: `getNeighbors(Caucasus, 2, canMoveAir)` does NOT contain Syria — Turkey as 2-hop waypoint is blocked

## Acceptance

- [x] 3 targeted tests pass
- [x] Full `./gradlew :game-app:game-core:test` — BUILD SUCCESSFUL
- [x] `spotlessApply` + `spotlessCheck` clean
- [ ] 🧑 Manual: Verify British air in round 9 game state no longer routes Caucasus→Syria via Turkey (requires live sidecar run)

## Out of scope (per issue body)

- Futile single-unit neutral attacks (British AI attacking Turkey round 6–9 with one unit)
- Land-adjacency divergence u266 Paraguay→Uruguay